### PR TITLE
docs: mark AccountState as a documented single-state exception

### DIFF
--- a/lib/features/account/application/account_state.dart
+++ b/lib/features/account/application/account_state.dart
@@ -2,6 +2,21 @@ part of 'account_bloc.dart';
 
 enum AccountStatus { initial, loading, success, failure }
 
+/// Single-state + status enum is intentional here under the project's
+/// state-modeling rule (CLAUDE.md → State Modeling, exception #1:
+/// **concurrent state access**).
+///
+/// `AccountBloc` emits `state.copyWith(status: loading)` and
+/// `state.copyWith(status: failure)` to preserve the previously loaded
+/// `data` across transitions, and the account form (`account_page.dart`)
+/// reads `state.data?.firstName/lastName/email` regardless of the current
+/// status so the user keeps seeing their profile during a refresh or
+/// after a save failure. Splitting into sealed variants would either
+/// force `data` onto every variant (redundant) or blank the form during
+/// any non-success state (UX regression).
+///
+/// When this BLoC is touched in the future, prefer the existing shape
+/// unless the concurrent-access requirement is removed.
 class AccountState extends Equatable {
   const AccountState({this.data, this.status = AccountStatus.initial});
 


### PR DESCRIPTION
## Description

Adds a dartdoc comment above `AccountState` explaining that its legacy single-state + status enum shape is **intentional** under `CLAUDE.md → State Modeling` exception #1 (**concurrent state access**), so a future contributor doesn't reflexively migrate it to sealed during the broader Phase 4b work.

### Why this BLoC is genuinely an exception

- `AccountBloc` emits `state.copyWith(status: loading)` and `state.copyWith(status: failure)` — the previously loaded `UserEntity` is preserved across transitions.
- `account_page.dart` reads `state.data?.firstName / lastName / email` regardless of the current status so the user keeps seeing their profile during a refresh attempt or after a save failure.
- Splitting into sealed variants would either force `data` onto every variant (redundant duplication) or blank the form during any non-success state (UX regression).

This is exactly the case Felix Angelov flagged in [felangel/bloc#1726](https://github.com/felangel/bloc/issues/1726) as a justified use of single-state: *"still needed to have access to the previous user when an error occurred"*.

### Trade-off considered (and rejected)

A sealed migration that carries `UserEntity? data` on `AccountInitial/Loading/Success/Failure` was considered. It's mechanically possible but adds noise to every variant and forces the bloc to manually thread the previous data through every `emit(...)` — the precise overhead the rule's exception was written to avoid.

## Related Issue

Part of #81 (sealed-by-default migration) — this PR explicitly *excludes* AccountState from the migration and records the reason, instead of leaving silence to be misread later.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation update (architectural reasoning embedded in code)
- [ ] CI/CD or build configuration change

## Checklist

- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1387 tests passed**, 0 failures (no behavioural change)

## Additional Notes

Next migration target: `lifecycle_state.dart` (likely a clean sealed conversion — fields evolve in a simple state machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)