### PR TITLE
fix: separate account and change password cards in settings

### DIFF
--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -27,6 +27,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
   final GlobalKey<FormBuilderState> _loginFormKey = GlobalKey<FormBuilderState>(debugLabel: '__loginFormKey__');
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>(debugLabel: '__loginScaffoldKey__');
   late AnimationController _animController;
+  final FocusNode _forgotPwFocus = FocusNode(skipTraversal: true);
 
   @override
   void initState() {
@@ -37,6 +38,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
 
   @override
   void dispose() {
+    _forgotPwFocus.dispose();
     _animController.dispose();
     super.dispose();
   }
@@ -497,6 +499,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
       key: loginTextFieldUsernameKey,
       name: 'username',
       decoration: const InputDecoration(hintText: 'm@example.com'),
+      textInputAction: TextInputAction.next,
       validator: FormBuilderValidators.compose([
         FormBuilderValidators.required(errorText: S.of(context).required_field),
         FormBuilderValidators.minLength(4, errorText: S.of(context).min_length_4),
@@ -558,6 +561,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
   Widget _forgotPasswordLink(BuildContext context) {
     return TextButton(
       key: loginButtonForgotPasswordKey,
+      focusNode: _forgotPwFocus,
       onPressed: () => context.push(ApplicationRoutesConstants.forgotPassword),
       style: TextButton.styleFrom(
         padding: const EdgeInsets.symmetric(horizontal: 4),

--- a/lib/features/settings/presentation/pages/settings_screen.dart
+++ b/lib/features/settings/presentation/pages/settings_screen.dart
@@ -48,6 +48,12 @@ class SettingsScreen extends StatelessWidget {
                     subtitle: 'View or edit your profile information',
                     onTap: () => context.push(ApplicationRoutesConstants.account),
                   ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              _SettingsSection(
+                title: S.of(context).change_password,
+                children: [
                   _SettingsTile(
                     key: settingsChangePasswordButtonKey,
                     icon: Icons.lock_outline,


### PR DESCRIPTION
## Summary
- **Settings screen**: Account and Change Password tiles were grouped inside a single card — split them into separate sections so each is independently tappable
- **Login screen**: Tab key from username field was landing on Forgot Password button instead of password field — added `TextInputAction.next` to username and `skipTraversal` to the forgot password button

## Test plan
- [x] `dart analyze` — no issues
- [x] `dart format` — 0 changes
- [x] `flutter test` — 1393 tests passed
- [x] `flutter build web` — success
- [ ] Visual verification: Settings page shows separate cards
- [ ] Visual verification: Tab from username goes to password on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)