### PR TITLE
docs: update FVM version in `README` to `3.32.8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ dart format . --line-length=120
 [FVM Documentation](https://fvm.app/documentation/getting-started/installation)
 
 ```shell
-fvm install 3.27.1
-fvm use 3.27.1
+fvm install 3.32.8
+fvm use 3.32.8
 ```
 update environment!!!
 


### PR DESCRIPTION
This PR updates the FVM version in the README to match the Flutter/Dart versions specified in `pubspec.yaml`.
The README previously referenced `3.27.1`, while the project uses Flutter `3.32.8`.
This correction ensures consistency for contributors setting up the project environment.

**Changes Made**

- Updated FVM installation instructions in `README.md`
- Set version to `3.32.8` to match the project's actual Flutter SDK version

**Verification Checklist**

I have followed all steps in the Contributing Guide:

- Synced my fork with the upstream repository
- Pulled the latest changes into my local branch
- Resolved any merge conflicts
- Ran the required commands sequentially:
   - flutter clean
   - flutter pub get
   - dart run build_runner build --delete-conflicting-outputs
   - dart run intl_utils:generate
   - flutter analyze
   - flutter test --coverage
- Confirmed there are no errors, and all tests pass successfully

**Additional Notes**

No functional code changes were made.

This update improves onboarding clarity for new contributors.