### PR TITLE
refactor: ChangePasswordState — sealed hierarchy with Dart 3 switch

### DIFF
--- a/lib/features/auth/application/change_password_bloc.dart
+++ b/lib/features/auth/application/change_password_bloc.dart
@@ -16,31 +16,21 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
 
   ChangePasswordBloc({required ChangePasswordUseCase changePasswordUseCase})
     : _changePasswordUseCase = changePasswordUseCase,
-      super(const ChangePasswordState()) {
+      super(const ChangePasswordInitialState()) {
     on<ChangePasswordChanged>(_onSubmit);
   }
 
   FutureOr<void> _onSubmit(ChangePasswordChanged event, Emitter<ChangePasswordState> emit) async {
     _log.debug("BEGIN: changePassword bloc: _onSubmit");
-    emit(const ChangePasswordState(status: ChangePasswordStatus.loading));
+    emit(const ChangePasswordLoadingState());
 
     if (event.currentPassword.isEmpty || event.newPassword.isEmpty) {
-      emit(
-        const ChangePasswordState(
-          status: ChangePasswordStatus.failure,
-          errorMessage: 'Both current and new password are required',
-        ),
-      );
+      emit(const ChangePasswordFailureState(errorMessage: 'Both current and new password are required'));
       return;
     }
 
     if (event.currentPassword == event.newPassword) {
-      emit(
-        const ChangePasswordState(
-          status: ChangePasswordStatus.failure,
-          errorMessage: 'New password must be different from current password',
-        ),
-      );
+      emit(const ChangePasswordFailureState(errorMessage: 'New password must be different from current password'));
       return;
     }
 
@@ -49,10 +39,10 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
     final result = await _changePasswordUseCase(passwordChangeDTO);
     switch (result) {
       case Success():
-        emit(const ChangePasswordState(status: ChangePasswordStatus.success));
+        emit(const ChangePasswordSuccessState());
         _log.debug("END: changePassword bloc: _onSubmit success");
       case Failure(:final error):
-        emit(ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: error.message));
+        emit(ChangePasswordFailureState(errorMessage: error.message));
         _log.error("END: changePassword bloc: _onSubmit error: {}", [error.toString()]);
     }
   }

--- a/lib/features/auth/application/change_password_state.dart
+++ b/lib/features/auth/application/change_password_state.dart
@@ -1,20 +1,35 @@
 part of 'change_password_bloc.dart';
 
-enum ChangePasswordStatus { initial, loading, success, failure }
+sealed class ChangePasswordState extends Equatable {
+  const ChangePasswordState();
+}
 
-class ChangePasswordState extends Equatable {
-  final ChangePasswordStatus status;
-  final String? errorMessage;
-
-  const ChangePasswordState({this.status = ChangePasswordStatus.initial, this.errorMessage});
-
-  ChangePasswordState copyWith({ChangePasswordStatus? status, String? errorMessage}) {
-    return ChangePasswordState(status: status ?? this.status, errorMessage: errorMessage ?? this.errorMessage);
-  }
+final class ChangePasswordInitialState extends ChangePasswordState {
+  const ChangePasswordInitialState();
 
   @override
-  List<Object?> get props => [status, errorMessage];
+  List<Object?> get props => const [];
+}
+
+final class ChangePasswordLoadingState extends ChangePasswordState {
+  const ChangePasswordLoadingState();
 
   @override
-  bool get stringify => true;
+  List<Object?> get props => const [];
+}
+
+final class ChangePasswordSuccessState extends ChangePasswordState {
+  const ChangePasswordSuccessState();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+final class ChangePasswordFailureState extends ChangePasswordState {
+  const ChangePasswordFailureState({required this.errorMessage});
+
+  final String errorMessage;
+
+  @override
+  List<Object?> get props => [errorMessage];
 }

--- a/lib/features/auth/presentation/pages/change_password_page.dart
+++ b/lib/features/auth/presentation/pages/change_password_page.dart
@@ -29,7 +29,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<ChangePasswordBloc, ChangePasswordState>(
-      listenWhen: (previous, current) => previous.status != current.status,
+      listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       listener: (context, state) => _handleStateChanges(context, state),
       child: PopScope(
         canPop: !(_formKey.currentState?.isDirty ?? false),
@@ -41,7 +41,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
 
   Widget _buildBody(BuildContext context) {
     return BlocBuilder<ChangePasswordBloc, ChangePasswordState>(
-      buildWhen: (previous, current) => previous.status != current.status,
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       builder: (context, state) {
         return SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),
@@ -142,13 +142,14 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   }
 
   Widget _submitButton(BuildContext context, ChangePasswordState state) {
+    final isLoading = state is ChangePasswordLoadingState;
     return SizedBox(
       width: double.infinity,
       child: ResponsiveSubmitButton(
         key: changePasswordButtonSubmitKey,
         buttonText: S.of(context).save,
-        onPressed: state.status == ChangePasswordStatus.loading ? null : () => _onSubmit(context, state),
-        isLoading: state.status == ChangePasswordStatus.loading,
+        onPressed: isLoading ? null : () => _onSubmit(context, state),
+        isLoading: isLoading,
       ),
     );
   }
@@ -175,21 +176,18 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
 
   void _handleStateChanges(BuildContext context, ChangePasswordState state) {
     const duration = Duration(milliseconds: 1000);
-    switch (state.status) {
-      case ChangePasswordStatus.initial:
+    switch (state) {
+      case ChangePasswordInitialState():
         break;
-      case ChangePasswordStatus.loading:
+      case ChangePasswordLoadingState():
         _showSnackBar(context, S.of(context).loading, duration);
-        break;
-      case ChangePasswordStatus.success:
+      case ChangePasswordSuccessState():
         _formKey.currentState?.fields['currentPassword']?.reset();
         _formKey.currentState?.fields['newPassword']?.reset();
         _formKey.currentState?.reset();
         _showSnackBar(context, S.of(context).success, duration);
-        break;
-      case ChangePasswordStatus.failure:
+      case ChangePasswordFailureState():
         _showSnackBar(context, S.of(context).failed, duration);
-        break;
     }
   }
 

--- a/test/features/auth/application/change_password_bloc_test.dart
+++ b/test/features/auth/application/change_password_bloc_test.dart
@@ -34,26 +34,31 @@ void main() {
 
   //region state
   group("ChangePasswordState", () {
-    test("ChangePasswordState supports value comparisons", () {
-      expect(const ChangePasswordState(), const ChangePasswordState());
+    test("ChangePasswordInitialState equals", () {
+      expect(const ChangePasswordInitialState(), const ChangePasswordInitialState());
+      expect(const ChangePasswordInitialState().props, const <Object?>[]);
     });
 
-    test("ChangePasswordState with different status are not equal", () {
+    test("ChangePasswordLoadingState equals", () {
+      expect(const ChangePasswordLoadingState(), const ChangePasswordLoadingState());
+      expect(const ChangePasswordLoadingState().props, const <Object?>[]);
+    });
+
+    test("ChangePasswordSuccessState equals", () {
+      expect(const ChangePasswordSuccessState(), const ChangePasswordSuccessState());
+      expect(const ChangePasswordSuccessState().props, const <Object?>[]);
+    });
+
+    test("ChangePasswordFailureState equals", () {
       expect(
-        const ChangePasswordState(status: ChangePasswordStatus.loading),
-        isNot(const ChangePasswordState(status: ChangePasswordStatus.initial)),
+        const ChangePasswordFailureState(errorMessage: "boom"),
+        const ChangePasswordFailureState(errorMessage: "boom"),
       );
+      expect(const ChangePasswordFailureState(errorMessage: "boom").props, const <Object?>["boom"]);
     });
 
-    test("copyWith retains same values if no arguments provided", () {
-      expect(const ChangePasswordState().copyWith(), const ChangePasswordState());
-    });
-
-    test("copyWith replaces status", () {
-      expect(
-        const ChangePasswordState().copyWith(status: ChangePasswordStatus.loading),
-        const ChangePasswordState(status: ChangePasswordStatus.loading),
-      );
+    test("different variants are not equal", () {
+      expect(const ChangePasswordLoadingState(), isNot(const ChangePasswordInitialState()));
     });
   });
   //endregion state
@@ -78,10 +83,10 @@ void main() {
 
   //region bloc
   group("ChangePasswordBloc", () {
-    test("initial state is ChangePasswordState with initial status", () {
+    test("initial state is ChangePasswordInitialState", () {
       expect(
         ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)).state,
-        const ChangePasswordState(status: ChangePasswordStatus.initial),
+        const ChangePasswordInitialState(),
       );
     });
 
@@ -90,8 +95,8 @@ void main() {
       method() => repository.changePassword(input);
 
       final event = ChangePasswordChanged(currentPassword: input.currentPassword!, newPassword: input.newPassword!);
-      const loadingState = ChangePasswordState(status: ChangePasswordStatus.loading);
-      const successState = ChangePasswordState(status: ChangePasswordStatus.success);
+      const loadingState = ChangePasswordLoadingState();
+      const successState = ChangePasswordSuccessState();
 
       const statesSuccess = [loadingState, successState];
 
@@ -109,10 +114,7 @@ void main() {
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ServerError('Change password failed'))),
         build: () => ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)),
         act: (bloc) => bloc..add(event),
-        expect: () => [
-          loadingState,
-          const ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: 'Change password failed'),
-        ],
+        expect: () => [loadingState, const ChangePasswordFailureState(errorMessage: 'Change password failed')],
         verify: (_) => verify(method).called(1),
       );
 
@@ -121,10 +123,7 @@ void main() {
         setUp: () => when(method).thenAnswer((_) async => const Failure<void>(ValidationError('Invalid password'))),
         build: () => ChangePasswordBloc(changePasswordUseCase: ChangePasswordUseCase(repository)),
         act: (bloc) => bloc..add(event),
-        expect: () => [
-          loadingState,
-          const ChangePasswordState(status: ChangePasswordStatus.failure, errorMessage: 'Invalid password'),
-        ],
+        expect: () => [loadingState, const ChangePasswordFailureState(errorMessage: 'Invalid password')],
         verify: (_) => verify(method).called(1),
       );
     });

--- a/test/features/auth/presentation/pages/change_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/change_password_screen_test.dart
@@ -42,7 +42,7 @@ void main() {
     stateController = StreamController<ChangePasswordState>.broadcast();
 
     when(() => changePasswordBloc.stream).thenAnswer((_) => stateController.stream);
-    when(() => changePasswordBloc.state).thenReturn(const ChangePasswordState());
+    when(() => changePasswordBloc.state).thenReturn(const ChangePasswordInitialState());
 
     when(() => authorityBloc.stream).thenAnswer((_) => Stream.fromIterable([const AuthorityInitialState()]));
     when(() => authorityBloc.state).thenReturn(const AuthorityInitialState());
@@ -200,7 +200,7 @@ void main() {
       await tester.pumpWidget(getWidget());
       await tester.pumpAndSettle();
       // When: emit loading state via stream
-      stateController.add(const ChangePasswordState(status: ChangePasswordStatus.loading));
+      stateController.add(const ChangePasswordLoadingState());
       await tester.pump();
       await tester.pump();
       // Then
@@ -218,7 +218,7 @@ void main() {
       await tester.pump();
 
       // When: emit success state
-      stateController.add(const ChangePasswordState(status: ChangePasswordStatus.success));
+      stateController.add(const ChangePasswordSuccessState());
       await tester.pump();
       await tester.pump();
       // Then
@@ -230,7 +230,7 @@ void main() {
       await tester.pumpWidget(getWidget());
       await tester.pumpAndSettle();
       // When: emit failure state
-      stateController.add(const ChangePasswordState(status: ChangePasswordStatus.failure));
+      stateController.add(const ChangePasswordFailureState(errorMessage: 'Test error'));
       await tester.pump();
       await tester.pump();
       // Then


### PR DESCRIPTION
## Description

First **Phase 4b** migration step (single-state → sealed). Converts `ChangePasswordState` from single-state + status enum to a pure Dart 3 sealed hierarchy following the project main rule.

### State

```diff
- enum ChangePasswordStatus { initial, loading, success, failure }
-
- class ChangePasswordState extends Equatable {
-   final ChangePasswordStatus status;
-   final String? errorMessage;
-   ChangePasswordState copyWith({...}) { ... }
- }
+ sealed class ChangePasswordState extends Equatable {
+   const ChangePasswordState();
+ }
+ final class ChangePasswordInitialState extends ChangePasswordState { ... }
+ final class ChangePasswordLoadingState extends ChangePasswordState { ... }
+ final class ChangePasswordSuccessState extends ChangePasswordState { ... }
+ final class ChangePasswordFailureState extends ChangePasswordState {
+   const ChangePasswordFailureState({required this.errorMessage});
+   final String errorMessage;
+ }
```

- Variant TYPE is now the status. Only `ChangePasswordFailureState` carries `errorMessage`; the other three variants have no fields.
- `copyWith`, `status`, and the enum are gone.

### Bloc

Five `emit(...)` call-sites switched from `ChangePasswordState(status: X, ...)` to direct variant construction. Reads more cleanly.

### UI (`change_password_page.dart`)

- `state.status == ChangePasswordStatus.loading` → `state is ChangePasswordLoadingState`.
- `_handleStateChanges` switch is now a pure sealed `switch (state) { ChangePasswordLoadingState() => ..., ... }` — exhaustive by Dart 3's compiler.
- `BlocListener.listenWhen` / `BlocBuilder.buildWhen` compare `runtimeType` instead of the removed status field, preserving the "fire only on variant change" semantic.

### Tests

- `change_password_bloc_test.dart`: rewritten with per-variant props assertions; removed base-class equality + `copyWith` tests that no longer apply; added a "different variants are not equal" test.
- `change_password_screen_test.dart`: four mock state injections (`stateController.add(...)`) now construct specific variants.

## Related Issue

Continued execution of #81. First sealed migration of a previously single-state BLoC.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes beyond the migration)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows project main rule (`CLAUDE.md` → State Modeling)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1387 tests passed**, 0 failures

## Additional Notes

Next in Phase 4b: `account_state.dart` (same single-state → sealed conversion with UI consumer at `account_page.dart`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)