### PR TITLE
refactor: inject FeatureFlagService into LifecycleBloc

### DIFF
--- a/lib/features/lifecycle/application/lifecycle_bloc.dart
+++ b/lib/features/lifecycle/application/lifecycle_bloc.dart
@@ -10,7 +10,10 @@ import 'package:flutter_bloc_advance/features/lifecycle/domain/repositories/life
 import 'package:flutter_bloc_advance/shared/utils/app_constants.dart';
 
 class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
-  LifecycleBloc({required ILifecycleRepository repository}) : _repository = repository, super(const LifecycleState()) {
+  LifecycleBloc({required ILifecycleRepository repository, required FeatureFlagService featureFlagService})
+    : _repository = repository,
+      _featureFlagService = featureFlagService,
+      super(const LifecycleState()) {
     on<LifecycleCheckEvent>(_onCheck);
     on<LifecycleDismissUpdateEvent>(_onDismissUpdate);
   }
@@ -18,6 +21,7 @@ class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
   static final _log = AppLogger.getLogger('LifecycleBloc');
 
   final ILifecycleRepository _repository;
+  final FeatureFlagService _featureFlagService;
 
   FutureOr<void> _onCheck(LifecycleCheckEvent event, Emitter<LifecycleState> emit) async {
     _log.debug('Checking app lifecycle config');
@@ -29,7 +33,7 @@ class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
       case Success(:final data):
         // Update feature flags
         if (data.featureFlags.isNotEmpty) {
-          FeatureFlagService.instance.updateFlags(data.featureFlags);
+          _featureFlagService.updateFlags(data.featureFlags);
         }
 
         // Check maintenance mode first

--- a/test/features/lifecycle/application/lifecycle_bloc_test.dart
+++ b/test/features/lifecycle/application/lifecycle_bloc_test.dart
@@ -31,7 +31,7 @@ void main() {
 
   group('LifecycleBloc', () {
     test('initial state should be LifecycleState with initial status', () {
-      final bloc = LifecycleBloc(repository: mockRepository);
+      final bloc = LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
       expect(bloc.state, const LifecycleState());
       expect(bloc.state.status, LifecycleStatus.initial);
       expect(bloc.state.config, isNull);
@@ -47,7 +47,7 @@ void main() {
             (_) async =>
                 const Success(AppConfigEntity(minimumVersion: '0.5.0', latestVersion: '1.0.0', maintenanceMode: false)),
           );
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -64,7 +64,7 @@ void main() {
           when(() => mockRepository.fetchAppConfig()).thenAnswer(
             (_) async => const Success(AppConfigEntity(maintenanceMode: true, maintenanceMessage: 'Under maintenance')),
           );
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -82,7 +82,7 @@ void main() {
             (_) async =>
                 const Success(AppConfigEntity(minimumVersion: '2.0.0', latestVersion: '2.0.0', maintenanceMode: false)),
           );
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -99,7 +99,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Failure(NetworkError('No connection')));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -122,7 +122,7 @@ void main() {
               ),
             ),
           );
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -137,7 +137,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '1.0.0', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -152,7 +152,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '0.9.0', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -167,7 +167,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -184,7 +184,7 @@ void main() {
               AppConfigEntity(maintenanceMode: false, featureFlags: {'dark_mode': true, 'chat': false}),
             ),
           );
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         verify: (_) {
@@ -199,7 +199,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(maintenanceMode: false, featureFlags: {})));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         verify: (_) {
@@ -211,7 +211,7 @@ void main() {
     group('LifecycleDismissUpdateEvent', () {
       blocTest<LifecycleBloc, LifecycleState>(
         'should emit ready status when update is dismissed',
-        build: () => LifecycleBloc(repository: mockRepository),
+        build: () => LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance),
         seed: () => const LifecycleState(
           status: LifecycleStatus.forceUpdate,
           config: AppConfigEntity(minimumVersion: '2.0.0'),
@@ -229,7 +229,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '1.0.1', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -245,7 +245,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '1.1.0', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -261,7 +261,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '2.0.0', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
@@ -277,7 +277,7 @@ void main() {
           when(
             () => mockRepository.fetchAppConfig(),
           ).thenAnswer((_) async => const Success(AppConfigEntity(minimumVersion: '1.9.9', maintenanceMode: false)));
-          return LifecycleBloc(repository: mockRepository);
+          return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [


### PR DESCRIPTION
## Description

`LifecycleBloc` previously reached into the global `FeatureFlagService.instance` singleton inside its event handler to push downloaded feature flags. This created hidden coupling, made the side-effect invisible to unit tests without manipulating the singleton, and contradicted the existing pattern in `SystemDashboardCubit` which already takes `FeatureFlagService` as a constructor parameter (`lib/app/di/app_scope.dart:76`).

The bloc now accepts `FeatureFlagService` through its constructor and uses the injected reference:

```dart
LifecycleBloc({
  required ILifecycleRepository repository,
  required FeatureFlagService featureFlagService,
})
```

```diff
-          FeatureFlagService.instance.updateFlags(data.featureFlags);
+          _featureFlagService.updateFlags(data.featureFlags);
```

Tests pass `FeatureFlagService.instance` to keep the existing assertion shape (`FeatureFlagService.instance.isEnabled(...)`) — but they could now swap in a fake without touching global state if a future test wanted isolation.

### Scope note — production wiring is missing entirely

A repo-wide grep showed that `LifecycleBloc` is **not yet wired into any `BlocProvider`** in production code. Consumers (`LifecycleGate`, `MaintenanceScreen`, `DashboardHomePage`) call `context.read<LifecycleBloc>()` with defensive fallbacks for the missing case. That production-wiring gap is unrelated to this refactor; this PR keeps the constructor signature correct for when the wiring is added, and #18 (the original audit issue) doesn't ask for production wiring either.

### Interface vs. concrete

The issue body suggested extracting an `IFeatureFlagService` interface. The codebase currently injects the concrete `FeatureFlagService` everywhere (`SystemDashboardCubit` does this too). Following YAGNI + consistency, this PR keeps the concrete injection; an interface extraction can be a follow-up that simultaneously updates `SystemDashboardCubit`.

## Related Issue

Closes #87

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] Test file updated — 10 `LifecycleBloc(...)` construction sites now pass the new parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)