### PR TITLE
refactor: AuthorityState — drop copyWith base, pure Dart 3 sealed

### DIFF
--- a/lib/features/users/application/authority_state.dart
+++ b/lib/features/users/application/authority_state.dart
@@ -1,41 +1,37 @@
 part of 'authority_bloc.dart';
 
-enum AuthorityStatus { initial, loading, success, failure }
+sealed class AuthorityState extends Equatable {
+  const AuthorityState();
+}
 
-class AuthorityState extends Equatable {
-  const AuthorityState({this.authorities = const [], this.status = AuthorityStatus.initial});
+final class AuthorityInitialState extends AuthorityState {
+  const AuthorityInitialState();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+final class AuthorityLoadingState extends AuthorityState {
+  const AuthorityLoadingState();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+final class AuthorityLoadSuccessState extends AuthorityState {
+  const AuthorityLoadSuccessState({required this.authorities});
 
   final List<String?> authorities;
-  final AuthorityStatus status;
-
-  AuthorityState copyWith({List<String?>? authorities, AuthorityStatus? status}) {
-    return AuthorityState(status: status ?? this.status, authorities: authorities ?? this.authorities);
-  }
 
   @override
-  List<Object> get props => [status, authorities];
-
-  @override
-  bool get stringify => true;
+  List<Object?> get props => [authorities];
 }
 
-class AuthorityInitialState extends AuthorityState {
-  const AuthorityInitialState() : super(status: AuthorityStatus.initial);
-}
-
-class AuthorityLoadingState extends AuthorityState {
-  const AuthorityLoadingState() : super(status: AuthorityStatus.loading);
-}
-
-class AuthorityLoadSuccessState extends AuthorityState {
-  const AuthorityLoadSuccessState({required super.authorities}) : super(status: AuthorityStatus.success);
-}
-
-class AuthorityLoadFailureState extends AuthorityState {
-  const AuthorityLoadFailureState({required this.message}) : super(status: AuthorityStatus.failure);
+final class AuthorityLoadFailureState extends AuthorityState {
+  const AuthorityLoadFailureState({required this.message});
 
   final String message;
 
   @override
-  List<Object> get props => [status, message];
+  List<Object?> get props => [message];
 }

--- a/test/features/auth/presentation/pages/change_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/change_password_screen_test.dart
@@ -44,8 +44,8 @@ void main() {
     when(() => changePasswordBloc.stream).thenAnswer((_) => stateController.stream);
     when(() => changePasswordBloc.state).thenReturn(const ChangePasswordState());
 
-    when(() => authorityBloc.stream).thenAnswer((_) => Stream.fromIterable([const AuthorityState()]));
-    when(() => authorityBloc.state).thenReturn(const AuthorityState());
+    when(() => authorityBloc.stream).thenAnswer((_) => Stream.fromIterable([const AuthorityInitialState()]));
+    when(() => authorityBloc.state).thenReturn(const AuthorityInitialState());
   });
 
   final Iterable<LocalizationsDelegate<dynamic>> locales = [

--- a/test/features/users/application/authority_bloc_test.dart
+++ b/test/features/users/application/authority_bloc_test.dart
@@ -34,52 +34,28 @@ void main() {
   /// Authority State Tests
   group("AuthorityState", () {
     const authorities = ["test"];
-    const status = AuthorityStatus.initial;
 
-    test("supports value comparisons", () {
-      expect(
-        const AuthorityState(authorities: authorities, status: status),
-        const AuthorityState(authorities: authorities, status: status),
-      );
-    });
-
-    test("AuthorityInitialState", () {
+    test("AuthorityInitialState equals", () {
       expect(const AuthorityInitialState(), const AuthorityInitialState());
+      expect(const AuthorityInitialState().props, const <Object?>[]);
     });
 
-    test("AuthorityLoadInProgressState", () {
+    test("AuthorityLoadingState equals", () {
       expect(const AuthorityLoadingState(), const AuthorityLoadingState());
+      expect(const AuthorityLoadingState().props, const <Object?>[]);
     });
 
-    test("AuthorityLoadSuccessState", () {
+    test("AuthorityLoadSuccessState equals", () {
       expect(
         const AuthorityLoadSuccessState(authorities: authorities),
         const AuthorityLoadSuccessState(authorities: authorities),
       );
+      expect(const AuthorityLoadSuccessState(authorities: authorities).props, const <Object?>[authorities]);
     });
 
-    test("AuthorityLoadFailureState", () {
+    test("AuthorityLoadFailureState equals", () {
       expect(const AuthorityLoadFailureState(message: "test"), const AuthorityLoadFailureState(message: "test"));
-    });
-    test("AuthorityState copyWith", () {
-      expect(const AuthorityState().copyWith(), const AuthorityState());
-      expect(const AuthorityState().copyWith(authorities: authorities), const AuthorityState(authorities: authorities));
-      expect(
-        const AuthorityState().copyWith(status: AuthorityStatus.success),
-        const AuthorityState(status: AuthorityStatus.success),
-      );
-    });
-    test("AuthorityState stringify", () {
-      expect(const AuthorityState().stringify, true);
-    });
-    test("AuthorityState props", () {
-      expect(const AuthorityState().props, [AuthorityStatus.initial, []]);
-      expect(const AuthorityState(authorities: authorities).props, [AuthorityStatus.initial, authorities]);
-
-      expect(const AuthorityInitialState().props, [AuthorityStatus.initial, []]);
-      expect(const AuthorityLoadingState().props, [AuthorityStatus.loading, []]);
-      expect(const AuthorityLoadSuccessState(authorities: authorities).props, [AuthorityStatus.success, authorities]);
-      expect(const AuthorityLoadFailureState(message: "test").props, [AuthorityStatus.failure, "test"]);
+      expect(const AuthorityLoadFailureState(message: "test").props, const <Object?>["test"]);
     });
   });
 


### PR DESCRIPTION
## Description

Second migration step of the sealed-by-default transition. Cleans up the mixed-pattern `AuthorityState` (single base with `copyWith` + subclasses) to a pure Dart 3 sealed hierarchy.

### Changes

```diff
- enum AuthorityStatus { initial, loading, success, failure }
-
- class AuthorityState extends Equatable {
-   const AuthorityState({this.authorities = const [], this.status = AuthorityStatus.initial});
-   final List<String?> authorities;
-   final AuthorityStatus status;
-   AuthorityState copyWith({...}) { ... }
- }
+ sealed class AuthorityState extends Equatable {
+   const AuthorityState();
+ }
```

- `class AuthorityState` → `sealed class AuthorityState`; variants prefixed with `final class`.
- `AuthorityStatus` enum and the base `authorities` + `status` fields removed. **Variant TYPE is now the status.**
- `authorities` lives only on `AuthorityLoadSuccessState` where it actually carries data; `message` only on `AuthorityLoadFailureState`.
- `copyWith` on the base removed — sealed variants have no shared mutable shape, so `copyWith` has no purpose; the bloc already emits fresh variant instances.

### Bloc unaffected

`AuthorityBloc` already emitted concrete variants only (`emit(const AuthorityLoadingState())`, `emit(AuthorityLoadSuccessState(authorities: data))`, etc.), so no bloc changes were needed.

### Unrelated-test fix

One test in `change_password_screen_test.dart` was mocking `authorityBloc.state` with `const AuthorityState()` (legal under the old non-sealed base, illegal now). Updated to `const AuthorityInitialState()`.

```diff
- when(() => authorityBloc.state).thenReturn(const AuthorityState());
+ when(() => authorityBloc.state).thenReturn(const AuthorityInitialState());
```

### Test count

Net -4 (removed the base-class `copyWith` / `stringify` / status-only props tests that no longer apply); behaviour preserved.

## Related Issue

Continued execution of #81 (sealed-by-default in code).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows the new project main rule (`CLAUDE.md` → State Modeling): sealed hierarchy used
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1388 tests passed**, 0 failures

## Additional Notes

Next in the migration queue: `register_state.dart` (same mixed → sealed cleanup), then the bulk single-state migrations (`change_password`, `account`, `lifecycle`, ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)