### PR TITLE
chore: remove empty base event handlers from 3 BLoCs

### DIFF
--- a/lib/features/account/application/account_bloc.dart
+++ b/lib/features/account/application/account_bloc.dart
@@ -22,7 +22,6 @@ class AccountBloc extends Bloc<AccountEvent, AccountState> {
        _updateAccountUseCase =
            updateAccountUseCase ?? UpdateAccountUseCase(repository ?? (throw ArgumentError('repository is required'))),
        super(const AccountState()) {
-    on<AccountEvent>((event, emit) {});
     on<AccountFetchEvent>(_onFetchAccount);
     on<AccountSubmitEvent>(_onSubmit);
   }

--- a/lib/features/users/application/authority_bloc.dart
+++ b/lib/features/users/application/authority_bloc.dart
@@ -13,7 +13,6 @@ class AuthorityBloc extends Bloc<AuthorityEvent, AuthorityState> {
   AuthorityBloc({required IAuthorityRepository repository})
     : _repository = repository,
       super(const AuthorityInitialState()) {
-    on<AuthorityEvent>((event, emit) {});
     on<AuthorityLoad>(_onLoad);
   }
 

--- a/lib/features/users/application/user_bloc.dart
+++ b/lib/features/users/application/user_bloc.dart
@@ -30,7 +30,6 @@ class UserBloc extends Bloc<UserEvent, UserState> {
        _deleteUserUseCase =
            deleteUserUseCase ?? DeleteUserUseCase(repository ?? (throw ArgumentError('repository is required'))),
        super(const UserState()) {
-    on<UserEvent>((event, emit) {});
     on<UserSearchEvent>(_onSearch);
     on<UserFetchEvent>(_onFetchUser);
     on<UserDeleteEvent>(_onDelete);


### PR DESCRIPTION
## Description

Removes the no-op `on<BaseEvent>((event, emit) {});` lines in `UserBloc`, `AuthorityBloc`, and `AccountBloc`. Each subtype event is already registered via its own `on<...>` handler, so the base-class registration added zero behavior while suggesting an intentional contract that does not exist. Removing it:

- Eliminates cargo-cult risk for new contributors copying the pattern.
- Removes a redundant handler dispatch per event (the base handler runs alongside the real handler under bloc's `event is T` matching).
- Aligns these three BLoCs with the rest of the codebase, which already follows the cleaner pattern.

## Related Issue

Closes #84

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] My code follows the project's architecture (Feature-First Clean Architecture)
- [x] I have added the feature under `lib/features/<feature_name>/` with proper layering — N/A (deletion only, no new code)
- [x] My changes do not introduce cross-feature imports
- [x] I have run `fvm dart analyze` with no issues (`No issues found!` on the affected directories)
- [x] I have run `fvm dart format . --line-length=120` — N/A (no formatting changes needed for pure deletions)
- [x] I have added/updated tests for my changes — Not applicable; existing tests cover the affected BLoCs and prove behavior is unchanged
- [x] I have run `fvm flutter test` and all tests pass (**1395 tests passed**, 0 failures)
- [x] I have updated translations in `lib/l10n/` if needed — N/A
- [x] I have updated documentation if needed — N/A

## Additional Notes

This is the smallest of the 21 tech-debt issues filed in the recent BLoC audit and serves as a proving run for the branch + PR + CI workflow before tackling larger refactors. No behavior change; the bloc package's `event is T` matching means subtype events were already being correctly dispatched to their specific handlers — the base no-op simply added a redundant call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)