### PR TITLE
refactor: LifecycleState — sealed state machine

### DIFF
--- a/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
@@ -52,7 +52,12 @@ class _DashboardHomePageState extends State<DashboardHomePage> {
   }
 
   void _updateAppConfigFromLifecycle(LifecycleState? lifecycleState) {
-    final config = lifecycleState?.config;
+    final config = switch (lifecycleState) {
+      LifecycleReady(:final config) => config,
+      LifecycleMaintenance(:final config) => config,
+      LifecycleForceUpdate(:final config) => config,
+      _ => null,
+    };
 
     final environment = ProfileConstants.isProduction
         ? 'prod'
@@ -89,7 +94,7 @@ class _DashboardHomePageState extends State<DashboardHomePage> {
     try {
       context.read<LifecycleBloc>();
       child = BlocListener<LifecycleBloc, LifecycleState>(
-        listenWhen: (previous, current) => previous.config != current.config,
+        listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
         listener: (context, lifecycleState) {
           _updateAppConfigFromLifecycle(lifecycleState);
         },

--- a/lib/features/lifecycle/application/lifecycle_bloc.dart
+++ b/lib/features/lifecycle/application/lifecycle_bloc.dart
@@ -13,7 +13,7 @@ class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
   LifecycleBloc({required ILifecycleRepository repository, required FeatureFlagService featureFlagService})
     : _repository = repository,
       _featureFlagService = featureFlagService,
-      super(const LifecycleState()) {
+      super(const LifecycleInitial()) {
     on<LifecycleCheckEvent>(_onCheck);
     on<LifecycleDismissUpdateEvent>(_onDismissUpdate);
   }
@@ -25,7 +25,7 @@ class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
 
   FutureOr<void> _onCheck(LifecycleCheckEvent event, Emitter<LifecycleState> emit) async {
     _log.debug('Checking app lifecycle config');
-    emit(state.copyWith(status: LifecycleStatus.loading));
+    emit(const LifecycleLoading());
 
     final result = await _repository.fetchAppConfig();
 
@@ -39,29 +39,35 @@ class LifecycleBloc extends Bloc<LifecycleEvent, LifecycleState> {
         // Check maintenance mode first
         if (data.maintenanceMode) {
           _log.info('App is in maintenance mode');
-          emit(state.copyWith(status: LifecycleStatus.maintenance, config: data));
+          emit(LifecycleMaintenance(config: data));
           return;
         }
 
         // Check force update
         if (data.minimumVersion != null && _isVersionBelow(AppConstants.appVersion, data.minimumVersion!)) {
           _log.info('Force update required: current={}, minimum={}', [AppConstants.appVersion, data.minimumVersion]);
-          emit(state.copyWith(status: LifecycleStatus.forceUpdate, config: data));
+          emit(LifecycleForceUpdate(config: data));
           return;
         }
 
         // All clear
-        emit(state.copyWith(status: LifecycleStatus.ready, config: data));
+        emit(LifecycleReady(config: data));
 
       case Failure(:final error):
         _log.warn('Failed to fetch app config: {}', [error.message]);
         // On failure, allow the app to proceed (graceful degradation)
-        emit(state.copyWith(status: LifecycleStatus.ready, error: error.message));
+        emit(LifecycleReady(error: error.message));
     }
   }
 
   FutureOr<void> _onDismissUpdate(LifecycleDismissUpdateEvent event, Emitter<LifecycleState> emit) {
-    emit(state.copyWith(status: LifecycleStatus.ready));
+    final config = switch (state) {
+      LifecycleMaintenance(:final config) => config,
+      LifecycleForceUpdate(:final config) => config,
+      LifecycleReady(:final config) => config,
+      _ => null,
+    };
+    emit(LifecycleReady(config: config));
   }
 
   /// Compare semantic versions. Returns true if [current] < [minimum].

--- a/lib/features/lifecycle/application/lifecycle_state.dart
+++ b/lib/features/lifecycle/application/lifecycle_state.dart
@@ -1,19 +1,55 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc_advance/features/lifecycle/domain/entities/app_config_entity.dart';
 
-enum LifecycleStatus { initial, loading, ready, forceUpdate, maintenance, failure }
+sealed class LifecycleState extends Equatable {
+  const LifecycleState();
+}
 
-class LifecycleState extends Equatable {
-  const LifecycleState({this.status = LifecycleStatus.initial, this.config, this.error});
+final class LifecycleInitial extends LifecycleState {
+  const LifecycleInitial();
 
-  final LifecycleStatus status;
+  @override
+  List<Object?> get props => const [];
+}
+
+final class LifecycleLoading extends LifecycleState {
+  const LifecycleLoading();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// App is allowed to render normally.
+///
+/// [config] is present when the remote config fetch succeeded.
+/// [error] is present when the fetch failed but the app is degrading
+/// gracefully (we still proceed instead of blocking the user).
+final class LifecycleReady extends LifecycleState {
+  const LifecycleReady({this.config, this.error});
+
   final AppConfigEntity? config;
   final String? error;
 
-  LifecycleState copyWith({LifecycleStatus? status, AppConfigEntity? config, String? error}) {
-    return LifecycleState(status: status ?? this.status, config: config ?? this.config, error: error ?? this.error);
-  }
+  @override
+  List<Object?> get props => [config, error];
+}
+
+/// App is blocked behind a "maintenance mode" screen.
+final class LifecycleMaintenance extends LifecycleState {
+  const LifecycleMaintenance({required this.config});
+
+  final AppConfigEntity config;
 
   @override
-  List<Object?> get props => [status, config, error];
+  List<Object?> get props => [config];
+}
+
+/// App is blocked behind a "force update" screen.
+final class LifecycleForceUpdate extends LifecycleState {
+  const LifecycleForceUpdate({required this.config});
+
+  final AppConfigEntity config;
+
+  @override
+  List<Object?> get props => [config];
 }

--- a/lib/features/lifecycle/presentation/pages/lifecycle_gate.dart
+++ b/lib/features/lifecycle/presentation/pages/lifecycle_gate.dart
@@ -18,25 +18,17 @@ class LifecycleGate extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<LifecycleBloc, LifecycleState>(
-      builder: (context, state) {
-        switch (state.status) {
-          case LifecycleStatus.forceUpdate:
-            return ForceUpdateScreen(
-              storeUrl: state.config?.storeUrl,
-              currentVersion: AppConstants.appVersion,
-              minimumVersion: state.config?.minimumVersion,
-            );
-          case LifecycleStatus.maintenance:
-            return MaintenanceScreen(
-              message: state.config?.maintenanceMessage,
-              estimatedEnd: state.config?.maintenanceEstimatedEnd,
-            );
-          case LifecycleStatus.initial:
-          case LifecycleStatus.loading:
-          case LifecycleStatus.ready:
-          case LifecycleStatus.failure:
-            return child;
-        }
+      builder: (context, state) => switch (state) {
+        LifecycleForceUpdate(:final config) => ForceUpdateScreen(
+          storeUrl: config.storeUrl,
+          currentVersion: AppConstants.appVersion,
+          minimumVersion: config.minimumVersion,
+        ),
+        LifecycleMaintenance(:final config) => MaintenanceScreen(
+          message: config.maintenanceMessage,
+          estimatedEnd: config.maintenanceEstimatedEnd,
+        ),
+        LifecycleInitial() || LifecycleLoading() || LifecycleReady() => child,
       },
     );
   }

--- a/test/features/lifecycle/application/lifecycle_bloc_test.dart
+++ b/test/features/lifecycle/application/lifecycle_bloc_test.dart
@@ -30,12 +30,9 @@ void main() {
   });
 
   group('LifecycleBloc', () {
-    test('initial state should be LifecycleState with initial status', () {
+    test('initial state should be LifecycleInitial', () {
       final bloc = LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
-      expect(bloc.state, const LifecycleState());
-      expect(bloc.state.status, LifecycleStatus.initial);
-      expect(bloc.state.config, isNull);
-      expect(bloc.state.error, isNull);
+      expect(bloc.state, const LifecycleInitial());
       bloc.close();
     });
 
@@ -50,12 +47,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>()
-              .having((s) => s.status, 'status', LifecycleStatus.ready)
-              .having((s) => s.config, 'config', isNotNull),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleReady>().having((s) => s.config, 'config', isNotNull)],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -68,10 +60,12 @@ void main() {
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>()
-              .having((s) => s.status, 'status', LifecycleStatus.maintenance)
-              .having((s) => s.config!.maintenanceMessage, 'maintenanceMessage', 'Under maintenance'),
+          const LifecycleLoading(),
+          isA<LifecycleMaintenance>().having(
+            (s) => s.config.maintenanceMessage,
+            'maintenanceMessage',
+            'Under maintenance',
+          ),
         ],
       );
 
@@ -86,10 +80,8 @@ void main() {
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>()
-              .having((s) => s.status, 'status', LifecycleStatus.forceUpdate)
-              .having((s) => s.config!.minimumVersion, 'minimumVersion', '2.0.0'),
+          const LifecycleLoading(),
+          isA<LifecycleForceUpdate>().having((s) => s.config.minimumVersion, 'minimumVersion', '2.0.0'),
         ],
       );
 
@@ -103,10 +95,8 @@ void main() {
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
         expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>()
-              .having((s) => s.status, 'status', LifecycleStatus.ready)
-              .having((s) => s.error, 'error', 'No connection'),
+          const LifecycleLoading(),
+          isA<LifecycleReady>().having((s) => s.error, 'error', 'No connection'),
         ],
       );
 
@@ -125,10 +115,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.maintenance),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleMaintenance>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -140,10 +127,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.ready),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleReady>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -155,10 +139,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.ready),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleReady>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -170,10 +151,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.ready),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleReady>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -210,14 +188,11 @@ void main() {
 
     group('LifecycleDismissUpdateEvent', () {
       blocTest<LifecycleBloc, LifecycleState>(
-        'should emit ready status when update is dismissed',
+        'should emit ready (preserving config) when update is dismissed from force-update',
         build: () => LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance),
-        seed: () => const LifecycleState(
-          status: LifecycleStatus.forceUpdate,
-          config: AppConfigEntity(minimumVersion: '2.0.0'),
-        ),
+        seed: () => const LifecycleForceUpdate(config: AppConfigEntity(minimumVersion: '2.0.0')),
         act: (bloc) => bloc.add(const LifecycleDismissUpdateEvent()),
-        expect: () => [isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.ready)],
+        expect: () => [isA<LifecycleReady>().having((s) => s.config?.minimumVersion, 'config.minimumVersion', '2.0.0')],
       );
     });
 
@@ -232,10 +207,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.forceUpdate),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleForceUpdate>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -248,10 +220,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.forceUpdate),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleForceUpdate>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -264,10 +233,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.forceUpdate),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleForceUpdate>()],
       );
 
       blocTest<LifecycleBloc, LifecycleState>(
@@ -280,10 +246,7 @@ void main() {
           return LifecycleBloc(repository: mockRepository, featureFlagService: FeatureFlagService.instance);
         },
         act: (bloc) => bloc.add(const LifecycleCheckEvent()),
-        expect: () => [
-          const LifecycleState(status: LifecycleStatus.loading),
-          isA<LifecycleState>().having((s) => s.status, 'status', LifecycleStatus.ready),
-        ],
+        expect: () => [const LifecycleLoading(), isA<LifecycleReady>()],
       );
     });
   });


### PR DESCRIPTION
## Description

Converts the lifecycle feature from single-state + status enum to a pure Dart 3 sealed hierarchy. Each variant maps 1:1 to a discrete phase of the app's startup gate — every state is mutually exclusive, payloads differ per variant, and the UI uses `switch (state)` exhaustively. Textbook sealed case.

### State

```diff
- enum LifecycleStatus { initial, loading, ready, forceUpdate, maintenance, failure }
-
- class LifecycleState extends Equatable {
-   final LifecycleStatus status;
-   final AppConfigEntity? config;
-   final String? error;
-   LifecycleState copyWith({...}) { ... }
- }
+ sealed class LifecycleState extends Equatable {}
+ final class LifecycleInitial extends LifecycleState { ... }
+ final class LifecycleLoading extends LifecycleState { ... }
+ final class LifecycleReady extends LifecycleState {
+   const LifecycleReady({this.config, this.error});
+   final AppConfigEntity? config;
+   final String? error;
+ }
+ final class LifecycleMaintenance extends LifecycleState {
+   const LifecycleMaintenance({required this.config});
+   final AppConfigEntity config;
+ }
+ final class LifecycleForceUpdate extends LifecycleState {
+   const LifecycleForceUpdate({required this.config});
+   final AppConfigEntity config;
+ }
```

- `LifecycleReady` keeps optional `config` and `error` (graceful degradation path where the fetch failed but the app proceeds).
- `LifecycleMaintenance` / `LifecycleForceUpdate` take `config` as **required** — the screens that render them always need it.
- The `failure` enum value was unreachable (the bloc emits `ready` with an error on `Failure`), so the sealed hierarchy drops it.

### Bloc

- `super(const LifecycleInitial())`.
- Every `state.copyWith(status: X, ...)` rewritten to direct variant construction.
- `_onDismissUpdate` now pattern-matches the previous state to lift `config` forward when transitioning back to `LifecycleReady`:

```dart
final config = switch (state) {
  LifecycleMaintenance(:final config) => config,
  LifecycleForceUpdate(:final config) => config,
  LifecycleReady(:final config) => config,
  _ => null,
};
emit(LifecycleReady(config: config));
```

### UI

- `lifecycle_gate.dart`: `switch (state.status)` → Dart 3 `switch (state)` expression form with destructuring `(:final config)`.
- `dashboard_home_page.dart`: `lifecycleState?.config` access rewritten as a pattern-match switch. `BlocListener.listenWhen` compares `runtimeType` instead of the removed `config` getter.

### Tests

`isA<LifecycleState>().having((s) => s.status, ...)` chains replaced with `isA<LifecycleReady>()` / `isA<LifecycleMaintenance>()` / etc., reading fields directly off the variant. `seed:` for the dismiss-update test now uses `LifecycleForceUpdate` directly. Tests cover the config-lifting behaviour in dismiss explicitly.

## Related Issue

Continued execution of #81 — sealed-by-default migration, this BLoC is one of the cleanest fits.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes beyond the migration)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows project main rule (`CLAUDE.md` → State Modeling)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1387 tests passed**, 0 failures

## Additional Notes

Next migration target: `forgot_password_state.dart`. Then `dynamic_form`, `user` (with #75 god-bloc split), and `login` (#70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)