### PR TITLE
refactor: enforce required-usecase DI in 5 BLoC constructors

### DIFF
--- a/lib/features/account/application/account_bloc.dart
+++ b/lib/features/account/application/account_bloc.dart
@@ -6,22 +6,16 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/get_account_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/update_account_usecase.dart';
-import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
 
 part 'account_event.dart';
 part 'account_state.dart';
 
 class AccountBloc extends Bloc<AccountEvent, AccountState> {
-  AccountBloc({
-    GetAccountUseCase? getAccountUseCase,
-    UpdateAccountUseCase? updateAccountUseCase,
-    IAccountRepository? repository,
-  }) : _getAccountUseCase =
-           getAccountUseCase ?? GetAccountUseCase(repository ?? (throw ArgumentError('repository is required'))),
-       _updateAccountUseCase =
-           updateAccountUseCase ?? UpdateAccountUseCase(repository ?? (throw ArgumentError('repository is required'))),
-       super(const AccountState()) {
+  AccountBloc({required GetAccountUseCase getAccountUseCase, required UpdateAccountUseCase updateAccountUseCase})
+    : _getAccountUseCase = getAccountUseCase,
+      _updateAccountUseCase = updateAccountUseCase,
+      super(const AccountState()) {
     on<AccountFetchEvent>(_onFetchAccount);
     on<AccountSubmitEvent>(_onSubmit);
   }

--- a/lib/features/auth/application/change_password_bloc.dart
+++ b/lib/features/auth/application/change_password_bloc.dart
@@ -6,7 +6,6 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/change_password_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/data/models/change_password.dart';
-import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 
 part 'change_password_event.dart';
 part 'change_password_state.dart';
@@ -15,9 +14,8 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
   static final _log = AppLogger.getLogger("ChangePasswordBloc");
   final ChangePasswordUseCase _changePasswordUseCase;
 
-  ChangePasswordBloc({ChangePasswordUseCase? changePasswordUseCase, IAccountRepository? repository})
-    : _changePasswordUseCase =
-          changePasswordUseCase ?? ChangePasswordUseCase(repository ?? (throw ArgumentError('repository is required'))),
+  ChangePasswordBloc({required ChangePasswordUseCase changePasswordUseCase})
+    : _changePasswordUseCase = changePasswordUseCase,
       super(const ChangePasswordState()) {
     on<ChangePasswordChanged>(_onSubmit);
   }

--- a/lib/features/auth/application/forgot_password_bloc.dart
+++ b/lib/features/auth/application/forgot_password_bloc.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/reset_password_usecase.dart';
-import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 
 part 'forgot_password_event.dart';
 part 'forgot_password_state.dart';
@@ -14,9 +13,8 @@ class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> 
   static final _log = AppLogger.getLogger("ForgotPasswordBloc");
   final ResetPasswordUseCase _resetPasswordUseCase;
 
-  ForgotPasswordBloc({ResetPasswordUseCase? resetPasswordUseCase, IAccountRepository? repository})
-    : _resetPasswordUseCase =
-          resetPasswordUseCase ?? ResetPasswordUseCase(repository ?? (throw ArgumentError('repository is required'))),
+  ForgotPasswordBloc({required ResetPasswordUseCase resetPasswordUseCase})
+    : _resetPasswordUseCase = resetPasswordUseCase,
       super(const ForgotPasswordState(status: ForgotPasswordStatus.initial)) {
     on<ForgotPasswordEmailChanged>(_onSubmit);
   }

--- a/lib/features/auth/application/register_bloc.dart
+++ b/lib/features/auth/application/register_bloc.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/register_account_usecase.dart';
-import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
 
 part 'register_event.dart';
@@ -15,10 +14,8 @@ class RegisterBloc extends Bloc<RegisterEvent, RegisterState> {
   static final _log = AppLogger.getLogger("RegisterBloc");
   final RegisterAccountUseCase _registerAccountUseCase;
 
-  RegisterBloc({RegisterAccountUseCase? registerAccountUseCase, IAccountRepository? repository})
-    : _registerAccountUseCase =
-          registerAccountUseCase ??
-          RegisterAccountUseCase(repository ?? (throw ArgumentError('repository is required'))),
+  RegisterBloc({required RegisterAccountUseCase registerAccountUseCase})
+    : _registerAccountUseCase = registerAccountUseCase,
       super(const RegisterInitialState()) {
     on<RegisterFormSubmitted>(_onSubmit);
   }

--- a/lib/features/auth/navigation/auth_routes.dart
+++ b/lib/features/auth/navigation/auth_routes.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/change_password_usecase.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/register_account_usecase.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/reset_password_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/application/change_password_bloc.dart';
 import 'package:flutter_bloc_advance/features/auth/application/forgot_password_bloc.dart';
@@ -36,7 +39,8 @@ class AuthFeatureRoutes {
       name: 'forgot-password',
       path: ApplicationRoutesConstants.forgotPassword,
       builder: (context, state) => BlocProvider(
-        create: (_) => ForgotPasswordBloc(repository: context.read<IAccountRepository>()),
+        create: (_) =>
+            ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(context.read<IAccountRepository>())),
         child: ForgotPasswordScreen(),
       ),
     ),
@@ -44,7 +48,7 @@ class AuthFeatureRoutes {
       name: 'register',
       path: ApplicationRoutesConstants.register,
       builder: (context, state) => BlocProvider(
-        create: (_) => RegisterBloc(repository: context.read<IAccountRepository>()),
+        create: (_) => RegisterBloc(registerAccountUseCase: RegisterAccountUseCase(context.read<IAccountRepository>())),
         child: RegisterScreen(),
       ),
     ),
@@ -59,7 +63,8 @@ class AuthFeatureRoutes {
         state: state,
         type: AppPageTransitionType.slideRight,
         child: BlocProvider(
-          create: (_) => ChangePasswordBloc(repository: context.read<IAccountRepository>()),
+          create: (_) =>
+              ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(context.read<IAccountRepository>())),
           child: ChangePasswordScreen(),
         ),
       ),

--- a/lib/features/users/application/user_bloc.dart
+++ b/lib/features/users/application/user_bloc.dart
@@ -8,7 +8,6 @@ import 'package:flutter_bloc_advance/features/users/application/usecases/delete_
 import 'package:flutter_bloc_advance/features/users/application/usecases/fetch_user_usecase.dart';
 import 'package:flutter_bloc_advance/features/users/application/usecases/save_user_usecase.dart';
 import 'package:flutter_bloc_advance/features/users/application/usecases/search_users_usecase.dart';
-import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
 
 part 'user_event.dart';
@@ -16,19 +15,14 @@ part 'user_state.dart';
 
 class UserBloc extends Bloc<UserEvent, UserState> {
   UserBloc({
-    SearchUsersUseCase? searchUsersUseCase,
-    FetchUserUseCase? fetchUserUseCase,
-    SaveUserUseCase? saveUserUseCase,
-    DeleteUserUseCase? deleteUserUseCase,
-    IUserRepository? repository,
-  }) : _searchUsersUseCase =
-           searchUsersUseCase ?? SearchUsersUseCase(repository ?? (throw ArgumentError('repository is required'))),
-       _fetchUserUseCase =
-           fetchUserUseCase ?? FetchUserUseCase(repository ?? (throw ArgumentError('repository is required'))),
-       _saveUserUseCase =
-           saveUserUseCase ?? SaveUserUseCase(repository ?? (throw ArgumentError('repository is required'))),
-       _deleteUserUseCase =
-           deleteUserUseCase ?? DeleteUserUseCase(repository ?? (throw ArgumentError('repository is required'))),
+    required SearchUsersUseCase searchUsersUseCase,
+    required FetchUserUseCase fetchUserUseCase,
+    required SaveUserUseCase saveUserUseCase,
+    required DeleteUserUseCase deleteUserUseCase,
+  }) : _searchUsersUseCase = searchUsersUseCase,
+       _fetchUserUseCase = fetchUserUseCase,
+       _saveUserUseCase = saveUserUseCase,
+       _deleteUserUseCase = deleteUserUseCase,
        super(const UserState()) {
     on<UserSearchEvent>(_onSearch);
     on<UserFetchEvent>(_onFetchUser);

--- a/test/architecture/import_guard_test.dart
+++ b/test/architecture/import_guard_test.dart
@@ -34,14 +34,20 @@ const _knownCrossFeatureExceptions = {
   'lib/features/dashboard/presentation/pages/dashboard_home_page.dart → lifecycle/application/lifecycle_state',
   'lib/features/account/data/repositories/account_repository.dart → users/data/models/user',
   'lib/features/auth/navigation/auth_routes.dart → account/domain/repositories/account_repository',
+  // Cross-feature use case imports moved here when the BLoC constructors
+  // switched to required-use-case DI (#86). Proper fix is to relocate the
+  // Register/Forgot/Change BlocProviders out of auth/navigation into
+  // app/di/app_scope so the cross-feature coupling lives at the composition
+  // root. That move would change BLoC lifecycle (route-scoped → app-scoped),
+  // so it's deferred to its own issue.
+  'lib/features/auth/navigation/auth_routes.dart → account/application/usecases/change_password_usecase',
+  'lib/features/auth/navigation/auth_routes.dart → account/application/usecases/register_account_usecase',
+  'lib/features/auth/navigation/auth_routes.dart → account/application/usecases/reset_password_usecase',
   'lib/features/auth/application/forgot_password_bloc.dart → account/application/usecases/reset_password_usecase',
-  'lib/features/auth/application/forgot_password_bloc.dart → account/domain/repositories/account_repository',
   'lib/features/auth/application/login_bloc.dart → account/application/usecases/get_account_usecase',
   'lib/features/auth/application/change_password_bloc.dart → account/application/usecases/change_password_usecase',
   'lib/features/auth/application/change_password_bloc.dart → account/data/models/change_password',
-  'lib/features/auth/application/change_password_bloc.dart → account/domain/repositories/account_repository',
   'lib/features/auth/application/register_bloc.dart → account/application/usecases/register_account_usecase',
-  'lib/features/auth/application/register_bloc.dart → account/domain/repositories/account_repository',
 };
 
 /// features/ importing app/ (route constants used for navigation)

--- a/test/features/account/application/account_bloc_test.dart
+++ b/test/features/account/application/account_bloc_test.dart
@@ -1,6 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/get_account_usecase.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/update_account_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/data/models/change_password.dart';
 import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/account/application/account_bloc.dart';
@@ -125,7 +127,10 @@ void main() {
 
     setUp(() {
       repository = _FakeAccountRepository();
-      bloc = AccountBloc(repository: repository);
+      bloc = AccountBloc(
+        getAccountUseCase: GetAccountUseCase(repository),
+        updateAccountUseCase: UpdateAccountUseCase(repository),
+      );
     });
 
     tearDown(() {

--- a/test/features/auth/application/change_password_bloc_test.dart
+++ b/test/features/auth/application/change_password_bloc_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/change_password_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/data/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/application/change_password_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -79,7 +80,7 @@ void main() {
   group("ChangePasswordBloc", () {
     test("initial state is ChangePasswordState with initial status", () {
       expect(
-        ChangePasswordBloc(repository: repository).state,
+        ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)).state,
         const ChangePasswordState(status: ChangePasswordStatus.initial),
       );
     });
@@ -97,7 +98,7 @@ void main() {
       blocTest<ChangePasswordBloc, ChangePasswordState>(
         "emits [loading, success] when ChangePasswordChanged is added",
         setUp: () => when(method).thenAnswer((_) async => const Success<void>(null)),
-        build: () => ChangePasswordBloc(repository: repository),
+        build: () => ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => statesSuccess,
         verify: (_) => verify(method).called(1),
@@ -106,7 +107,7 @@ void main() {
       blocTest<ChangePasswordBloc, ChangePasswordState>(
         "emits [loading, error] when ChangePasswordChanged is added and returns Failure",
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ServerError('Change password failed'))),
-        build: () => ChangePasswordBloc(repository: repository),
+        build: () => ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => [
           loadingState,
@@ -118,7 +119,7 @@ void main() {
       blocTest<ChangePasswordBloc, ChangePasswordState>(
         "emits [loading, error] when repository returns Failure with ValidationError",
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ValidationError('Invalid password'))),
-        build: () => ChangePasswordBloc(repository: repository),
+        build: () => ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => [
           loadingState,

--- a/test/features/auth/application/forgot_password_bloc_test.dart
+++ b/test/features/auth/application/forgot_password_bloc_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/reset_password_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/data/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/application/forgot_password_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -72,7 +73,7 @@ void main() {
     //ForgotPasswordState Initial Test
     test('initial state is ForgotPasswordState', () {
       expect(
-        ForgotPasswordBloc(repository: repository).state,
+        ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)).state,
         const ForgotPasswordState(status: ForgotPasswordStatus.initial),
       );
     });
@@ -110,7 +111,7 @@ void main() {
 
     test("initial state is ForgotPasswordState", () {
       expect(
-        ForgotPasswordBloc(repository: repository).state,
+        ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)).state,
         const ForgotPasswordState(status: ForgotPasswordStatus.initial),
       );
     });
@@ -123,7 +124,7 @@ void main() {
     blocTest<ForgotPasswordBloc, ForgotPasswordState>(
       'emits [ForgotPasswordLoadingState, ForgotPasswordCompletedState] when resetPassword is successful',
       setUp: () => when(() => repository.resetPassword(email)).thenAnswer((_) async => const Success<void>(null)),
-      build: () => ForgotPasswordBloc(repository: repository),
+      build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: email)),
       expect: () => [
         const ForgotPasswordState(status: ForgotPasswordStatus.loading),
@@ -136,7 +137,7 @@ void main() {
       setUp: () => when(
         () => repository.resetPassword(email),
       ).thenAnswer((_) async => const Failure<void>(ServerError('Reset failed'))),
-      build: () => ForgotPasswordBloc(repository: repository),
+      build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: email)),
       expect: () => [
         const ForgotPasswordState(status: ForgotPasswordStatus.loading),
@@ -149,7 +150,7 @@ void main() {
       setUp: () => when(
         () => repository.resetPassword('invalid-email'),
       ).thenAnswer((_) async => const Failure<void>(ValidationError('Invalid email'))),
-      build: () => ForgotPasswordBloc(repository: repository),
+      build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: 'invalid-email')),
       expect: () => [
         const ForgotPasswordState(status: ForgotPasswordStatus.loading),

--- a/test/features/auth/application/register_bloc_test.dart
+++ b/test/features/auth/application/register_bloc_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/account/application/usecases/register_account_usecase.dart';
 import 'package:flutter_bloc_advance/features/account/data/models/change_password.dart';
 import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/application/register_bloc.dart';
@@ -110,7 +111,7 @@ void main() {
   group("RegisterBloc", () {
     const initialState = RegisterInitialState();
     test("initial state is LoginState", () {
-      expect(RegisterBloc(repository: repository).state, initialState);
+      expect(RegisterBloc(registerAccountUseCase: RegisterAccountUseCase(repository)).state, initialState);
     });
 
     group("LoginFormSubmitted", () {
@@ -126,7 +127,7 @@ void main() {
       blocTest<RegisterBloc, RegisterState>(
         "emits [loading, success] when submit is successful",
         setUp: () => repository.registerResult = const Success(input),
-        build: () => RegisterBloc(repository: repository),
+        build: () => RegisterBloc(registerAccountUseCase: RegisterAccountUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => statesSuccess,
       );
@@ -134,7 +135,7 @@ void main() {
       blocTest<RegisterBloc, RegisterState>(
         "emits [loading, failure] when exception occurs",
         setUp: () => repository.registerResult = const Failure(UnknownError("Register Error")),
-        build: () => RegisterBloc(repository: repository),
+        build: () => RegisterBloc(registerAccountUseCase: RegisterAccountUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => statesFailure,
       );
@@ -142,7 +143,7 @@ void main() {
       blocTest<RegisterBloc, RegisterState>(
         "emits [loading, failure] when response is failure",
         setUp: () => repository.registerResult = const Failure(ValidationError("Register Error")),
-        build: () => RegisterBloc(repository: repository),
+        build: () => RegisterBloc(registerAccountUseCase: RegisterAccountUseCase(repository)),
         act: (bloc) => bloc..add(event),
         expect: () => statesFailure,
       );

--- a/test/features/users/application/user_bloc_test.dart
+++ b/test/features/users/application/user_bloc_test.dart
@@ -1,6 +1,10 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/users/application/usecases/delete_user_usecase.dart';
+import 'package:flutter_bloc_advance/features/users/application/usecases/fetch_user_usecase.dart';
+import 'package:flutter_bloc_advance/features/users/application/usecases/save_user_usecase.dart';
+import 'package:flutter_bloc_advance/features/users/application/usecases/search_users_usecase.dart';
 import 'package:flutter_bloc_advance/features/users/application/user_bloc.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
@@ -72,7 +76,12 @@ void main() {
 
   setUp(() {
     repository = _FakeUserRepository();
-    bloc = UserBloc(repository: repository);
+    bloc = UserBloc(
+      searchUsersUseCase: SearchUsersUseCase(repository),
+      fetchUserUseCase: FetchUserUseCase(repository),
+      saveUserUseCase: SaveUserUseCase(repository),
+      deleteUserUseCase: DeleteUserUseCase(repository),
+    );
   });
 
   tearDown(() async {


### PR DESCRIPTION
## Description

Five BLoCs (`UserBloc`, `AccountBloc`, `RegisterBloc`, `ChangePasswordBloc`, `ForgotPasswordBloc`) previously accepted both a use case and a repository in their constructor, with the use case defaulting to one built from the repository — and throwing `ArgumentError` at use-case construction time if neither was supplied:

```dart
UserBloc({
  SearchUsersUseCase? searchUsersUseCase,
  // ...
  IUserRepository? repository,
}) : _searchUsersUseCase = searchUsersUseCase
       ?? SearchUsersUseCase(repository ?? (throw ArgumentError('repository is required'))),
     // ... repeated four times
```

This:
- created two valid construction paths the BLoC had to support
- punted missing-dependency failures from compile time to runtime
- forced the BLoC to import its data-layer repository interface (cross-layer leak)
- diverged from `LoginBloc` and `LifecycleBloc`, which already used the clean `required` form

All five BLoCs now expose only `required` use case parameters; the repository imports and `throw ArgumentError` fallbacks are gone.

### Wiring updates

- **`lib/app/di/app_scope.dart`** — already constructed `AccountBloc` this way; no change.
- **`lib/features/users/navigation/users_routes.dart`** — already constructed `UserBloc` this way; no change.
- **`lib/features/auth/navigation/auth_routes.dart`** — now constructs `ResetPasswordUseCase`, `RegisterAccountUseCase`, and `ChangePasswordUseCase` inline at the BlocProvider site.
- **Five test files** updated to do the same for `_buildBloc(...)`-style helpers.

### Architecture-guard note

The `auth_routes.dart` change introduces three new cross-feature imports (`auth → account/application/usecases/*`). They are added to the architecture guard's `_knownCrossFeatureExceptions` with a comment that the proper architectural fix is to **relocate the three BlocProviders into `app/di/app_scope`** — moving them changes BLoC lifecycle from route-scoped to app-scoped, which has UX implications (stale forgot-password state across visits) and is left to its own follow-up. The three old `account/domain/repositories/account_repository` BLoC-level exceptions are removed since those imports are no longer needed.

## Related Issue

Closes #86

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows Feature-First Clean Architecture (with architecture-guard exceptions documented above)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures (including the architecture guard suite)

## Additional Notes

The remaining cross-feature coupling in `auth_routes.dart` is a known architectural debt, not introduced by this PR — the file was already importing `IAccountRepository` from `account/` under an existing exception. This PR shifts the coupling from one cross-feature import to three (the use cases) but keeps the direction and intent. A proper follow-up (moving the BlocProviders to `app_scope.dart`) is the right place to remove all four exceptions at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)