### PR TITLE
chore: add Tech Debt / Refactor issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,125 @@
+name: Tech Debt / Refactor
+description: Report code quality issues, architectural concerns, or technical debt from audits/reviews
+title: "[Tech Debt]: "
+labels: ["tech-debt", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to report code quality, architectural, or technical debt issues — typically discovered during internal code reviews, audits, or refactoring planning.
+
+        - For runtime bugs reported by users, please use the **Bug Report** template.
+        - For new feature proposals, please use the **Feature Request** template.
+        - For open-ended questions or discussions, please use [GitHub Discussions](https://github.com/cevheri/flutter-bloc-advanced/discussions).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A single sentence stating the problem. The issue title should mirror this.
+      placeholder: e.g., LoginBloc mixes subclass-based states and copyWith, causing field loss across emits.
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: One or more `file:line` references where the issue lives.
+      placeholder: |
+        lib/features/auth/application/login_bloc.dart:48
+        lib/features/auth/application/login_bloc.dart:90
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current State
+      description: The existing code or structure, and what is wrong with it. Code snippets are encouraged.
+      render: dart
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired
+    attributes:
+      label: Desired State
+      description: An enterprise-grade or idiomatic alternative. Include code snippets if helpful.
+      render: dart
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why It Matters
+      description: The impact of leaving this unresolved — e.g., bug risk, maintainability, performance, security, testability, onboarding cost.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: |
+        How urgent is this?
+          - **Critical** — Latent bug, data corruption risk, security exposure, or layering violation.
+          - **High** — Significant maintainability or quality gap; blocks future enterprise-grade work.
+          - **Medium** — Design hygiene issue; should be fixed but not blocking.
+          - **Low** — Minor cleanup; can be done opportunistically.
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: The primary concern of this issue.
+      options:
+        - State Management (BLoC)
+        - Architecture
+        - Error Handling
+        - Logging
+        - Testing
+        - Performance
+        - Security
+        - Code Style
+        - Other
+
+  - type: dropdown
+    id: features
+    attributes:
+      label: Affected Feature(s) / Module(s)
+      description: Which feature modules or shared layers does this touch?
+      multiple: true
+      options:
+        - account
+        - auth
+        - dashboard
+        - dynamic_forms
+        - lifecycle
+        - settings
+        - users
+        - shared
+        - core
+        - infrastructure
+        - app
+        - other
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to Bloc documentation, Flutter style guide, enterprise pattern sources, blog posts, RFCs, prior issues/PRs, etc.
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Suggested Approach
+      description: A high-level idea only. Implementation details belong in the PR. Leave blank if you want maintainers to decide.


### PR DESCRIPTION
## Description

Adds a new GitHub Issue Form (`.github/ISSUE_TEMPLATE/tech_debt.yml`) for reporting code quality, architectural, or technical debt findings — typically discovered during internal code reviews and audits.

The form captures structured information that the existing Bug Report and Feature Request templates cannot:

- **Location**: `file:line` references
- **Current vs Desired state**: side-by-side with optional Dart code snippets
- **Why it matters**: impact rationale (bug risk, maintainability, performance, security, testability)
- **Severity**: `Critical` / `High` / `Medium` / `Low` (with inline guidance)
- **Category**: State Management (BLoC), Architecture, Error Handling, Logging, Testing, Performance, Security, Code Style, Other
- **Affected Feature(s)**: multi-select across all 7 feature modules + shared/core/infrastructure/app
- **References**: links to docs, RFCs, prior issues/PRs
- **Suggested Approach**: high-level only (implementation belongs in the PR)

Auto-applied labels: `tech-debt`, `triage`.

## Related Issue

No tracking issue — this is preparatory work for an upcoming BLoC architecture audit (~20+ tech-debt findings to be filed using this template).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update (project tooling / contribution workflow)
- [ ] CI/CD or build configuration change

## Checklist

The standard Dart/Flutter checklist items do not apply — this PR only adds a `.github/ISSUE_TEMPLATE/*.yml` file. Applicable items:

- [x] YAML validated locally (`yq` parse OK, 11 body fields, 6 required)
- [x] Auto-applied labels (`tech-debt`, `triage`) verified to exist in the repo
- [x] Follows the existing template style (matches `bug_report.yml` / `feature_request.yml` conventions)
- [x] No cross-cutting code changes; no test, l10n, or translation impact

## Additional Notes

After merge, the form will appear at `New Issue → Tech Debt / Refactor` alongside the existing Bug Report and Feature Request options. Maintainers can still add finer-grained labels (`bloc`, `architecture`, `refactor`, severity-derived) manually — GitHub Issue Forms do not support conditional auto-labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)