### PR TITLE
fix: remove stale email quote-stripping in ForgotPasswordBloc

### DIFF
--- a/lib/features/auth/application/forgot_password_bloc.dart
+++ b/lib/features/auth/application/forgot_password_bloc.dart
@@ -33,11 +33,10 @@ class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> 
     _log.debug("BEGIN: forgotPassword bloc: _onSubmit");
     emit(state.copyWith(status: ForgotPasswordStatus.loading));
 
-    final email = event.email.replaceAll('"', '');
-    final result = await _resetPasswordUseCase(email);
+    final result = await _resetPasswordUseCase(event.email);
     switch (result) {
       case Success():
-        emit(state.copyWith(status: ForgotPasswordStatus.success, email: email));
+        emit(state.copyWith(status: ForgotPasswordStatus.success, email: event.email));
         _log.debug("END: forgotPassword bloc: _onSubmit success");
       case Failure(:final error):
         emit(state.copyWith(status: ForgotPasswordStatus.failure));


### PR DESCRIPTION
## Description

`ForgotPasswordBloc._onSubmit` was stripping double-quotes from the submitted email via `event.email.replaceAll('"', '')`. The line was introduced in [`762a0238`](https://github.com/cevheri/flutter-bloc-advanced/commit/762a0238) in November 2023 with no commit message rationale and was preserved unchanged through several major refactors:

- HTTP-layer migration from `http` to `dio` with interceptor chain
- Adoption of sealed `Result<T>` + `AppError` instead of raw exceptions
- Feature-first architecture migration

No test in `test/features/auth/application/forgot_password_bloc_test.dart` or the screen test exercises a quoted-email path; the original author no longer recalls the reason; and the most plausible original cause (a JSON encoding quirk in the old HTTP layer) no longer applies. `LoginBloc` and `ChangePasswordBloc` do not perform this normalization either.

```diff
-    final email = event.email.replaceAll('"', '');
-    final result = await _resetPasswordUseCase(email);
+    final result = await _resetPasswordUseCase(event.email);
     switch (result) {
       case Success():
-        emit(state.copyWith(status: ForgotPasswordStatus.success, email: email));
+        emit(state.copyWith(status: ForgotPasswordStatus.success, email: event.email));
```

If the defensive strip turns out to still be load-bearing in production (reset password is a low-traffic flow, so a regression may not be immediately obvious), it can be reintroduced with a proper comment explaining why.

## Related Issue

Closes #88

## Type of Change

- [x] Bug fix (removes stale defensive code)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart analyze lib/features/auth/` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] No new test required — existing tests cover the success and failure paths with non-quoted emails

## Additional Notes

This is the evidence-based path discussed in the issue: tests pass, sibling BLoCs don't normalize, and the original cause is undocumented. Project owner / original author chose this path over adding a "defensive code of unknown origin" comment or building out an `Email` value object now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)