### PR TITLE
refactor: ForgotPasswordState — pure Dart 3 sealed hierarchy

### DIFF
--- a/lib/features/auth/application/forgot_password_bloc.dart
+++ b/lib/features/auth/application/forgot_password_bloc.dart
@@ -15,23 +15,21 @@ class ForgotPasswordBloc extends Bloc<ForgotPasswordEvent, ForgotPasswordState> 
 
   ForgotPasswordBloc({required ResetPasswordUseCase resetPasswordUseCase})
     : _resetPasswordUseCase = resetPasswordUseCase,
-      super(const ForgotPasswordState(status: ForgotPasswordStatus.initial)) {
+      super(const ForgotPasswordInitialState()) {
     on<ForgotPasswordEmailChanged>(_onSubmit);
   }
 
   FutureOr<void> _onSubmit(ForgotPasswordEmailChanged event, Emitter<ForgotPasswordState> emit) async {
     _log.debug("BEGIN: forgotPassword bloc: _onSubmit");
-    emit(const ForgotPasswordState(status: ForgotPasswordStatus.loading));
+    emit(const ForgotPasswordLoadingState());
 
     final result = await _resetPasswordUseCase(event.email);
     switch (result) {
       case Success():
-        emit(ForgotPasswordState(status: ForgotPasswordStatus.success, email: event.email));
+        emit(ForgotPasswordCompletedState(email: event.email));
         _log.debug("END: forgotPassword bloc: _onSubmit success");
       case Failure(:final error):
-        emit(
-          ForgotPasswordState(status: ForgotPasswordStatus.failure, email: event.email, errorMessage: error.message),
-        );
+        emit(ForgotPasswordErrorState(email: event.email, errorMessage: error.message));
         _log.error("END: forgotPassword bloc: _onSubmit error: {}", [error.toString()]);
     }
   }

--- a/lib/features/auth/application/forgot_password_state.dart
+++ b/lib/features/auth/application/forgot_password_state.dart
@@ -1,46 +1,38 @@
 part of 'forgot_password_bloc.dart';
 
-enum ForgotPasswordStatus { initial, loading, success, failure }
+sealed class ForgotPasswordState extends Equatable {
+  const ForgotPasswordState();
+}
 
-class ForgotPasswordState extends Equatable {
-  final String? email;
-  final ForgotPasswordStatus status;
-  final String? errorMessage;
-
-  const ForgotPasswordState({this.email, this.status = ForgotPasswordStatus.initial, this.errorMessage});
-
-  ForgotPasswordState copyWith({String? email, ForgotPasswordStatus? status, String? errorMessage}) {
-    return ForgotPasswordState(
-      email: email ?? this.email,
-      status: status ?? this.status,
-      errorMessage: errorMessage ?? this.errorMessage,
-    );
-  }
+final class ForgotPasswordInitialState extends ForgotPasswordState {
+  const ForgotPasswordInitialState();
 
   @override
-  List<Object?> get props => [status, email, errorMessage];
+  List<Object?> get props => const [];
+}
+
+final class ForgotPasswordLoadingState extends ForgotPasswordState {
+  const ForgotPasswordLoadingState();
 
   @override
-  bool get stringify => true;
+  List<Object?> get props => const [];
 }
 
-class ForgotPasswordInitialState extends ForgotPasswordState {
-  const ForgotPasswordInitialState() : super(status: ForgotPasswordStatus.initial);
-}
+final class ForgotPasswordCompletedState extends ForgotPasswordState {
+  const ForgotPasswordCompletedState({required this.email});
 
-class ForgotPasswordLoadingState extends ForgotPasswordState {
-  const ForgotPasswordLoadingState() : super(status: ForgotPasswordStatus.loading);
-}
-
-class ForgotPasswordCompletedState extends ForgotPasswordState {
-  const ForgotPasswordCompletedState() : super(status: ForgotPasswordStatus.success);
-}
-
-class ForgotPasswordErrorState extends ForgotPasswordState {
-  final String message;
-
-  const ForgotPasswordErrorState({required this.message}) : super(status: ForgotPasswordStatus.failure);
+  final String email;
 
   @override
-  List<Object?> get props => [status, message];
+  List<Object?> get props => [email];
+}
+
+final class ForgotPasswordErrorState extends ForgotPasswordState {
+  const ForgotPasswordErrorState({required this.email, required this.errorMessage});
+
+  final String email;
+  final String errorMessage;
+
+  @override
+  List<Object?> get props => [email, errorMessage];
 }

--- a/lib/features/auth/presentation/pages/forgot_password_page.dart
+++ b/lib/features/auth/presentation/pages/forgot_password_page.dart
@@ -22,7 +22,7 @@ class ForgotPasswordScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocListener<ForgotPasswordBloc, ForgotPasswordState>(
-      listenWhen: (previous, current) => previous.status != current.status,
+      listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       listener: (context, state) => _handleStateChanges(context, state),
       child: PopScope(
         canPop: !(_formKey.currentState?.isDirty ?? false),
@@ -42,7 +42,7 @@ class ForgotPasswordScreen extends StatelessWidget {
 
   Widget _buildBody(BuildContext context) {
     return BlocBuilder<ForgotPasswordBloc, ForgotPasswordState>(
-      buildWhen: (previous, current) => previous.status != current.status,
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       builder: (context, state) {
         return ResponsiveFormBuilder(
           formKey: _formKey,
@@ -108,8 +108,8 @@ class ForgotPasswordScreen extends StatelessWidget {
       child: ResponsiveSubmitButton(
         key: forgotPasswordButtonSubmitKey,
         buttonText: S.of(context).email_send,
-        onPressed: () => state.status == ForgotPasswordStatus.loading ? null : _onSubmit(context, state),
-        isLoading: state.status == ForgotPasswordStatus.loading,
+        onPressed: () => state is ForgotPasswordLoadingState ? null : _onSubmit(context, state),
+        isLoading: state is ForgotPasswordLoadingState,
       ),
     );
   }
@@ -134,19 +134,16 @@ class ForgotPasswordScreen extends StatelessWidget {
 
   void _handleStateChanges(BuildContext context, ForgotPasswordState state) {
     const duration = Duration(milliseconds: 1000);
-    switch (state.status) {
-      case ForgotPasswordStatus.initial:
+    switch (state) {
+      case ForgotPasswordInitialState():
         break;
-      case ForgotPasswordStatus.loading:
+      case ForgotPasswordLoadingState():
         _showSnackBar(context, S.of(context).loading, duration);
-        break;
-      case ForgotPasswordStatus.success:
+      case ForgotPasswordCompletedState():
         _formKey.currentState?.reset();
         _showSnackBar(context, S.of(context).success, duration);
-        break;
-      case ForgotPasswordStatus.failure:
+      case ForgotPasswordErrorState():
         _showSnackBar(context, S.of(context).failed, duration);
-        break;
     }
   }
 

--- a/test/features/auth/application/forgot_password_bloc_test.dart
+++ b/test/features/auth/application/forgot_password_bloc_test.dart
@@ -63,56 +63,39 @@ void main() {
   //region state
   /// ForgotPassword State Tests
   group('ForgotPassword State Tests', () {
-    //ForgotPasswordState
-    test("supports value comparisons", () {
-      expect(const ForgotPasswordState(), const ForgotPasswordState());
-      const state = ForgotPasswordState(status: ForgotPasswordStatus.initial);
-      expect(const ForgotPasswordState(), state);
-    });
-
-    //ForgotPasswordState Initial Test
-    test('initial state is ForgotPasswordState', () {
-      expect(
-        ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)).state,
-        const ForgotPasswordState(status: ForgotPasswordStatus.initial),
-      );
-    });
-
-    //ForgotPasswordInitialState Test
     test("ForgotPasswordInitialState", () {
       expect(const ForgotPasswordInitialState(), const ForgotPasswordInitialState());
+      expect(const ForgotPasswordInitialState().props, const <Object?>[]);
     });
 
-    //ForgotPasswordCompletedState Test
+    test("ForgotPasswordLoadingState", () {
+      expect(const ForgotPasswordLoadingState(), const ForgotPasswordLoadingState());
+      expect(const ForgotPasswordLoadingState().props, const <Object?>[]);
+    });
+
     test("ForgotPasswordCompletedState", () {
-      expect(const ForgotPasswordCompletedState(), const ForgotPasswordCompletedState());
+      expect(
+        const ForgotPasswordCompletedState(email: 'test@example.com'),
+        const ForgotPasswordCompletedState(email: 'test@example.com'),
+      );
+      expect(const ForgotPasswordCompletedState(email: 'test@example.com').props, const <Object?>['test@example.com']);
     });
 
-    // ForgotPasswordErrorState Test
     test("ForgotPasswordErrorState", () {
       expect(
-        const ForgotPasswordErrorState(message: "Reset Password Error"),
-        const ForgotPasswordErrorState(message: "Reset Password Error"),
+        const ForgotPasswordErrorState(email: 'test@example.com', errorMessage: 'boom'),
+        const ForgotPasswordErrorState(email: 'test@example.com', errorMessage: 'boom'),
       );
-    });
-
-    test("copyWith retains the same values if no arguments are provided", () {
-      const state = ForgotPasswordState(status: ForgotPasswordStatus.failure, email: "test@example.com");
-      expect(state.copyWith(), state);
-    });
-
-    test("props", () {
-      expect(const ForgotPasswordState(status: ForgotPasswordStatus.initial, email: 'test@example.com').props, [
-        ForgotPasswordStatus.initial,
-        "test@example.com",
-        null,
+      expect(const ForgotPasswordErrorState(email: 'test@example.com', errorMessage: 'boom').props, const <Object?>[
+        'test@example.com',
+        'boom',
       ]);
     });
 
-    test("initial state is ForgotPasswordState", () {
+    test("initial bloc state is ForgotPasswordInitialState", () {
       expect(
         ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)).state,
-        const ForgotPasswordState(status: ForgotPasswordStatus.initial),
+        const ForgotPasswordInitialState(),
       );
     });
   });
@@ -122,43 +105,36 @@ void main() {
   group("ForgotPassword Bloc Test", () {
     const email = "test@test.com";
     blocTest<ForgotPasswordBloc, ForgotPasswordState>(
-      'emits [ForgotPasswordLoadingState, ForgotPasswordCompletedState] when resetPassword is successful',
+      'emits [Loading, Completed] when resetPassword is successful',
       setUp: () => when(() => repository.resetPassword(email)).thenAnswer((_) async => const Success<void>(null)),
       build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: email)),
-      expect: () => [
-        const ForgotPasswordState(status: ForgotPasswordStatus.loading),
-        const ForgotPasswordState(status: ForgotPasswordStatus.success, email: email),
-      ],
+      expect: () => [const ForgotPasswordLoadingState(), const ForgotPasswordCompletedState(email: email)],
     );
 
     blocTest<ForgotPasswordBloc, ForgotPasswordState>(
-      'emits [ForgotPasswordLoadingState, ForgotPasswordErrorState] when resetPassword returns Failure',
+      'emits [Loading, Error] when resetPassword returns Failure',
       setUp: () => when(
         () => repository.resetPassword(email),
       ).thenAnswer((_) async => const Failure<void>(ServerError('Reset failed'))),
       build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: email)),
       expect: () => [
-        const ForgotPasswordState(status: ForgotPasswordStatus.loading),
-        const ForgotPasswordState(status: ForgotPasswordStatus.failure, email: email, errorMessage: 'Reset failed'),
+        const ForgotPasswordLoadingState(),
+        const ForgotPasswordErrorState(email: email, errorMessage: 'Reset failed'),
       ],
     );
 
     blocTest<ForgotPasswordBloc, ForgotPasswordState>(
-      'emits [ForgotPasswordLoadingState, ForgotPasswordErrorState] when resetPassword returns ValidationError',
+      'emits [Loading, Error] when resetPassword returns ValidationError',
       setUp: () => when(
         () => repository.resetPassword('invalid-email'),
       ).thenAnswer((_) async => const Failure<void>(ValidationError('Invalid email'))),
       build: () => ForgotPasswordBloc(resetPasswordUseCase: ResetPasswordUseCase(repository)),
       act: (bloc) => bloc..add(const ForgotPasswordEmailChanged(email: 'invalid-email')),
       expect: () => [
-        const ForgotPasswordState(status: ForgotPasswordStatus.loading),
-        const ForgotPasswordState(
-          status: ForgotPasswordStatus.failure,
-          email: 'invalid-email',
-          errorMessage: 'Invalid email',
-        ),
+        const ForgotPasswordLoadingState(),
+        const ForgotPasswordErrorState(email: 'invalid-email', errorMessage: 'Invalid email'),
       ],
     );
   });

--- a/test/features/auth/presentation/pages/forgot_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/forgot_password_screen_test.dart
@@ -31,10 +31,8 @@ void main() {
     forgotPasswordBloc = MockForgotPasswordBloc();
     accountBloc = MockAccountBloc();
 
-    when(
-      () => forgotPasswordBloc.stream,
-    ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordState(status: ForgotPasswordStatus.initial)]));
-    when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordState(status: ForgotPasswordStatus.initial));
+    when(() => forgotPasswordBloc.stream).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordInitialState()]));
+    when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordInitialState());
 
     when(() => accountBloc.stream).thenAnswer((_) => Stream.fromIterable([const AccountState()]));
     when(() => accountBloc.state).thenReturn(const AccountState());
@@ -124,8 +122,8 @@ void main() {
       // Given
       when(
         () => forgotPasswordBloc.stream,
-      ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordState(status: ForgotPasswordStatus.loading)]));
-      when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordState(status: ForgotPasswordStatus.loading));
+      ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordLoadingState()]));
+      when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordLoadingState());
       await tester.pumpWidget(getWidget());
 
       //When:
@@ -141,8 +139,8 @@ void main() {
       // Given
       when(
         () => forgotPasswordBloc.stream,
-      ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordState(status: ForgotPasswordStatus.success)]));
-      when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordState(status: ForgotPasswordStatus.success));
+      ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordCompletedState(email: 'test@example.com')]));
+      when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordCompletedState(email: 'test@example.com'));
       await tester.pumpWidget(getWidget());
 
       //When:
@@ -157,10 +155,12 @@ void main() {
     // ForgotPasswordFailureState
     testWidgets("Validate failure state", (WidgetTester tester) async {
       // Given
+      when(() => forgotPasswordBloc.stream).thenAnswer(
+        (_) => Stream.fromIterable([const ForgotPasswordErrorState(email: 'test@example.com', errorMessage: 'Failed')]),
+      );
       when(
-        () => forgotPasswordBloc.stream,
-      ).thenAnswer((_) => Stream.fromIterable([const ForgotPasswordErrorState(message: "Failed")]));
-      when(() => forgotPasswordBloc.state).thenReturn(const ForgotPasswordErrorState(message: "Failed"));
+        () => forgotPasswordBloc.state,
+      ).thenReturn(const ForgotPasswordErrorState(email: 'test@example.com', errorMessage: 'Failed'));
       await tester.pumpWidget(getWidget());
 
       //When:


### PR DESCRIPTION
## Description

Cleans up the mixed-pattern `ForgotPasswordState` (single base with `copyWith` + subclasses) into a pure Dart 3 sealed hierarchy per the project state-modeling rule.

### State

```diff
- class ForgotPasswordState extends Equatable {
-   final String? email;
-   final ForgotPasswordStatus status;
-   final String? errorMessage;
-   ForgotPasswordState copyWith({...}) { ... }
- }
- enum ForgotPasswordStatus { initial, loading, success, failure }
+ sealed class ForgotPasswordState extends Equatable { ... }
+ final class ForgotPasswordInitialState extends ForgotPasswordState { ... }
+ final class ForgotPasswordLoadingState extends ForgotPasswordState { ... }
+ final class ForgotPasswordCompletedState extends ForgotPasswordState {
+   const ForgotPasswordCompletedState({required this.email});
+   final String email;
+ }
+ final class ForgotPasswordErrorState extends ForgotPasswordState {
+   const ForgotPasswordErrorState({required this.email, required this.errorMessage});
+   final String email;
+   final String errorMessage;
+ }
```

- Initial / Loading carry no payload.
- Completed carries the submitted `email` so the UI can confirm "we sent a reset link to <email>".
- Error carries both the submitted `email` and the use-case `errorMessage` so the UI can show "reset failed for <email>".

### Bloc

- `super(const ForgotPasswordInitialState())`.
- Every `emit(...)` constructs the relevant variant directly.

### UI (`forgot_password_page.dart`)

- `state.status == ForgotPasswordStatus.loading` → `state is ForgotPasswordLoadingState`.
- `_handleStateChanges` switch is now exhaustive Dart 3 sealed `switch (state)` with empty arms for variants that don't trigger a snack bar.
- `BlocListener.listenWhen` / `BlocBuilder.buildWhen` compare `runtimeType` instead of the removed `status` getter.

### Tests

- `forgot_password_bloc_test.dart`: rewritten — base-class `copyWith` / `props` tests dropped; per-variant equality + props tests added; bloc tests now construct specific variants in `expect:` lists.
- `forgot_password_screen_test.dart`: four mock state injections (`stateController.add(...)` / `when(...state).thenReturn(...)`) use concrete variants with the new required fields.

## Related Issue

Continued execution of #81 — sealed-by-default migration.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows project main rule (`CLAUDE.md` → State Modeling)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1384 tests passed**, 0 failures

## Additional Notes

Next: `dynamic_form_state.dart`. Then `user` (combined with #75) and `login` (#70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)