### PR TITLE
docs: establish sealed state hierarchies as the project main rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,7 @@ lib/
 ## BLoC Pattern
 
 Every feature follows: **Event → BLoC → State → UI**
-- BLoCs use `Equatable` for state equality, `copyWith()` for immutable updates.
-- States use status enums: `initial`, `loading`, `success`, `failure`.
+- BLoCs use `Equatable` for state equality.
 - Local UI state can be handled within the page, but business logic MUST be in BLoCs.
 
 ### `Bloc` vs `Cubit`
@@ -84,6 +83,53 @@ Every feature follows: **Event → BLoC → State → UI**
 - Use **`Cubit`** when every interaction is an atomic, fire-and-forget call and the event stream adds no value (no debouncing, no concurrency policy, no historical event payload needed). Example: `SettingsCubit` (`changeLanguage`, `changeTheme`, `logout`).
 - Use **`Bloc`** when events carry meaningful payload, when an `EventTransformer` (debounce, restartable, droppable) is needed, or when the event log itself is valuable for replay/observability. Example: `UserBloc` (search + pagination + CRUD).
 - Default to `Bloc` for any new feature touching network requests or user input streams; reach for `Cubit` only after confirming none of the above apply.
+
+### State Modeling — MAIN RULE
+
+> ⚠️ **Migration in progress (May 2026):** The project is transitioning to sealed state hierarchies as the default state-modeling pattern. Some BLoCs may still be on the legacy single-state + status enum pattern during this transition; new code MUST follow the rule below, and existing BLoCs are being migrated under the tech-debt audit. Once the migration completes, this warning will be removed.
+
+**Default to sealed state hierarchies** that leverage Dart 3's `sealed` modifier and exhaustive `switch` expressions. The compiler enforces handling of every state variant; UIs render via pattern matching.
+
+```dart
+// State
+sealed class UserState extends Equatable {
+  const UserState();
+}
+final class UserInitial extends UserState { /* ... */ }
+final class UserLoading extends UserState { /* ... */ }
+final class UserLoaded extends UserState {
+  const UserLoaded(this.users);
+  final List<UserEntity> users;
+  @override List<Object?> get props => [users];
+}
+final class UserFailure extends UserState {
+  const UserFailure(this.errorCode);
+  final String errorCode;
+  @override List<Object?> get props => [errorCode];
+}
+
+// UI
+BlocBuilder<UserBloc, UserState>(
+  builder: (context, state) => switch (state) {
+    UserInitial() => const SizedBox.shrink(),
+    UserLoading() => const Loading(),
+    UserLoaded(:final users) => UserList(users),
+    UserFailure(:final errorCode) => ErrorBanner(errorCode),
+  },
+);
+```
+
+**Use single-state + status enum only when** one of these is genuinely true:
+
+1. **Concurrent state access:** UI must render data from one state while reacting to another (e.g., show the previously loaded list while an error banner appears for the latest refresh attempt).
+2. **Transactional snapshot:** State carries a coherent bundle whose fields all evolve together (search query + filters + pagination + result set) and splitting them into sealed variants would lose meaning.
+3. **Form persistence:** Thin form/CRUD wrapper where status changes but form fields persist across all states, AND no genuine state machine exists underneath.
+
+When in doubt, prefer sealed and split the BLoC instead of growing the single state.
+
+**UI consumers** use `switch (state) { ... }` expressions, NOT `if (state is X) ... else if (state is Y)`. Reach for `BlocSelector` only when narrowing to a slice of a variant's fields — not for type discrimination.
+
+**Why this rule (short version):** Compile-time exhaustive matching catches forgotten states at build time; impossible-state combinations (e.g. `loading=true && error="…"`) become unrepresentable; the `copyWith` null-clearing class of bugs disappears because variants carry only their own fields. Bloc creator [Felix Angelov](https://github.com/felangel/bloc/issues/1726) treats both patterns as valid; we pick sealed because Dart 3's modifiers + switch expressions tilt the trade-off decisively in its favor for this codebase.
 
 ## Logging
 


### PR DESCRIPTION
## Description

Locks in **Dart 3 sealed state hierarchies as this project's default state-modeling pattern**, with a narrow set of explicit exceptions for cases where single-state + status enum genuinely fits better.

This is a *governance-only* PR — no production code changes. It plants the rule in `CLAUDE.md` so all subsequent migration PRs (and any community contribution) start from a documented, defensible standard.

### What the new section says

- **Default:** sealed state classes, with UI rendering via Dart 3 `switch` expressions for compile-time exhaustive matching.
- **Exceptions (use single-state + status enum only when):**
  1. Concurrent state access (previous data must remain visible during a new transition).
  2. Transactional snapshot (search + filters + pagination + result evolve together).
  3. Form persistence (form fields must survive across status changes with no genuine state machine).
- **UI consumers:** prefer `switch (state) { ... }`; avoid `state is X` chains; use `BlocSelector` for slice narrowing, not type discrimination.

### Why now (and why this rule)

- **Felix Angelov's stance** ([felangel/bloc#1726](https://github.com/felangel/bloc/issues/1726)) treats both patterns as valid. We pick sealed because Dart 3 sealed modifiers + switch expressions decisively tilt the trade-off for this codebase.
- **Mega-class growth** (e.g., `UserState`'s 9-value `UserStatus` enum, tracked in #75) is the dominant failure mode of single-state at scale here.
- **#74 (`copyWith` null-clearing)** dissolves under sealed — variants carry only their own fields, no nullable sentinels.

### Migration banner

The new section opens with a transition warning so the rule is published *before* the migration is complete. Some BLoCs are still on the legacy pattern; new code must follow the rule, existing BLoCs are migrated one-by-one under the tech-debt audit (#70 / #75 / #81 follow-ups). The warning gets removed once migration completes.

### Cleanup

Two now-misleading lines removed from the top of "BLoC Pattern":

```diff
- BLoCs use `Equatable` for state equality, `copyWith()` for immutable updates.
- States use status enums: `initial`, `loading`, `success`, `failure`.
+ BLoCs use `Equatable` for state equality.
```

`copyWith` and the four-status enum are single-state-pattern specifics that no longer apply project-wide under the new rule.

## Related Issue

Partially addresses #81 — establishes the decision; the actual BLoC migrations are tracked under #70, #75, and a follow-up wave of single-state → sealed PRs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation update (project main rule)
- [ ] CI/CD or build configuration change

## Checklist

- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → unchanged (docs-only)
- [x] `fvm flutter test` → unchanged (docs-only)
- [x] CLAUDE.md addition follows the existing structure (subsection under "BLoC Pattern")

## Additional Notes

The rule was decided after a deep dive into the Bloc team's `Modeling State` doc, Very Good Ventures' architecture writeups, multiple community articles for and against each pattern, and Felix Angelov's own GitHub comments. The full reasoning chain lives in the maintainer's session notes; the *outcome* is what this PR publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)