### PR TITLE
refactor: SettingsState — pure Dart 3 sealed hierarchy

### DIFF
--- a/lib/features/settings/application/settings_state.dart
+++ b/lib/features/settings/application/settings_state.dart
@@ -1,57 +1,53 @@
 part of 'settings_cubit.dart';
 
-enum SettingsStatus { initial, loading, success, failure }
-
-abstract class SettingsState extends Equatable {
-  const SettingsState({required this.status});
-
-  final SettingsStatus status;
+sealed class SettingsState extends Equatable {
+  const SettingsState();
 }
 
-class SettingsInitial extends SettingsState {
-  const SettingsInitial() : super(status: SettingsStatus.initial);
+final class SettingsInitial extends SettingsState {
+  const SettingsInitial();
 
   @override
-  List<Object> get props => [status];
+  List<Object?> get props => const [];
 }
 
-class SettingsLoading extends SettingsState {
-  const SettingsLoading() : super(status: SettingsStatus.loading);
+final class SettingsLoading extends SettingsState {
+  const SettingsLoading();
 
   @override
-  List<Object> get props => [status];
+  List<Object?> get props => const [];
 }
 
-class SettingsLogoutSuccess extends SettingsState {
-  const SettingsLogoutSuccess() : super(status: SettingsStatus.success);
+final class SettingsLogoutSuccess extends SettingsState {
+  const SettingsLogoutSuccess();
 
   @override
-  List<Object> get props => [status];
+  List<Object?> get props => const [];
 }
 
-class SettingsLanguageChanged extends SettingsState {
-  const SettingsLanguageChanged({required this.language}) : super(status: SettingsStatus.success);
+final class SettingsLanguageChanged extends SettingsState {
+  const SettingsLanguageChanged({required this.language});
 
   final String? language;
 
   @override
-  List<Object> get props => [status, language ?? ''];
+  List<Object?> get props => [language];
 }
 
-class SettingsThemeChanged extends SettingsState {
-  const SettingsThemeChanged({required this.theme}) : super(status: SettingsStatus.success);
+final class SettingsThemeChanged extends SettingsState {
+  const SettingsThemeChanged({required this.theme});
 
   final ThemeMode theme;
 
   @override
-  List<Object> get props => [theme, status];
+  List<Object?> get props => [theme];
 }
 
-class SettingsFailure extends SettingsState {
-  const SettingsFailure({required this.message}) : super(status: SettingsStatus.failure);
+final class SettingsFailure extends SettingsState {
+  const SettingsFailure({required this.message});
 
   final String message;
 
   @override
-  List<Object> get props => [message, status];
+  List<Object?> get props => [message];
 }

--- a/test/features/settings/application/settings_cubit_test.dart
+++ b/test/features/settings/application/settings_cubit_test.dart
@@ -22,27 +22,27 @@ void main() {
 
     test("SettingsInitial", () {
       expect(const SettingsInitial(), const SettingsInitial());
-      expect(const SettingsInitial().props, [SettingsStatus.initial]);
+      expect(const SettingsInitial().props, const <Object?>[]);
     });
     test("SettingsLoading", () {
       expect(const SettingsLoading(), const SettingsLoading());
-      expect(const SettingsLoading().props, [SettingsStatus.loading]);
+      expect(const SettingsLoading().props, const <Object?>[]);
     });
     test("SettingsLogoutSuccess", () {
       expect(const SettingsLogoutSuccess(), const SettingsLogoutSuccess());
-      expect(const SettingsLogoutSuccess().props, [SettingsStatus.success]);
+      expect(const SettingsLogoutSuccess().props, const <Object?>[]);
     });
     test("SettingsLanguageChanged", () {
       expect(const SettingsLanguageChanged(language: "en"), const SettingsLanguageChanged(language: "en"));
-      expect(const SettingsLanguageChanged(language: "en").props, [SettingsStatus.success, "en"]);
+      expect(const SettingsLanguageChanged(language: "en").props, const <Object?>["en"]);
     });
     test("SettingsThemeChanged", () {
       expect(const SettingsThemeChanged(theme: ThemeMode.system), const SettingsThemeChanged(theme: ThemeMode.system));
-      expect(const SettingsThemeChanged(theme: ThemeMode.system).props, [ThemeMode.system, SettingsStatus.success]);
+      expect(const SettingsThemeChanged(theme: ThemeMode.system).props, const <Object?>[ThemeMode.system]);
     });
     test("SettingsFailure", () {
       expect(const SettingsFailure(message: "Error"), const SettingsFailure(message: "Error"));
-      expect(const SettingsFailure(message: "Error").props, ["Error", SettingsStatus.failure]);
+      expect(const SettingsFailure(message: "Error").props, const <Object?>["Error"]);
     });
   });
   //endregion state


### PR DESCRIPTION
## Description

First migration step of the sealed-by-default transition established in #103. Upgrades `SettingsState` from the legacy `abstract class` + status enum shape to a pure Dart 3 sealed hierarchy.

### Changes

```diff
- abstract class SettingsState extends Equatable {
-   const SettingsState({required this.status});
-   final SettingsStatus status;
- }
- enum SettingsStatus { initial, loading, success, failure }
+ sealed class SettingsState extends Equatable {
+   const SettingsState();
+ }
```

- `abstract class SettingsState` → `sealed class SettingsState`.
- Every variant prefixed with `final class` (Dart 3 modifier) to lock the hierarchy at the library boundary and let `switch` expressions remain exhaustive without a `default` arm.
- `SettingsStatus` enum and `status` field removed from the base — the variant TYPE is the status. UI consumers (none exist for this cubit yet) should pattern-match on the variant instead of checking a status string.
- Each variant carries only the fields it actually needs; props lists shrink accordingly. Equality semantics unchanged.

### Why this BLoC first

- **Smallest, lowest-risk migration**: no UI consumer reads `SettingsCubit` state at all (the screen renders static tiles), so the public surface change has zero downstream impact.
- **Validates the migration pattern** for the larger BLoCs that follow.

### No cubit changes required

Every `emit(...)` call in `SettingsCubit` already constructs a specific variant (`SettingsLoading()`, `SettingsLanguageChanged(language: ...)`, etc.), so dropping the base-class `status` parameter has no effect on the cubit itself.

## Related Issue

First execution step of #81 — establishes sealed-by-default in code, not just in CLAUDE.md.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows the new project main rule (`CLAUDE.md` → State Modeling): sealed hierarchy used
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1392 tests passed**, 0 failures
- [x] Test props assertions updated to the new variant-only shape

## Additional Notes

Subsequent PRs will migrate the remaining BLoCs in roughly this order: `change_password`, `account`, `lifecycle`, `forgot_password`, `dynamic_form`, `user` (likely combined with the #75 god-bloc split), `login` (#70 fix). `SystemDashboardState` will keep its single-state form under the documented "transactional snapshot" exception (24 fields evolve together). Once all migrations land, the transition warning in `CLAUDE.md` will be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)