### PR TITLE
fix: replace DynamicFormBloc silent POST fallback with explicit verbs

### DIFF
--- a/lib/features/dynamic_forms/application/dynamic_form_bloc.dart
+++ b/lib/features/dynamic_forms/application/dynamic_form_bloc.dart
@@ -49,7 +49,9 @@ class DynamicFormBloc extends Bloc<DynamicFormEvent, DynamicFormState> {
       final response = switch (action.method.toUpperCase()) {
         'POST' => await ApiClient.post(action.endpoint, event.data),
         'PUT' => await ApiClient.put(action.endpoint, event.data),
-        _ => await ApiClient.post(action.endpoint, event.data),
+        'PATCH' => await ApiClient.patch(action.endpoint, event.data),
+        'DELETE' => await ApiClient.delete(action.endpoint),
+        final method => throw UnsupportedError('Unsupported HTTP method: $method'),
       };
 
       emit(state.copyWith(status: DynamicFormStatus.submitted, submitResponse: response.data));


### PR DESCRIPTION
## Description

`DynamicFormBloc._onSubmit` previously dispatched on `action.method.toUpperCase()` with a wildcard `_` arm that silently performed a POST regardless of the requested verb. Any unrecognized method — `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, or a typo — would quietly become a POST, possibly mutating data the backend did not expect.

```diff
       final response = switch (action.method.toUpperCase()) {
         'POST' => await ApiClient.post(action.endpoint, event.data),
         'PUT' => await ApiClient.put(action.endpoint, event.data),
-        _ => await ApiClient.post(action.endpoint, event.data),
+        'PATCH' => await ApiClient.patch(action.endpoint, event.data),
+        'DELETE' => await ApiClient.delete(action.endpoint),
+        final method => throw UnsupportedError('Unsupported HTTP method: $method'),
       };
```

### Design notes

- `PATCH` and `DELETE` are already supported by `ApiClient` (signatures at `lib/infrastructure/http/api_client.dart:135` and `:148`).
- `DELETE` is dispatched **without a body** via `ApiClient.delete(endpoint)`, following the REST convention that DELETE identifies the resource through the path / query.
- Unsupported verbs throw `UnsupportedError`, which is caught by the existing `try/catch` in the same handler and surfaced as `DynamicFormStatus.failure` with the method name embedded in the error message — so an operator sees the cause instead of an opaque-but-successful create on the wrong endpoint.

## Related Issue

Closes #89

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes (CI's format gate happy)
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] No new test required — existing tests cover POST and PUT paths; the unsupported-verb path can be covered when the broader DynamicFormBloc rewrite (#72) lands

## Additional Notes

This is a tactical fix; the broader DynamicFormBloc architecture rewrite is tracked in **#72** (introduce Repository + UseCase layer and migrate from `try/catch` to `Result<T>`). When #72 lands, this switch will move into a use case but the explicit-verb pattern stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)