### PR TITLE
chore: standardize log call style on SLF4J parameterized form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,13 @@ Every feature follows: **Event → BLoC → State → UI**
 - States use status enums: `initial`, `loading`, `success`, `failure`.
 - Local UI state can be handled within the page, but business logic MUST be in BLoCs.
 
+## Logging
+
+- Acquire loggers via `AppLogger.getLogger('Name')` (`lib/core/logging/app_logger.dart`).
+- Use SLF4J-style parameterized substitution: `_log.debug('msg: {}', [arg])` — **not** string interpolation (`_log.debug('msg: ${arg}')`).
+  - Parameterized form skips `toString()` when the log level is disabled — faster, and avoids accidentally stringifying secrets carried on events with `stringify = true`.
+- BLoC lifecycle transitions are logged centrally by `AppBlocObserver` (`lib/core/logging/app_bloc_observer.dart`). Do **not** override `onTransition` inside BLoCs.
+
 ## Environments
 
 - **dev/test** → mock data from `assets/mock/*.json`

--- a/lib/core/errors/app_api_exception.dart
+++ b/lib/core/errors/app_api_exception.dart
@@ -7,7 +7,7 @@ abstract class AppException implements Exception {
   final String? _prefix;
 
   AppException(String? message, String? prefix) : _message = message, _prefix = prefix {
-    _log.error("$_prefix$_message");
+    _log.error('{}{}', [_prefix, _message]);
   }
 
   @override


### PR DESCRIPTION
## Description

The codebase had already converged on the SLF4J-style `_log.debug('msg: {}', [arg])` form across all 299 logger call sites in `lib/` — **except a single holdout** in `lib/core/errors/app_api_exception.dart`, which used string interpolation:

```diff
-    _log.error("$_prefix$_message");
+    _log.error('{}{}', [_prefix, _message]);
```

Most of the migration happened as a side effect of **#80** (centralizing `onTransition` into `AppBlocObserver`), which removed the four per-BLoC `onTransition` overrides that were the main interpolation users. This PR finishes the job and documents the standard in `CLAUDE.md` so contributors don't reintroduce the interpolation form.

### CLAUDE.md addition

A new **Logging** section documents:
- the `AppLogger.getLogger('Name')` entry point
- the SLF4J parameterized form as the project standard, with the interpolation form explicitly rejected
- the rationale (lazy `toString()` evaluation + protection against accidental secret leakage)
- that BLoCs should not override `onTransition` (handled by `AppBlocObserver`)

## Related Issue

Closes #79

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation update
- [ ] CI/CD or build configuration change

(There is also a one-line code change to the last interpolation holdout — but the substantive part is documentation locking in the standard.)

## Checklist

- [x] Follows Feature-First Clean Architecture
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1395 tests passed**, 0 failures

## Additional Notes

Issue #79 was filed under the assumption of mixed styles across BLoCs. By the time we got here, **#80 had already done the heavy lifting** — an instructive example of why fixing issues in dependency order pays off. This PR is the cleanup tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)