### PR TITLE
refactor: centralize BLoC transition logging via AppBlocObserver

### DIFF
--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc_advance/app/di/app_dependencies.dart';
 import 'package:flutter_bloc_advance/app/analytics/crash_reporter.dart';
 import 'package:flutter_bloc_advance/app/dev_console/time_travel/time_travel_bloc_observer.dart';
 import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
+import 'package:flutter_bloc_advance/core/logging/app_bloc_observer.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
@@ -44,9 +45,7 @@ class AppBootstrap {
     final analytics = LogAnalyticsService();
     CrashReporter.install(analytics);
 
-    if (kDebugMode) {
-      Bloc.observer = TimeTravelBlocObserver();
-    }
+    Bloc.observer = kDebugMode ? TimeTravelBlocObserver() : AppBlocObserver();
 
     AppRouter().setRouter(RouterType.goRouter);
 

--- a/lib/app/dev_console/time_travel/time_travel_bloc_observer.dart
+++ b/lib/app/dev_console/time_travel/time_travel_bloc_observer.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/dev_console_store.dart';
 import 'package:flutter_bloc_advance/app/dev_console/time_travel/time_travel_store.dart';
+import 'package:flutter_bloc_advance/core/logging/app_bloc_observer.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/dev_console_store.dart';
 
 /// Combined BlocObserver that feeds both [DevConsoleStore] and [TimeTravelStore].
 ///
+/// Extends [AppBlocObserver] so transitions are also routed through [AppLogger]
+/// in addition to the dev-console / time-travel sinks.
+///
 /// Replaces [DevConsoleBlocObserver] when time-travel is enabled.
 /// Install via `Bloc.observer = TimeTravelBlocObserver();` in bootstrap.
-class TimeTravelBlocObserver extends BlocObserver {
+class TimeTravelBlocObserver extends AppBlocObserver {
   @override
   void onCreate(BlocBase bloc) {
     super.onCreate(bloc);

--- a/lib/core/logging/app_bloc_observer.dart
+++ b/lib/core/logging/app_bloc_observer.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+
+/// Central [BlocObserver] that routes BLoC lifecycle events through
+/// [AppLogger].
+///
+/// Logs only runtime types (not stringified content) to avoid leaking
+/// sensitive fields like passwords or tokens that may be carried on
+/// events or held in states with `stringify = true`. BLoCs that need
+/// to log specific content should do so explicitly inside their event
+/// handlers with whitelisted fields.
+///
+/// Install once at app startup via `Bloc.observer = AppBlocObserver()`.
+/// Other observers (e.g. dev console, analytics) can extend this class
+/// to inherit logging while adding their own behaviour.
+class AppBlocObserver extends BlocObserver {
+  static final _log = AppLogger.getLogger('Bloc');
+
+  @override
+  void onCreate(BlocBase bloc) {
+    super.onCreate(bloc);
+    _log.trace('onCreate: {}', [bloc.runtimeType]);
+  }
+
+  @override
+  void onTransition(Bloc bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    _log.trace('onTransition: {} | event={} | {} -> {}', [
+      bloc.runtimeType,
+      transition.event.runtimeType,
+      transition.currentState.runtimeType,
+      transition.nextState.runtimeType,
+    ]);
+  }
+
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    super.onChange(bloc, change);
+    _log.trace('onChange: {} | {} -> {}', [
+      bloc.runtimeType,
+      change.currentState.runtimeType,
+      change.nextState.runtimeType,
+    ]);
+  }
+
+  @override
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    _log.error('onError: {} | {}', [bloc.runtimeType, error]);
+  }
+
+  @override
+  void onClose(BlocBase bloc) {
+    super.onClose(bloc);
+    _log.trace('onClose: {}', [bloc.runtimeType]);
+  }
+}

--- a/lib/features/auth/application/change_password_bloc.dart
+++ b/lib/features/auth/application/change_password_bloc.dart
@@ -22,14 +22,6 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
     on<ChangePasswordChanged>(_onSubmit);
   }
 
-  @override
-  void onTransition(Transition<ChangePasswordEvent, ChangePasswordState> transition) {
-    super.onTransition(transition);
-    _log.trace("current state: ${transition.currentState.toString()}");
-    _log.trace("event: ${transition.event.toString()}");
-    _log.trace("next state: ${transition.nextState.toString()}");
-  }
-
   FutureOr<void> _onSubmit(ChangePasswordChanged event, Emitter<ChangePasswordState> emit) async {
     _log.debug("BEGIN: changePassword bloc: _onSubmit");
     emit(state.copyWith(status: ChangePasswordStatus.loading));

--- a/lib/features/auth/application/forgot_password_bloc.dart
+++ b/lib/features/auth/application/forgot_password_bloc.dart
@@ -21,14 +21,6 @@ class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> 
     on<ForgotPasswordEmailChanged>(_onSubmit);
   }
 
-  @override
-  void onTransition(Transition<ForgotPasswordEvent, ForgotPasswordState> transition) {
-    super.onTransition(transition);
-    _log.trace("current state: ${transition.currentState.toString()}");
-    _log.trace("event: ${transition.event.toString()}");
-    _log.trace("next state: ${transition.nextState.toString()}");
-  }
-
   FutureOr<void> _onSubmit(ForgotPasswordEmailChanged event, Emitter<ForgotPasswordState> emit) async {
     _log.debug("BEGIN: forgotPassword bloc: _onSubmit");
     emit(state.copyWith(status: ForgotPasswordStatus.loading));

--- a/lib/features/auth/application/login_bloc.dart
+++ b/lib/features/auth/application/login_bloc.dart
@@ -38,11 +38,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     on<VerifyOtpSubmitted>(_onVerifyOtpSubmitted);
   }
 
-  @override
-  void onTransition(Transition<LoginEvent, LoginState> transition) {
-    super.onTransition(transition);
-  }
-
   FutureOr<void> _onSubmit(LoginFormSubmitted event, Emitter<LoginState> emit) async {
     _log.debug("BEGIN: onSubmit LoginFormSubmitted event: {}", [event.username]);
     emit(LoginLoadingState(username: event.username, password: event.password));

--- a/lib/features/auth/application/register_bloc.dart
+++ b/lib/features/auth/application/register_bloc.dart
@@ -23,14 +23,6 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
     on<RegisterFormSubmitted>(_onSubmit);
   }
 
-  @override
-  void onTransition(Transition<RegisterEvent, RegisterState> transition) {
-    super.onTransition(transition);
-    _log.trace("current state: ${transition.currentState.toString()}");
-    _log.trace("event: ${transition.event.toString()}");
-    _log.trace("next state: ${transition.nextState.toString()}");
-  }
-
   FutureOr<void> _onSubmit(RegisterFormSubmitted event, Emitter<RegisterState> emit) async {
     _log.debug('BEGIN: onSubmit RegisterFormSubmitted login={}', [event.data.login]);
     emit(const RegisterLoadingState());


### PR DESCRIPTION
## Description

Introduces `AppBlocObserver` in `lib/core/logging/app_bloc_observer.dart` as the single cross-cutting sink for BLoC lifecycle events (`onCreate` / `onTransition` / `onChange` / `onError` / `onClose`), routed through `AppLogger` at `trace` / `error` level.

The observer logs **runtime types only** — not stringified content — to prevent sensitive fields like passwords or tokens from leaking when events or states have `stringify = true`. Per-BLoC handlers can still log specific whitelisted fields where needed.

### Changes

- **New:** `lib/core/logging/app_bloc_observer.dart`.
- **Modified:** `TimeTravelBlocObserver` now extends `AppBlocObserver` instead of `BlocObserver`, inheriting the logging while preserving its existing DevConsole / TimeTravel sinks.
- **Modified:** `AppBootstrap` installs `TimeTravelBlocObserver` in debug and `AppBlocObserver` in release builds. Production transitions are now logged for the first time (previously only debug builds emitted observer events).
- **Removed:** the duplicated `onTransition` overrides from `LoginBloc`, `ChangePasswordBloc`, `ForgotPasswordBloc`, and `RegisterBloc`. The empty no-op override in `LoginBloc` is also gone.

### Bonus security win

This change also closes a password-leak path that the **#82** audit surfaced (mentioned in PR #93's description). `ChangePasswordBloc.onTransition` previously dumped `transition.event.toString()` at trace level, and `ChangePasswordChanged` carries `currentPassword` + `newPassword` in its `Equatable` props with `stringify = true` — so trace logs would contain the user's password.

The new observer logs only `event.runtimeType`, so the content can no longer reach the log sink. No follow-up issue is needed for that leak.

## Related Issue

Closes #80

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes beyond logging detail)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture (new file lives in `lib/core/logging/`, no cross-feature imports)
- [x] `fvm dart analyze` → No issues found across the whole repo
- [x] `fvm dart format . --line-length=120` → 1 file reformatted (the new `app_bloc_observer.dart`)
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] No new test required for the observer itself — following the existing convention (`TimeTravelBlocObserver`, `DevConsoleBlocObserver`, `AnalyticsBlocObserver` have no tests either). A follow-up issue can add coverage if desired.

## Additional Notes

After merge, manually verify in `fvm flutter run --target lib/main/main_local.dart` that BLoC lifecycle trace logs still surface with the new format `Bloc | onTransition: LoginBloc | event=LoginFormSubmitted | LoginState -> LoginLoadingState`. Per-BLoC `_log.debug('BEGIN: ...')` lines inside handlers are unchanged and still emit content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)