### PR TITLE
refactor: RegisterState — drop copyWith base, pure Dart 3 sealed

### DIFF
--- a/lib/features/auth/application/register_state.dart
+++ b/lib/features/auth/application/register_state.dart
@@ -1,38 +1,37 @@
 part of 'register_bloc.dart';
 
-enum RegisterStatus { initial, loading, success, error }
+sealed class RegisterState extends Equatable {
+  const RegisterState();
+}
 
-class RegisterState extends Equatable {
-  final UserEntity? data;
-  final RegisterStatus status;
-
-  const RegisterState({this.data, this.status = RegisterStatus.initial});
-
-  RegisterState copyWith({UserEntity? data, RegisterStatus? status}) {
-    return RegisterState(data: data ?? this.data, status: status ?? this.status);
-  }
+final class RegisterInitialState extends RegisterState {
+  const RegisterInitialState();
 
   @override
-  List<Object> get props => [status, data ?? ''];
+  List<Object?> get props => const [];
+}
+
+final class RegisterLoadingState extends RegisterState {
+  const RegisterLoadingState();
 
   @override
-  bool get stringify => true;
+  List<Object?> get props => const [];
 }
 
-class RegisterInitialState extends RegisterState {
-  const RegisterInitialState() : super(status: RegisterStatus.initial);
+final class RegisterCompletedState extends RegisterState {
+  const RegisterCompletedState({required this.user});
+
+  final UserEntity user;
+
+  @override
+  List<Object?> get props => [user];
 }
 
-class RegisterLoadingState extends RegisterState {
-  const RegisterLoadingState() : super(status: RegisterStatus.loading);
-}
+final class RegisterErrorState extends RegisterState {
+  const RegisterErrorState({required this.message});
 
-class RegisterCompletedState extends RegisterState {
-  const RegisterCompletedState({required UserEntity user}) : super(data: user, status: RegisterStatus.success);
-}
-
-class RegisterErrorState extends RegisterState {
   final String message;
 
-  const RegisterErrorState({required this.message}) : super(status: RegisterStatus.error);
+  @override
+  List<Object?> get props => [message];
 }

--- a/lib/features/auth/presentation/pages/register_page.dart
+++ b/lib/features/auth/presentation/pages/register_page.dart
@@ -20,7 +20,7 @@ class RegisterScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocListener<RegisterBloc, RegisterState>(
-      listenWhen: (previous, current) => previous.status != current.status,
+      listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       listener: (context, state) => _handleStateChanges(context, state),
       child: Scaffold(appBar: _buildAppBar(context), body: _buildBody(context)),
     );
@@ -61,18 +61,20 @@ class RegisterScreen extends StatelessWidget {
   }
 
   List<Widget> _buildFormFields(BuildContext context, RegisterState state) {
+    final user = state is RegisterCompletedState ? state.user : null;
     return [
-      UserFormFields.firstNameField(context, state.data?.firstName),
-      UserFormFields.lastNameField(context, state.data?.lastName),
-      UserFormFields.emailField(context, state.data?.email),
+      UserFormFields.firstNameField(context, user?.firstName),
+      UserFormFields.lastNameField(context, user?.lastName),
+      UserFormFields.emailField(context, user?.email),
     ];
   }
 
   Widget _submitButton(BuildContext context, RegisterState state) {
+    final isLoading = state is RegisterLoadingState;
     return ResponsiveSubmitButton(
       key: const Key('registerSubmitButtonKey'),
-      onPressed: () => state.status == RegisterStatus.loading ? null : _onSubmit(context, state),
-      isLoading: state.status == RegisterStatus.loading,
+      onPressed: () => isLoading ? null : _onSubmit(context, state),
+      isLoading: isLoading,
     );
   }
 
@@ -100,19 +102,16 @@ class RegisterScreen extends StatelessWidget {
 
   void _handleStateChanges(BuildContext context, RegisterState state) {
     const duration = Duration(milliseconds: 1000);
-    switch (state.status) {
-      case RegisterStatus.initial:
+    switch (state) {
+      case RegisterInitialState():
         break;
-      case RegisterStatus.loading:
+      case RegisterLoadingState():
         _showSnackBar(context, S.of(context).loading, duration);
-        break;
-      case RegisterStatus.success:
+      case RegisterCompletedState():
         _formKey.currentState?.reset();
         _showSnackBar(context, S.of(context).success, duration);
-        break;
-      case RegisterStatus.error:
+      case RegisterErrorState():
         _showSnackBar(context, S.of(context).failed, duration);
-        break;
     }
   }
 

--- a/test/features/auth/application/register_bloc_test.dart
+++ b/test/features/auth/application/register_bloc_test.dart
@@ -65,32 +65,25 @@ void main() {
   /// Register State Tests
   group("RegisterState", () {
     const user = UserEntity(firstName: "test", lastName: "test", email: "test@test.com");
-    const status = RegisterStatus.initial;
-
-    test("supports value comparisons", () {
-      expect(const RegisterState(data: user, status: status), const RegisterState(data: user, status: status));
-    });
 
     test("RegisterInitialState", () {
       expect(const RegisterInitialState(), const RegisterInitialState());
+      expect(const RegisterInitialState().props, const <Object?>[]);
     });
 
     test("RegisterLoadingState", () {
       expect(const RegisterLoadingState(), const RegisterLoadingState());
+      expect(const RegisterLoadingState().props, const <Object?>[]);
     });
 
     test("RegisterCompletedState", () {
       expect(const RegisterCompletedState(user: user), const RegisterCompletedState(user: user));
+      expect(const RegisterCompletedState(user: user).props, const <Object?>[user]);
     });
 
     test("RegisterErrorState", () {
       expect(const RegisterErrorState(message: "Register Error"), const RegisterErrorState(message: "Register Error"));
-    });
-
-    test("RegisterState copyWith", () {
-      expect(const RegisterState().copyWith(), const RegisterState());
-      expect(const RegisterState().copyWith(data: user), const RegisterState(data: user));
-      expect(const RegisterState().copyWith(status: status), const RegisterState(status: status));
+      expect(const RegisterErrorState(message: "Register Error").props, const <Object?>["Register Error"]);
     });
   });
   //endregion state

--- a/test/features/auth/presentation/pages/register_screen_go_router_test.dart
+++ b/test/features/auth/presentation/pages/register_screen_go_router_test.dart
@@ -51,10 +51,8 @@ void main() {
     );
 
     // Setup default bloc behaviors
-    when(
-      () => mockRegisterBloc.stream,
-    ).thenAnswer((_) => Stream.fromIterable([const RegisterState(status: RegisterStatus.initial)]));
-    when(() => mockRegisterBloc.state).thenReturn(const RegisterState(status: RegisterStatus.initial));
+    when(() => mockRegisterBloc.stream).thenAnswer((_) => Stream.fromIterable([const RegisterInitialState()]));
+    when(() => mockRegisterBloc.state).thenReturn(const RegisterInitialState());
     when(() => mockAccountBloc.stream).thenAnswer((_) => Stream.fromIterable([const AccountState()]));
     when(() => mockAccountBloc.state).thenReturn(const AccountState());
   });
@@ -153,7 +151,7 @@ void main() {
       // Setup bloc with broadcast stream to allow multiple listeners
       final controller = StreamController<RegisterState>.broadcast();
       when(() => mockRegisterBloc.stream).thenAnswer((_) => controller.stream);
-      when(() => mockRegisterBloc.state).thenReturn(const RegisterState(status: RegisterStatus.initial));
+      when(() => mockRegisterBloc.state).thenReturn(const RegisterInitialState());
 
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pumpAndSettle();
@@ -164,8 +162,8 @@ void main() {
       await tester.enterText(find.byKey(const Key('userEditorEmailFieldKey')), testUser.email!);
 
       // Change to loading state
-      when(() => mockRegisterBloc.state).thenReturn(const RegisterState(status: RegisterStatus.loading));
-      controller.add(const RegisterState(status: RegisterStatus.loading));
+      when(() => mockRegisterBloc.state).thenReturn(const RegisterLoadingState());
+      controller.add(const RegisterLoadingState());
 
       // Submit form
       await tester.tap(find.byKey(const Key('registerSubmitButtonKey')));
@@ -230,7 +228,7 @@ void main() {
       // Arrange
       final controller = StreamController<RegisterState>.broadcast();
       when(() => mockRegisterBloc.stream).thenAnswer((_) => controller.stream);
-      when(() => mockRegisterBloc.state).thenReturn(const RegisterState(status: RegisterStatus.initial));
+      when(() => mockRegisterBloc.state).thenReturn(const RegisterInitialState());
 
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pumpAndSettle();
@@ -241,8 +239,8 @@ void main() {
       await tester.enterText(find.byKey(const Key('userEditorEmailFieldKey')), testUser.email!);
 
       // Submit form and emit loading state
-      when(() => mockRegisterBloc.state).thenReturn(const RegisterState(status: RegisterStatus.loading));
-      controller.add(const RegisterState(status: RegisterStatus.loading));
+      when(() => mockRegisterBloc.state).thenReturn(const RegisterLoadingState());
+      controller.add(const RegisterLoadingState());
       await tester.tap(find.byKey(const Key('registerSubmitButtonKey')));
       await tester.pump();
 


### PR DESCRIPTION
## Description

Third migration step of the sealed-by-default transition (completing Phase 4a). Cleans up the mixed-pattern `RegisterState` to a pure Dart 3 sealed hierarchy.

### State

```diff
- enum RegisterStatus { initial, loading, success, error }
-
- class RegisterState extends Equatable {
-   final UserEntity? data;
-   final RegisterStatus status;
-   const RegisterState({this.data, ...});
-   RegisterState copyWith({...}) { ... }
- }
+ sealed class RegisterState extends Equatable {
+   const RegisterState();
+ }
```

- `class RegisterState` → `sealed class RegisterState`; variants prefixed with `final class`.
- `RegisterStatus` enum and the base `data` + `status` fields removed. Variant TYPE is now the status.
- `user` lives only on `RegisterCompletedState`, `message` only on `RegisterErrorState`.
- `copyWith` removed — sealed variants share no mutable shape.

### UI (`register_page.dart`)

This BLoC had a real UI consumer, so the refactor touches the screen:

- `state.status == RegisterStatus.loading` → `state is RegisterLoadingState`
- `state.data?.firstName/lastName/email` → pattern-match on `RegisterCompletedState` to extract `user`, then access fields
- `BlocListener.listenWhen` compares `runtimeType` instead of a removed status field (preserves "fire only on variant change" semantic)
- `_handleStateChanges` switch is now a pure sealed `switch (state) { RegisterLoadingState() => ..., ... }`, exhaustive by Dart 3's compiler

### Tests

- `register_bloc_test.dart`: removed base-class equality / `copyWith` tests that no longer apply; added explicit per-variant props assertions
- `register_screen_go_router_test.dart`: 8 sites of `const RegisterState(status: RegisterStatus.X)` rewritten to the matching variant constructor

Net test count: -2 (removed redundant base-class tests).

## Related Issue

Continued execution of #81 — completes Phase 4a (cleanup of the three mixed-state BLoCs to pure sealed).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes beyond the migration)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows project main rule (`CLAUDE.md` → State Modeling)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1386 tests passed**, 0 failures

## Additional Notes

Phase 4a is now complete (settings, authority, register). Phase 4b begins: single-state BLoCs migrate to sealed one-by-one — starting with `change_password` (smallest), then `account`, `lifecycle`, `forgot_password`, `dynamic_form`, `user` (likely combined with #75), and finally `login` (#70 fix). `SystemDashboardState` keeps single-state under the "transactional snapshot" exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)