### PR TITLE
fix: remove password field from LoginState (security)

### DIFF
--- a/lib/features/auth/application/login_bloc.dart
+++ b/lib/features/auth/application/login_bloc.dart
@@ -40,7 +40,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
   FutureOr<void> _onSubmit(LoginFormSubmitted event, Emitter<LoginState> emit) async {
     _log.debug("BEGIN: onSubmit LoginFormSubmitted event: {}", [event.username]);
-    emit(LoginLoadingState(username: event.username, password: event.password));
+    emit(LoginLoadingState(username: event.username));
 
     if (event.username == "invalid") {
       emit(const LoginErrorState(message: "Login API Error: Invalid username"));
@@ -69,7 +69,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
           case Success(data: final user):
             await AppLocalStorage().save(StorageKeys.roles.name, user.authorities);
             _log.debug("onSubmit save storage roles: {}", [user.authorities]);
-            emit(LoginLoadedState(username: event.username, password: event.password));
+            emit(LoginLoadedState(username: event.username));
             _log.debug("END:onSubmit LoginFormSubmitted event success: {}", [data.toString()]);
           case Failure(:final error):
             emit(LoginErrorState(message: "Login API Error: ${error.message}"));
@@ -119,7 +119,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         switch (accountResult) {
           case Success(data: final user):
             await AppLocalStorage().save(StorageKeys.roles.name, user.authorities);
-            emit(LoginLoadedState(username: event.email, password: event.otpCode));
+            emit(LoginLoadedState(username: event.email));
           case Failure():
             emit(const LoginErrorState(message: "OTP validation error"));
         }

--- a/lib/features/auth/application/login_state.dart
+++ b/lib/features/auth/application/login_state.dart
@@ -4,7 +4,6 @@ enum LoginStatus { initial, loading, success, failure }
 
 class LoginState extends Equatable {
   final String? username;
-  final String? password;
   final LoginStatus status;
   final bool passwordVisible;
   final String? email;
@@ -15,7 +14,6 @@ class LoginState extends Equatable {
 
   const LoginState({
     this.username,
-    this.password,
     this.status = LoginStatus.initial,
     this.passwordVisible = false,
     this.email,
@@ -26,7 +24,6 @@ class LoginState extends Equatable {
 
   LoginState copyWith({
     String? username,
-    String? password,
     LoginStatus? status,
     bool? passwordVisible,
     String? email,
@@ -36,7 +33,6 @@ class LoginState extends Equatable {
   }) {
     return LoginState(
       username: username ?? this.username,
-      password: password ?? this.password,
       status: status ?? this.status,
       passwordVisible: passwordVisible ?? this.passwordVisible,
       email: email ?? this.email,
@@ -50,7 +46,7 @@ class LoginState extends Equatable {
   bool get stringify => true;
 
   @override
-  List<Object?> get props => [username, password, status, passwordVisible, email, otpCode, isOtpSent, loginMethod];
+  List<Object?> get props => [username, status, passwordVisible, email, otpCode, isOtpSent, loginMethod];
 }
 
 class LoginInitialState extends LoginState {
@@ -58,17 +54,17 @@ class LoginInitialState extends LoginState {
 }
 
 class LoginLoadingState extends LoginState {
-  const LoginLoadingState({super.username, super.password}) : super(status: LoginStatus.loading);
+  const LoginLoadingState({super.username}) : super(status: LoginStatus.loading);
 
   @override
-  List<Object?> get props => [username, password, status];
+  List<Object?> get props => [username, status];
 }
 
 class LoginLoadedState extends LoginState {
-  const LoginLoadedState({super.username, super.password}) : super(status: LoginStatus.success);
+  const LoginLoadedState({super.username}) : super(status: LoginStatus.success);
 
   @override
-  List<Object?> get props => [username, password, status];
+  List<Object?> get props => [username, status];
 }
 
 class LoginOtpSentState extends LoginState {

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -181,8 +181,8 @@ void main() {
 
     test("props", () {
       expect(
-        const LoginState(status: LoginStatus.initial, passwordVisible: false, username: "test", password: "test").props,
-        ["test", "test", LoginStatus.initial, false, null, null, false, LoginMethod.password],
+        const LoginState(status: LoginStatus.initial, passwordVisible: false, username: "test").props,
+        ["test", LoginStatus.initial, false, null, null, false, LoginMethod.password],
       );
     });
   });
@@ -220,8 +220,8 @@ void main() {
 
       final event = LoginFormSubmitted(username: input.username, password: input.password);
 
-      final loadingState = LoginLoadingState(username: input.username, password: input.password);
-      final successState = LoginLoadedState(username: input.username, password: input.password);
+      final loadingState = LoginLoadingState(username: input.username);
+      final successState = LoginLoadedState(username: input.username);
       const failureState = LoginErrorState(message: "Login API Error: Unauthorized");
       const failure2State = LoginErrorState(message: "Login API Error: Invalid Access Token");
 
@@ -272,8 +272,8 @@ void main() {
       const input = AuthCredentialsEntity(username: "username", password: "password");
       final event = LoginFormSubmitted(username: input.username, password: input.password);
 
-      final loadingState = LoginLoadingState(username: input.username, password: input.password);
-      final successState = LoginLoadedState(username: input.username, password: input.password);
+      final loadingState = LoginLoadingState(username: input.username);
+      final successState = LoginLoadedState(username: input.username);
       const failureState = LoginErrorState(message: "Login API Error: Unauthorized");
 
       blocTest<LoginBloc, LoginState>(

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -180,10 +180,15 @@ void main() {
     });
 
     test("props", () {
-      expect(
-        const LoginState(status: LoginStatus.initial, passwordVisible: false, username: "test").props,
-        ["test", LoginStatus.initial, false, null, null, false, LoginMethod.password],
-      );
+      expect(const LoginState(status: LoginStatus.initial, passwordVisible: false, username: "test").props, [
+        "test",
+        LoginStatus.initial,
+        false,
+        null,
+        null,
+        false,
+        LoginMethod.password,
+      ]);
     });
   });
   //endregion state

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -204,7 +204,7 @@ void main() {
       await AppLocalStorage().save(StorageKeys.jwtToken.name, "MOCK_TOKEN");
       await AppLocalStorage().save(StorageKeys.username.name, "mock");
       await AppLocalStorage().save(StorageKeys.roles.name, ["ROLE_USER"]);
-      loginStateController.add(const LoginLoadedState(username: "test@example.com", password: "123456"));
+      loginStateController.add(const LoginLoadedState(username: "test@example.com"));
       await tester.pump();
 
       expect(mockGoRouter.routerDelegate.currentConfiguration.uri.path, ApplicationRoutesConstants.home);


### PR DESCRIPTION
## Description

`LoginState` previously stored the user's password as a plain `String?`, surfacing in `Equatable.props`, `stringify`, the default `toString()`, and consequently in any `BlocObserver.onChange` / `onTransition` capture, debugger watch, or crash report payload. Authentication credentials are short-lived; BLoC state is long-lived, so the field was a leak surface waiting for a trigger.

The password now travels in-flight only — through the `LoginFormSubmitted` event into `AuthenticateUserUseCase` and the `AuthCredentialsEntity` value object — and is never persisted onto the state. The UI already holds the value in a `TextEditingController` where it always belonged.

### Changes

- Remove `password` field from `LoginState`, its constructor, `copyWith`, and `props`.
- Remove `super.password` from `LoginLoadingState` and `LoginLoadedState`.
- Drop the `password:` argument from the three `emit(...)` call-sites in `LoginBloc` (`_onSubmit` password path and OTP path).
- Update affected tests to construct the trimmed states.

### UI compatibility verified

A repo-wide grep for `state.password` returned only `state.passwordVisible` references (visibility toggle, unchanged) — **no UI consumer reads the password value from state**. No UI changes required.

## Related Issue

Closes #83

## Type of Change

- [x] Bug fix (security / sensitive data exposure)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] Tests updated: `login_bloc_test.dart` (5 state constructions) and `login_otp_verify_widget_test.dart` (1 state construction) — all expected props lists adjusted to match the new shape

## Additional Notes

Companion to #80, which removed the per-BLoC `onTransition` trace logs that would have exposed this password. Together these two PRs close the credential-leak surface for the auth flow on the BLoC side. The OTP code field still lives on the state — it's lower-sensitivity than a password but should be revisited if the same hygiene is desired more broadly (out of scope for #83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)