### PR TITLE
refactor: use nullable type in AccountState.props and drop sentinel

### DIFF
--- a/lib/features/account/application/account_state.dart
+++ b/lib/features/account/application/account_state.dart
@@ -13,7 +13,7 @@ class AccountState extends Equatable {
   }
 
   @override
-  List<Object> get props => [status, data ?? ''];
+  List<Object?> get props => [status, data];
 
   @override
   bool get stringify => true;


### PR DESCRIPTION
## Description

`AccountState.props` previously returned `List<Object> get props => [status, data ?? '']`, mixing a `UserEntity?` with an empty-string sentinel to satisfy the non-nullable list type. `Equatable` natively handles nulls in `props`, so the sentinel is unnecessary, and `List<Object?>` expresses nullability honestly.

```diff
-  List<Object> get props => [status, data ?? ''];
+  List<Object?> get props => [status, data];
```

**Behavioural equivalence:** Two `AccountState`s with `data == null` were equal before (both reduced to `''` in props); they are still equal after (both have `null`). Two states with the same non-null data are equal before and after. Two states differing in data are non-equal before and after. No equality semantics change.

This is the second cleanup in the BLoC enterprise-grade audit, following #84.

## Related Issue

Closes #85

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture (no cross-feature imports)
- [x] `fvm dart analyze lib/features/account/` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] No test changes required — existing equality semantics are preserved

## Additional Notes

The remaining BLoC states (`UserState`, `LoginState`, etc.) already use `List<Object?>` correctly; `AccountState` was the only outlier. No follow-up issue is needed for this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)