### PR TITLE
refactor: DynamicFormState — sealed hierarchy with explicit schema lifting

### DIFF
--- a/lib/features/dynamic_forms/application/dynamic_form_bloc.dart
+++ b/lib/features/dynamic_forms/application/dynamic_form_bloc.dart
@@ -9,7 +9,7 @@ import 'package:flutter_bloc_advance/features/dynamic_forms/data/models/form_sch
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 
 class DynamicFormBloc extends Bloc<DynamicFormEvent, DynamicFormState> {
-  DynamicFormBloc() : super(const DynamicFormState()) {
+  DynamicFormBloc() : super(const DynamicFormInitial()) {
     on<DynamicFormLoadEvent>(_onLoad);
     on<DynamicFormSubmitEvent>(_onSubmit);
     on<DynamicFormResetEvent>(_onReset);
@@ -19,30 +19,35 @@ class DynamicFormBloc extends Bloc<DynamicFormEvent, DynamicFormState> {
 
   FutureOr<void> _onLoad(DynamicFormLoadEvent event, Emitter<DynamicFormState> emit) async {
     _log.debug('Loading form schema: {}', [event.formId]);
-    emit(state.copyWith(status: DynamicFormStatus.loading));
+    emit(const DynamicFormLoading());
     try {
       final response = await ApiClient.get('/dynamic_forms', pathParams: event.formId);
       final schema = FormSchemaModel.fromJsonString(response.data!);
-      emit(state.copyWith(status: DynamicFormStatus.loaded, schema: schema));
+      emit(DynamicFormLoaded(schema: schema));
     } on AppException catch (e) {
-      emit(state.copyWith(status: DynamicFormStatus.failure, error: e.toString()));
+      emit(DynamicFormFailure(error: e.toString()));
     } catch (e) {
-      emit(state.copyWith(status: DynamicFormStatus.failure, error: e.toString()));
+      emit(DynamicFormFailure(error: e.toString()));
     }
   }
 
   FutureOr<void> _onSubmit(DynamicFormSubmitEvent event, Emitter<DynamicFormState> emit) async {
-    final schema = state.schema;
+    final schema = switch (state) {
+      DynamicFormLoaded(:final schema) => schema,
+      DynamicFormSubmitted(:final schema) => schema,
+      DynamicFormFailure(:final schema?) => schema,
+      _ => null,
+    };
     if (schema == null) return;
 
     _log.debug('Submitting form: {}', [schema.id]);
-    emit(state.copyWith(status: DynamicFormStatus.submitting));
+    emit(DynamicFormSubmitting(schema: schema));
 
     try {
       final action = schema.submitAction;
       if (action == null) {
         _log.info('No submit action defined — logging form data: {}', [event.data]);
-        emit(state.copyWith(status: DynamicFormStatus.submitted, submitResponse: 'Form data logged'));
+        emit(DynamicFormSubmitted(schema: schema, submitResponse: 'Form data logged'));
         return;
       }
 
@@ -54,15 +59,15 @@ class DynamicFormBloc extends Bloc<DynamicFormEvent, DynamicFormState> {
         final method => throw UnsupportedError('Unsupported HTTP method: $method'),
       };
 
-      emit(state.copyWith(status: DynamicFormStatus.submitted, submitResponse: response.data));
+      emit(DynamicFormSubmitted(schema: schema, submitResponse: response.data));
     } on AppException catch (e) {
-      emit(state.copyWith(status: DynamicFormStatus.failure, error: e.toString()));
+      emit(DynamicFormFailure(error: e.toString(), schema: schema));
     } catch (e) {
-      emit(state.copyWith(status: DynamicFormStatus.failure, error: e.toString()));
+      emit(DynamicFormFailure(error: e.toString(), schema: schema));
     }
   }
 
   FutureOr<void> _onReset(DynamicFormResetEvent event, Emitter<DynamicFormState> emit) {
-    emit(const DynamicFormState());
+    emit(const DynamicFormInitial());
   }
 }

--- a/lib/features/dynamic_forms/application/dynamic_form_state.dart
+++ b/lib/features/dynamic_forms/application/dynamic_form_state.dart
@@ -1,30 +1,67 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc_advance/features/dynamic_forms/domain/entities/form_schema_entity.dart';
 
-enum DynamicFormStatus { initial, loading, loaded, submitting, submitted, failure }
+/// Sealed state for the dynamic-form flow.
+///
+/// Variants enforce at compile time which fields are available where:
+/// - schema is required from [DynamicFormLoaded] onward (the bloc cannot
+///   submit before a schema is loaded);
+/// - submitResponse only exists once a submit has completed;
+/// - error is only carried on failure variants.
+sealed class DynamicFormState extends Equatable {
+  const DynamicFormState();
+}
 
-class DynamicFormState extends Equatable {
-  const DynamicFormState({this.status = DynamicFormStatus.initial, this.schema, this.submitResponse, this.error});
-
-  final DynamicFormStatus status;
-  final FormSchemaEntity? schema;
-  final String? submitResponse;
-  final String? error;
-
-  DynamicFormState copyWith({
-    DynamicFormStatus? status,
-    FormSchemaEntity? schema,
-    String? submitResponse,
-    String? error,
-  }) {
-    return DynamicFormState(
-      status: status ?? this.status,
-      schema: schema ?? this.schema,
-      submitResponse: submitResponse ?? this.submitResponse,
-      error: error ?? this.error,
-    );
-  }
+final class DynamicFormInitial extends DynamicFormState {
+  const DynamicFormInitial();
 
   @override
-  List<Object?> get props => [status, schema, submitResponse, error];
+  List<Object?> get props => const [];
+}
+
+final class DynamicFormLoading extends DynamicFormState {
+  const DynamicFormLoading();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+final class DynamicFormLoaded extends DynamicFormState {
+  const DynamicFormLoaded({required this.schema});
+
+  final FormSchemaEntity schema;
+
+  @override
+  List<Object?> get props => [schema];
+}
+
+final class DynamicFormSubmitting extends DynamicFormState {
+  const DynamicFormSubmitting({required this.schema});
+
+  final FormSchemaEntity schema;
+
+  @override
+  List<Object?> get props => [schema];
+}
+
+final class DynamicFormSubmitted extends DynamicFormState {
+  const DynamicFormSubmitted({required this.schema, this.submitResponse});
+
+  final FormSchemaEntity schema;
+  final String? submitResponse;
+
+  @override
+  List<Object?> get props => [schema, submitResponse];
+}
+
+/// Failure can happen either at load time (no schema) or at submit time
+/// (schema present from the prior [DynamicFormLoaded] state).
+final class DynamicFormFailure extends DynamicFormState {
+  const DynamicFormFailure({required this.error, this.schema});
+
+  final String error;
+  final FormSchemaEntity? schema;
+
+  @override
+  List<Object?> get props => [error, schema];
 }

--- a/lib/features/dynamic_forms/presentation/pages/dynamic_form_page.dart
+++ b/lib/features/dynamic_forms/presentation/pages/dynamic_form_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/features/dynamic_forms/application/dynamic_form_bloc.dart';
 import 'package:flutter_bloc_advance/features/dynamic_forms/application/dynamic_form_event.dart';
 import 'package:flutter_bloc_advance/features/dynamic_forms/application/dynamic_form_state.dart';
+import 'package:flutter_bloc_advance/features/dynamic_forms/domain/entities/form_schema_entity.dart';
 import 'package:flutter_bloc_advance/features/dynamic_forms/presentation/widgets/dynamic_form_renderer.dart';
 import 'package:flutter_bloc_advance/shared/design_system/components/app_error_state.dart';
 import 'package:flutter_bloc_advance/shared/design_system/tokens/app_spacing.dart';
@@ -31,47 +32,44 @@ class _DynamicFormPageState extends State<DynamicFormPage> {
   Widget build(BuildContext context) {
     return BlocConsumer<DynamicFormBloc, DynamicFormState>(
       listener: (context, state) {
-        if (state.status == DynamicFormStatus.submitted) {
+        if (state is DynamicFormSubmitted) {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(const SnackBar(content: Text('Form submitted successfully'), duration: Duration(seconds: 2)));
         }
       },
-      builder: (context, state) {
-        if (state.status == DynamicFormStatus.loading) {
-          return const Center(child: CircularProgressIndicator());
-        }
-
-        if (state.status == DynamicFormStatus.failure) {
-          return AppErrorState(
-            title: 'Error',
-            description: state.error ?? 'Failed to load form',
-            onRetry: () => context.read<DynamicFormBloc>().add(DynamicFormLoadEvent(widget.formId)),
-          );
-        }
-
-        final schema = state.schema;
-        if (schema == null) {
-          return const Center(child: Text('No form schema available.'));
-        }
-
-        return SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.lg),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(schema.title, style: Theme.of(context).textTheme.headlineSmall),
-              const SizedBox(height: AppSpacing.xl),
-              DynamicFormRenderer(
-                schema: schema,
-                formKey: _formKey,
-                readOnly: state.status == DynamicFormStatus.submitting,
-                onSubmit: (data) => context.read<DynamicFormBloc>().add(DynamicFormSubmitEvent(data)),
-              ),
-            ],
-          ),
-        );
+      builder: (context, state) => switch (state) {
+        DynamicFormInitial() || DynamicFormLoading() => const Center(child: CircularProgressIndicator()),
+        DynamicFormFailure(:final error) => AppErrorState(
+          title: 'Error',
+          description: error,
+          onRetry: () => context.read<DynamicFormBloc>().add(DynamicFormLoadEvent(widget.formId)),
+        ),
+        DynamicFormLoaded(:final schema) ||
+        DynamicFormSubmitting(:final schema) ||
+        DynamicFormSubmitted(
+          :final schema,
+        ) => _buildForm(context, schema, isSubmitting: state is DynamicFormSubmitting),
       },
+    );
+  }
+
+  Widget _buildForm(BuildContext context, FormSchemaEntity schema, {required bool isSubmitting}) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(schema.title, style: Theme.of(context).textTheme.headlineSmall),
+          const SizedBox(height: AppSpacing.xl),
+          DynamicFormRenderer(
+            schema: schema,
+            formKey: _formKey,
+            readOnly: isSubmitting,
+            onSubmit: (data) => context.read<DynamicFormBloc>().add(DynamicFormSubmitEvent(data)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/features/dynamic_forms/application/dynamic_form_bloc_test.dart
+++ b/test/features/dynamic_forms/application/dynamic_form_bloc_test.dart
@@ -127,37 +127,22 @@ void main() {
   });
 
   group('DynamicFormState', () {
-    test('initial state has correct defaults', () {
-      const state = DynamicFormState();
-      expect(state.status, DynamicFormStatus.initial);
-      expect(state.schema, isNull);
-      expect(state.submitResponse, isNull);
-      expect(state.error, isNull);
+    test('DynamicFormInitial equality and props', () {
+      expect(const DynamicFormInitial(), const DynamicFormInitial());
+      expect(const DynamicFormInitial().props, const <Object?>[]);
     });
 
-    test('supports value equality', () {
-      const state1 = DynamicFormState();
-      const state2 = DynamicFormState();
-      expect(state1, equals(state2));
+    test('DynamicFormLoading equality and props', () {
+      expect(const DynamicFormLoading(), const DynamicFormLoading());
+      expect(const DynamicFormLoading().props, const <Object?>[]);
     });
 
-    test('copyWith replaces non-null parameters', () {
-      const state = DynamicFormState();
-      final updated = state.copyWith(status: DynamicFormStatus.loading);
-      expect(updated.status, DynamicFormStatus.loading);
-      expect(updated.schema, isNull);
+    test('different variants are not equal', () {
+      expect(const DynamicFormInitial(), isNot(equals(const DynamicFormLoading())));
     });
 
-    test('copyWith preserves existing values when no args given', () {
-      const state = DynamicFormState(status: DynamicFormStatus.loaded, error: 'something');
-      final copy = state.copyWith();
-      expect(copy.status, DynamicFormStatus.loaded);
-      expect(copy.error, 'something');
-    });
-
-    test('props contains all fields', () {
-      const state = DynamicFormState();
-      expect(state.props, [DynamicFormStatus.initial, null, null, null]);
+    test('DynamicFormFailure carries error', () {
+      expect(const DynamicFormFailure(error: 'boom'), equals(const DynamicFormFailure(error: 'boom')));
     });
   });
 
@@ -306,10 +291,9 @@ void main() {
   });
 
   group('DynamicFormBloc', () {
-    test('initial state is DynamicFormState with initial status', () {
+    test('initial state is DynamicFormInitial', () {
       final bloc = DynamicFormBloc();
-      expect(bloc.state, const DynamicFormState());
-      expect(bloc.state.status, DynamicFormStatus.initial);
+      expect(bloc.state, const DynamicFormInitial());
       bloc.close();
     });
 
@@ -321,13 +305,11 @@ void main() {
         act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
         wait: const Duration(milliseconds: 300),
         expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.loaded)
-              .having((s) => s.schema, 'schema', isNotNull)
-              .having((s) => s.schema!.id, 'schema.id', 'test_form')
-              .having((s) => s.schema!.title, 'schema.title', 'Test Form')
-              .having((s) => s.schema!.fields, 'schema.fields', hasLength(3)),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormLoaded>()
+              .having((s) => s.schema.id, 'schema.id', 'test_form')
+              .having((s) => s.schema.title, 'schema.title', 'Test Form')
+              .having((s) => s.schema.fields, 'schema.fields', hasLength(3)),
         ],
       );
 
@@ -337,12 +319,7 @@ void main() {
         build: () => DynamicFormBloc(),
         act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
         wait: const Duration(milliseconds: 300),
-        expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.failure)
-              .having((s) => s.error, 'error', isNotNull),
-        ],
+        expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormFailure>().having((s) => s.error, 'error', isNotNull)],
       );
 
       blocTest<DynamicFormBloc, DynamicFormState>(
@@ -351,12 +328,7 @@ void main() {
         build: () => DynamicFormBloc(),
         act: (bloc) => bloc.add(const DynamicFormLoadEvent('unknown')),
         wait: const Duration(milliseconds: 300),
-        expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.failure)
-              .having((s) => s.error, 'error', isNotNull),
-        ],
+        expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormFailure>().having((s) => s.error, 'error', isNotNull)],
       );
 
       blocTest<DynamicFormBloc, DynamicFormState>(
@@ -366,10 +338,8 @@ void main() {
         act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
         wait: const Duration(milliseconds: 300),
         expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.failure)
-              .having((s) => s.error, 'error', contains('Timeout')),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormFailure>().having((s) => s.error, 'error', contains('Timeout')),
         ],
       );
     });
@@ -394,13 +364,11 @@ void main() {
         wait: const Duration(milliseconds: 300),
         expect: () => [
           // Load events
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loaded),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormLoaded>(),
           // Submit events
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.submitting),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.submitted)
-              .having((s) => s.submitResponse, 'submitResponse', 'Form data logged'),
+          isA<DynamicFormSubmitting>(),
+          isA<DynamicFormSubmitted>().having((s) => s.submitResponse, 'submitResponse', 'Form data logged'),
         ],
       );
 
@@ -418,13 +386,11 @@ void main() {
         wait: const Duration(milliseconds: 300),
         expect: () => [
           // Load events
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loaded),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormLoaded>(),
           // Submit events
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.submitting),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.submitted)
-              .having((s) => s.submitResponse, 'submitResponse', '{"id": "lead_1"}'),
+          isA<DynamicFormSubmitting>(),
+          isA<DynamicFormSubmitted>().having((s) => s.submitResponse, 'submitResponse', '{"id": "lead_1"}'),
         ],
       );
 
@@ -440,12 +406,10 @@ void main() {
         },
         wait: const Duration(milliseconds: 300),
         expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loaded),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.submitting),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.submitted)
-              .having((s) => s.submitResponse, 'submitResponse', '{"updated": true}'),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormLoaded>(),
+          isA<DynamicFormSubmitting>(),
+          isA<DynamicFormSubmitted>().having((s) => s.submitResponse, 'submitResponse', '{"updated": true}'),
         ],
       );
 
@@ -461,12 +425,10 @@ void main() {
         },
         wait: const Duration(milliseconds: 300),
         expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loaded),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.submitting),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.failure)
-              .having((s) => s.error, 'error', isNotNull),
+          isA<DynamicFormLoading>(),
+          isA<DynamicFormLoaded>(),
+          isA<DynamicFormSubmitting>(),
+          isA<DynamicFormFailure>().having((s) => s.error, 'error', isNotNull),
         ],
       );
     });
@@ -482,43 +444,15 @@ void main() {
           bloc.add(const DynamicFormResetEvent());
         },
         wait: const Duration(milliseconds: 300),
-        expect: () => [
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loading),
-          isA<DynamicFormState>().having((s) => s.status, 'status', DynamicFormStatus.loaded),
-          isA<DynamicFormState>()
-              .having((s) => s.status, 'status', DynamicFormStatus.initial)
-              .having((s) => s.schema, 'schema', isNull)
-              .having((s) => s.error, 'error', isNull)
-              .having((s) => s.submitResponse, 'submitResponse', isNull),
-        ],
+        expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormLoaded>(), isA<DynamicFormInitial>()],
       );
 
       blocTest<DynamicFormBloc, DynamicFormState>(
         'emits initial state when reset is dispatched from initial state',
         build: () => DynamicFormBloc(),
         act: (bloc) => bloc.add(const DynamicFormResetEvent()),
-        expect: () => [const DynamicFormState()],
+        expect: () => [const DynamicFormInitial()],
       );
-    });
-  });
-
-  group('DynamicFormStatus', () {
-    test('has all expected enum values', () {
-      expect(
-        DynamicFormStatus.values,
-        containsAll([
-          DynamicFormStatus.initial,
-          DynamicFormStatus.loading,
-          DynamicFormStatus.loaded,
-          DynamicFormStatus.submitting,
-          DynamicFormStatus.submitted,
-          DynamicFormStatus.failure,
-        ]),
-      );
-    });
-
-    test('has exactly 6 values', () {
-      expect(DynamicFormStatus.values, hasLength(6));
     });
   });
 }

--- a/test/features/dynamic_forms/presentation/pages/dynamic_form_page_test.dart
+++ b/test/features/dynamic_forms/presentation/pages/dynamic_form_page_test.dart
@@ -53,7 +53,7 @@ void main() {
   group('DynamicFormPage', () {
     group('loading state', () {
       testWidgets('shows CircularProgressIndicator when status is loading', (tester) async {
-        when(() => mockBloc.state).thenReturn(const DynamicFormState(status: DynamicFormStatus.loading));
+        when(() => mockBloc.state).thenReturn(const DynamicFormLoading());
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -65,9 +65,7 @@ void main() {
 
     group('failure state', () {
       testWidgets('shows AppErrorState when status is failure', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.failure, error: 'Network error'));
+        when(() => mockBloc.state).thenReturn(const DynamicFormFailure(error: 'Network error'));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -78,7 +76,7 @@ void main() {
       });
 
       testWidgets('shows default error message when error is null', (tester) async {
-        when(() => mockBloc.state).thenReturn(const DynamicFormState(status: DynamicFormStatus.failure));
+        when(() => mockBloc.state).thenReturn(const DynamicFormFailure(error: 'Failed to load form'));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -87,9 +85,7 @@ void main() {
       });
 
       testWidgets('shows retry button in error state', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.failure, error: 'Something went wrong'));
+        when(() => mockBloc.state).thenReturn(const DynamicFormFailure(error: 'Something went wrong'));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -97,22 +93,20 @@ void main() {
       });
     });
 
-    group('initial state with no schema', () {
-      testWidgets('shows "No form schema available." when schema is null and status is initial', (tester) async {
-        when(() => mockBloc.state).thenReturn(const DynamicFormState());
+    group('initial state', () {
+      testWidgets('shows CircularProgressIndicator while bloc is in DynamicFormInitial', (tester) async {
+        when(() => mockBloc.state).thenReturn(const DynamicFormInitial());
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
-        expect(find.text('No form schema available.'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
         expect(find.byType(DynamicFormRenderer), findsNothing);
       });
     });
 
     group('loaded state', () {
       testWidgets('shows form title and DynamicFormRenderer when loaded', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.loaded, schema: _testSchema));
+        when(() => mockBloc.state).thenReturn(const DynamicFormLoaded(schema: _testSchema));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -123,9 +117,7 @@ void main() {
       });
 
       testWidgets('renders form fields when loaded', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.loaded, schema: _testSchema));
+        when(() => mockBloc.state).thenReturn(const DynamicFormLoaded(schema: _testSchema));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -135,9 +127,7 @@ void main() {
       });
 
       testWidgets('shows submit button when form is loaded and not submitting', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.loaded, schema: _testSchema));
+        when(() => mockBloc.state).thenReturn(const DynamicFormLoaded(schema: _testSchema));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -147,9 +137,7 @@ void main() {
 
     group('submitting state', () {
       testWidgets('renders form as readOnly when submitting', (tester) async {
-        when(
-          () => mockBloc.state,
-        ).thenReturn(const DynamicFormState(status: DynamicFormStatus.submitting, schema: _testSchema));
+        when(() => mockBloc.state).thenReturn(const DynamicFormSubmitting(schema: _testSchema));
 
         await tester.pumpWidget(_buildTestWidget(mockBloc));
 
@@ -165,10 +153,10 @@ void main() {
         whenListen(
           statesController,
           Stream<DynamicFormState>.fromIterable([
-            const DynamicFormState(status: DynamicFormStatus.loaded, schema: _testSchema),
-            const DynamicFormState(status: DynamicFormStatus.submitted, schema: _testSchema),
+            const DynamicFormLoaded(schema: _testSchema),
+            const DynamicFormSubmitted(schema: _testSchema),
           ]),
-          initialState: const DynamicFormState(status: DynamicFormStatus.loaded, schema: _testSchema),
+          initialState: const DynamicFormLoaded(schema: _testSchema),
         );
 
         await tester.pumpWidget(_buildTestWidget(statesController));


### PR DESCRIPTION
## Description

Converts the dynamic form feature from single-state + 6-value status enum to a pure Dart 3 sealed hierarchy. Each variant declares which fields are actually available at that phase, eliminating the previous nullable-schema-everywhere shape.

### State

- `DynamicFormInitial`, `DynamicFormLoading`: empty payloads.
- `DynamicFormLoaded({required schema})`: schema is **required** for this variant — compile-time guarantee that the form renderer always has a schema.
- `DynamicFormSubmitting({required schema})`: schema lifted forward from Loaded.
- `DynamicFormSubmitted({required schema, submitResponse})`: ditto, plus optional response payload.
- `DynamicFormFailure({required error, schema})`: schema is nullable because load failures have no schema, while submit failures lift the previous schema forward so the user can retry.

### Bloc

- `super(const DynamicFormInitial())`.
- `_onSubmit` pattern-matches the previous state to lift the schema explicitly:

```dart
final schema = switch (state) {
  DynamicFormLoaded(:final schema) => schema,
  DynamicFormSubmitted(:final schema) => schema,
  DynamicFormFailure(:final schema?) => schema,
  _ => null,
};
if (schema == null) return;
```

Submit failure now carries the schema forward via `DynamicFormFailure(error: ..., schema: schema)`.

### UI (`dynamic_form_page.dart`)

- `BlocConsumer.builder` is a Dart 3 `switch (state)` expression with `||` patterns to group the three schema-bearing variants (Loaded / Submitting / Submitted) into the same form-render path:

```dart
DynamicFormLoaded(:final schema)
  || DynamicFormSubmitting(:final schema)
  || DynamicFormSubmitted(:final schema) =>
  _buildForm(context, schema, isSubmitting: state is DynamicFormSubmitting),
```

- `BlocConsumer.listener` uses `state is DynamicFormSubmitted` for the snackbar trigger.
- The dead "No form schema available." fallback is removed — the exhaustive switch no longer admits a schema-less form-render case.

### Tests

- `dynamic_form_bloc_test.dart`: removed legacy state/copyWith/status tests; per-variant equality/props tests added; bloc expectations rewritten as `isA<DynamicFormX>().having((s) => s.field, ...)` so field access is type-safe (no more `.schema!.id`). Removed the `DynamicFormStatus` enum-values test.
- `dynamic_form_page_test.dart`: 8 mock state injections rewritten to concrete variants; the "no schema available" branch test now asserts the spinner shown during `DynamicFormInitial`.

## Related Issue

Continued execution of #81 — sealed-by-default migration.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes beyond the migration)
- [ ] Documentation update
- [ ] CI/CD or build configuration change

## Checklist

- [x] Follows project main rule (`CLAUDE.md` → State Modeling)
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` → no changes
- [x] `fvm dart analyze` → No issues found
- [x] `fvm flutter test` → **1381 tests passed**, 0 failures

## Additional Notes

Next migration target: `user_state.dart`. Likely combined with **#75** (UserBloc god-bloc split) because the granular status enum (9 values: searchSuccess, fetchSuccess, deleteSuccess, etc.) is the textbook signal for splitting into bounded sub-blocs rather than just sealing the existing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)