### PR TITLE
fix: surface error message in ChangePassword/ForgotPassword state

### DIFF
--- a/lib/features/auth/application/change_password_bloc.dart
+++ b/lib/features/auth/application/change_password_bloc.dart
@@ -24,15 +24,25 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
 
   FutureOr<void> _onSubmit(ChangePasswordChanged event, Emitter<ChangePasswordState> emit) async {
     _log.debug("BEGIN: changePassword bloc: _onSubmit");
-    emit(state.copyWith(status: ChangePasswordStatus.loading));
+    emit(const ChangePasswordState(status: ChangePasswordStatus.loading));
 
     if (event.currentPassword.isEmpty || event.newPassword.isEmpty) {
-      emit(state.copyWith(status: ChangePasswordStatus.failure));
+      emit(
+        const ChangePasswordState(
+          status: ChangePasswordStatus.failure,
+          errorMessage: 'Both current and new password are required',
+        ),
+      );
       return;
     }
 
     if (event.currentPassword == event.newPassword) {
-      emit(state.copyWith(status: ChangePasswordStatus.failure));
+      emit(
+        const ChangePasswordState(
+          status: ChangePasswordStatus.failure,
+          errorMessage: 'New password must be different from current password',
+        ),
+      );
       return;
     }
 
@@ -41,10 +51,10 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
     final result = await _changePasswordUseCase(passwordChangeDTO);
     switch (result) {
       case Success():
-        emit(state.copyWith(status: ChangePasswordStatus.success));
+        emit(const ChangePasswordState(status: ChangePasswordStatus.success));
         _log.debug("END: changePassword bloc: _onSubmit success");
       case Failure(:final error):
-        emit(state.copyWith(status: ChangePasswordStatus.failure));
+        emit(ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: error.message));
         _log.error("END: changePassword bloc: _onSubmit error: {}", [error.toString()]);
     }
   }

--- a/lib/features/auth/application/change_password_state.dart
+++ b/lib/features/auth/application/change_password_state.dart
@@ -4,15 +4,16 @@ enum ChangePasswordStatus { initial, loading, success, failure }
 
 class ChangePasswordState extends Equatable {
   final ChangePasswordStatus status;
+  final String? errorMessage;
 
-  const ChangePasswordState({this.status = ChangePasswordStatus.initial});
+  const ChangePasswordState({this.status = ChangePasswordStatus.initial, this.errorMessage});
 
-  ChangePasswordState copyWith({ChangePasswordStatus? status}) {
-    return ChangePasswordState(status: status ?? this.status);
+  ChangePasswordState copyWith({ChangePasswordStatus? status, String? errorMessage}) {
+    return ChangePasswordState(status: status ?? this.status, errorMessage: errorMessage ?? this.errorMessage);
   }
 
   @override
-  List<Object> get props => [status];
+  List<Object?> get props => [status, errorMessage];
 
   @override
   bool get stringify => true;

--- a/lib/features/auth/application/forgot_password_bloc.dart
+++ b/lib/features/auth/application/forgot_password_bloc.dart
@@ -23,15 +23,17 @@ class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> 
 
   FutureOr<void> _onSubmit(ForgotPasswordEmailChanged event, Emitter<ForgotPasswordState> emit) async {
     _log.debug("BEGIN: forgotPassword bloc: _onSubmit");
-    emit(state.copyWith(status: ForgotPasswordStatus.loading));
+    emit(const ForgotPasswordState(status: ForgotPasswordStatus.loading));
 
     final result = await _resetPasswordUseCase(event.email);
     switch (result) {
       case Success():
-        emit(state.copyWith(status: ForgotPasswordStatus.success, email: event.email));
+        emit(ForgotPasswordState(status: ForgotPasswordStatus.success, email: event.email));
         _log.debug("END: forgotPassword bloc: _onSubmit success");
       case Failure(:final error):
-        emit(state.copyWith(status: ForgotPasswordStatus.failure));
+        emit(
+          ForgotPasswordState(status: ForgotPasswordStatus.failure, email: event.email, errorMessage: error.message),
+        );
         _log.error("END: forgotPassword bloc: _onSubmit error: {}", [error.toString()]);
     }
   }

--- a/lib/features/auth/application/forgot_password_state.dart
+++ b/lib/features/auth/application/forgot_password_state.dart
@@ -7,15 +7,20 @@ const String authenticationFailKey = 'error.authenticate';
 class ForgotPasswordState extends Equatable {
   final String? email;
   final ForgotPasswordStatus status;
+  final String? errorMessage;
 
-  const ForgotPasswordState({this.email, this.status = ForgotPasswordStatus.initial});
+  const ForgotPasswordState({this.email, this.status = ForgotPasswordStatus.initial, this.errorMessage});
 
-  ForgotPasswordState copyWith({String? email, ForgotPasswordStatus? status}) {
-    return ForgotPasswordState(email: email ?? this.email, status: status ?? this.status);
+  ForgotPasswordState copyWith({String? email, ForgotPasswordStatus? status, String? errorMessage}) {
+    return ForgotPasswordState(
+      email: email ?? this.email,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
   }
 
   @override
-  List<Object> get props => [status, email ?? ""];
+  List<Object?> get props => [status, email, errorMessage];
 
   @override
   bool get stringify => true;
@@ -39,5 +44,5 @@ class ForgotPasswordErrorState extends ForgotPasswordState {
   const ForgotPasswordErrorState({required this.message}) : super(status: ForgotPasswordStatus.failure);
 
   @override
-  List<Object> get props => [status, message];
+  List<Object?> get props => [status, message];
 }

--- a/test/features/auth/application/change_password_bloc_test.dart
+++ b/test/features/auth/application/change_password_bloc_test.dart
@@ -91,10 +91,8 @@ void main() {
       final event = ChangePasswordChanged(currentPassword: input.currentPassword!, newPassword: input.newPassword!);
       const loadingState = ChangePasswordState(status: ChangePasswordStatus.loading);
       const successState = ChangePasswordState(status: ChangePasswordStatus.success);
-      const errorState = ChangePasswordState(status: ChangePasswordStatus.failure);
 
       const statesSuccess = [loadingState, successState];
-      const statesError = [loadingState, errorState];
 
       blocTest<ChangePasswordBloc, ChangePasswordState>(
         "emits [loading, success] when ChangePasswordChanged is added",
@@ -110,7 +108,10 @@ void main() {
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ServerError('Change password failed'))),
         build: () => ChangePasswordBloc(repository: repository),
         act: (bloc) => bloc..add(event),
-        expect: () => statesError,
+        expect: () => [
+          loadingState,
+          const ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: 'Change password failed'),
+        ],
         verify: (_) => verify(method).called(1),
       );
 
@@ -119,7 +120,10 @@ void main() {
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ValidationError('Invalid password'))),
         build: () => ChangePasswordBloc(repository: repository),
         act: (bloc) => bloc..add(event),
-        expect: () => statesError,
+        expect: () => [
+          loadingState,
+          const ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: 'Invalid password'),
+        ],
         verify: (_) => verify(method).called(1),
       );
     });

--- a/test/features/auth/application/forgot_password_bloc_test.dart
+++ b/test/features/auth/application/forgot_password_bloc_test.dart
@@ -104,6 +104,7 @@ void main() {
       expect(const ForgotPasswordState(status: ForgotPasswordStatus.initial, email: 'test@example.com').props, [
         ForgotPasswordStatus.initial,
         "test@example.com",
+        null,
       ]);
     });
 
@@ -139,7 +140,7 @@ void main() {
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: email)),
       expect: () => [
         const ForgotPasswordState(status: ForgotPasswordStatus.loading),
-        const ForgotPasswordState(status: ForgotPasswordStatus.failure),
+        const ForgotPasswordState(status: ForgotPasswordStatus.failure, email: email, errorMessage: 'Reset failed'),
       ],
     );
 
@@ -152,7 +153,11 @@ void main() {
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: 'invalid-email')),
       expect: () => [
         const ForgotPasswordState(status: ForgotPasswordStatus.loading),
-        const ForgotPasswordState(status: ForgotPasswordStatus.failure),
+        const ForgotPasswordState(
+          status: ForgotPasswordStatus.failure,
+          email: 'invalid-email',
+          errorMessage: 'Invalid email',
+        ),
       ],
     );
   });


### PR DESCRIPTION
## Description

Both `ChangePasswordBloc` and `ForgotPasswordBloc` previously emitted a generic `state.copyWith(status: failure)` on every failure branch, dropping the underlying `AppError.message` before it could reach the UI. The user saw "something went wrong" with no indication of cause — wrong current password, validation failure, network error, all looked identical.

### Changes

**State:**
- `ChangePasswordState` and `ForgotPasswordState` now expose a `String? errorMessage` field, included in their constructor, `copyWith`, and `props`. `List<Object>` props upgraded to `List<Object?>` (consistent with the fix already applied to `AccountState` in #85).

**BLoCs:**
- Both `_onSubmit` handlers switch from `state.copyWith(...)` to explicit `ChangePasswordState(...)` / `ForgotPasswordState(...)` construction. This sidesteps the `copyWith` null-clearing limitation (tracked separately in #74) — a previous error message no longer survives into the next loading / success transition.

- `ChangePasswordBloc` also gains descriptive messages for the two local validation paths that previously failed silently:
  - empty fields → `"Both current and new password are required"`
  - duplicate password → `"New password must be different from current password"`

- `ForgotPasswordBloc` additionally preserves `email` through both success and failure transitions, so the UI can show "Reset failed for `<email>`" instead of losing the submitted address.

### #77 readiness

When **#77** (BLoC error codes / i18n) lands, these literal strings become i18n codes. For now the field is named `errorMessage` to honestly reflect what it carries.

## Related Issue

Closes #78

## Type of Change

- [x] Bug fix (UX / error visibility)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes (3 files reformatted earlier, all committed)
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures
- [x] Tests updated: shared `errorState` constant in `change_password_bloc_test` retired in favour of inline per-test expectations carrying the matching `errorMessage`; `forgot_password_bloc_test` updated for the new props shape and the email-preserving failure state

## Additional Notes

The existing `ForgotPasswordErrorState` subclass (in `forgot_password_state.dart`) is left untouched — it carries a `message` field but is not emitted by the BLoC and is only referenced by a state-equality test. Cleaning up the redundancy belongs with the broader state-pattern decision in #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)