### PR TITLE
fix(auth): LoginState pure sealed — fixes #70 mixed-pattern bug

### DIFF
--- a/lib/app/bootstrap/app_session_listeners.dart
+++ b/lib/app/bootstrap/app_session_listeners.dart
@@ -14,9 +14,9 @@ class AppSessionListeners extends StatelessWidget {
     return MultiBlocListener(
       listeners: [
         BlocListener<LoginBloc, LoginState>(
-          listenWhen: (previous, current) => previous.status != current.status,
+          listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
           listener: (context, state) {
-            if (state.status == LoginStatus.success) {
+            if (state is LoginLoadedState) {
               context.read<SessionCubit>().markAuthenticated();
             }
           },

--- a/lib/features/auth/application/login_bloc.dart
+++ b/lib/features/auth/application/login_bloc.dart
@@ -30,20 +30,52 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
        _sendOtpUseCase = sendOtpUseCase,
        _verifyOtpUseCase = verifyOtpUseCase,
        _getAccountUseCase = getAccountUseCase,
-       super(const LoginState()) {
+       super(const LoginInitialState()) {
     on<LoginFormSubmitted>(_onSubmit);
-    on<TogglePasswordVisibility>((event, emit) => emit(state.copyWith(passwordVisible: !state.passwordVisible)));
+    on<TogglePasswordVisibility>(_onTogglePasswordVisibility);
     on<ChangeLoginMethod>(_onChangeLoginMethod);
     on<SendOtpRequested>(_onSendOtpRequested);
     on<VerifyOtpSubmitted>(_onVerifyOtpSubmitted);
   }
 
+  /// Recreate the current variant with a flipped `passwordVisible`, preserving
+  /// its type and other carried fields. Plain `copyWith` cannot do this under
+  /// sealed semantics — that was the original #70 bug.
+  void _onTogglePasswordVisibility(TogglePasswordVisibility event, Emitter<LoginState> emit) {
+    final v = !state.passwordVisible;
+    final m = state.loginMethod;
+    emit(switch (state) {
+      LoginInitialState() => LoginInitialState(loginMethod: m, passwordVisible: v),
+      LoginLoadingState(:final username) => LoginLoadingState(username: username, loginMethod: m, passwordVisible: v),
+      LoginLoadedState(:final username) => LoginLoadedState(username: username, loginMethod: m, passwordVisible: v),
+      LoginOtpSentState(:final email) => LoginOtpSentState(email: email, passwordVisible: v),
+      LoginOtpVerifiedState(:final email, :final otpCode) => LoginOtpVerifiedState(
+        email: email,
+        otpCode: otpCode,
+        passwordVisible: v,
+      ),
+      LoginErrorState(:final message) => LoginErrorState(message: message, loginMethod: m, passwordVisible: v),
+    });
+  }
+
   FutureOr<void> _onSubmit(LoginFormSubmitted event, Emitter<LoginState> emit) async {
     _log.debug("BEGIN: onSubmit LoginFormSubmitted event: {}", [event.username]);
-    emit(LoginLoadingState(username: event.username));
+    emit(
+      LoginLoadingState(
+        username: event.username,
+        loginMethod: state.loginMethod,
+        passwordVisible: state.passwordVisible,
+      ),
+    );
 
     if (event.username == "invalid") {
-      emit(const LoginErrorState(message: "Login API Error: Invalid username"));
+      emit(
+        LoginErrorState(
+          message: "Login API Error: Invalid username",
+          loginMethod: state.loginMethod,
+          passwordVisible: state.passwordVisible,
+        ),
+      );
       _log.error("END:onSubmit LoginFormSubmitted event error: Invalid username");
       return;
     }
@@ -53,7 +85,13 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     switch (tokenResult) {
       case Success(:final data):
         if (!data.isValid) {
-          emit(const LoginErrorState(message: "Login API Error: Invalid Access Token"));
+          emit(
+            LoginErrorState(
+              message: "Login API Error: Invalid Access Token",
+              loginMethod: state.loginMethod,
+              passwordVisible: state.passwordVisible,
+            ),
+          );
           return;
         }
         await AppLocalStorage().save(StorageKeys.jwtToken.key, data.idToken);
@@ -69,45 +107,79 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
           case Success(data: final user):
             await AppLocalStorage().save(StorageKeys.roles.key, user.authorities);
             _log.debug("onSubmit save storage roles: {}", [user.authorities]);
-            emit(LoginLoadedState(username: event.username));
+            emit(
+              LoginLoadedState(
+                username: event.username,
+                loginMethod: state.loginMethod,
+                passwordVisible: state.passwordVisible,
+              ),
+            );
             _log.debug("END:onSubmit LoginFormSubmitted event success: {}", [data.toString()]);
           case Failure(:final error):
-            emit(LoginErrorState(message: "Login API Error: ${error.message}"));
+            emit(
+              LoginErrorState(
+                message: "Login API Error: ${error.message}",
+                loginMethod: state.loginMethod,
+                passwordVisible: state.passwordVisible,
+              ),
+            );
             _log.error("END:onSubmit getAccount error: {}", [error.toString()]);
         }
       case Failure(:final error):
-        emit(LoginErrorState(message: "Login API Error: ${error.message}"));
+        emit(
+          LoginErrorState(
+            message: "Login API Error: ${error.message}",
+            loginMethod: state.loginMethod,
+            passwordVisible: state.passwordVisible,
+          ),
+        );
         _log.error("END:onSubmit LoginFormSubmitted event error: {}", [error.message]);
     }
   }
 
   void _onChangeLoginMethod(ChangeLoginMethod event, Emitter<LoginState> emit) {
-    emit(state.copyWith(loginMethod: event.method, status: LoginStatus.initial, isOtpSent: false));
+    emit(LoginInitialState(loginMethod: event.method, passwordVisible: state.passwordVisible));
   }
 
   Future<void> _onSendOtpRequested(SendOtpRequested event, Emitter<LoginState> emit) async {
     _log.debug("BEGIN: onSendOtpRequested SendOtpRequested event: {}", [event.email]);
-    emit(LoginLoadingState(username: event.email));
+    emit(
+      LoginLoadingState(username: event.email, loginMethod: LoginMethod.otp, passwordVisible: state.passwordVisible),
+    );
     final result = await _sendOtpUseCase(SendOtpEntity(email: event.email));
     switch (result) {
       case Success():
-        emit(LoginOtpSentState(email: event.email));
+        emit(LoginOtpSentState(email: event.email, passwordVisible: state.passwordVisible));
         _log.debug("END: onSendOtpRequested SendOtpRequested event success: {}", [event.email]);
       case Failure(:final error):
-        emit(LoginErrorState(message: "Send OTP error: ${error.message}"));
+        emit(
+          LoginErrorState(
+            message: "Send OTP error: ${error.message}",
+            loginMethod: LoginMethod.otp,
+            passwordVisible: state.passwordVisible,
+          ),
+        );
         _log.error("END: onSendOtpRequested SendOtpRequested event error: {}", [error.message]);
     }
   }
 
   Future<void> _onVerifyOtpSubmitted(VerifyOtpSubmitted event, Emitter<LoginState> emit) async {
     _log.debug("BEGIN: onVerifyOtpSubmitted VerifyOtpSubmitted event: {}", [event.email]);
-    emit(state.copyWith(status: LoginStatus.loading));
+    emit(
+      LoginLoadingState(username: event.email, loginMethod: LoginMethod.otp, passwordVisible: state.passwordVisible),
+    );
     final tokenResult = await _verifyOtpUseCase(VerifyOtpEntity(email: event.email, otp: event.otpCode));
     switch (tokenResult) {
       case Success(:final data):
         _log.debug("onVerifyOtpSubmitted token: {}", [data.toString()]);
         if (!data.isValid) {
-          emit(const LoginErrorState(message: "OTP validation error"));
+          emit(
+            LoginErrorState(
+              message: "OTP validation error",
+              loginMethod: LoginMethod.otp,
+              passwordVisible: state.passwordVisible,
+            ),
+          );
           return;
         }
         await AppLocalStorage().save(StorageKeys.jwtToken.key, data.idToken);
@@ -119,12 +191,30 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
         switch (accountResult) {
           case Success(data: final user):
             await AppLocalStorage().save(StorageKeys.roles.key, user.authorities);
-            emit(LoginLoadedState(username: event.email));
+            emit(
+              LoginLoadedState(
+                username: event.email,
+                loginMethod: LoginMethod.otp,
+                passwordVisible: state.passwordVisible,
+              ),
+            );
           case Failure():
-            emit(const LoginErrorState(message: "OTP validation error"));
+            emit(
+              LoginErrorState(
+                message: "OTP validation error",
+                loginMethod: LoginMethod.otp,
+                passwordVisible: state.passwordVisible,
+              ),
+            );
         }
       case Failure(:final error):
-        emit(const LoginErrorState(message: "OTP validation error"));
+        emit(
+          LoginErrorState(
+            message: "OTP validation error",
+            loginMethod: LoginMethod.otp,
+            passwordVisible: state.passwordVisible,
+          ),
+        );
         _log.error("END: onVerifyOtpSubmitted error: {}", [error.message]);
     }
   }

--- a/lib/features/auth/application/login_state.dart
+++ b/lib/features/auth/application/login_state.dart
@@ -1,90 +1,67 @@
 part of 'login_bloc.dart';
 
-enum LoginStatus { initial, loading, success, failure }
+/// Sealed hierarchy. The base class carries the two UI-config fields
+/// (`loginMethod`, `passwordVisible`) that survive across every variant
+/// transition — concurrent-state-access exception (CLAUDE.md → State
+/// Modeling). Auth-flow data (`username`, `email`, `otpCode`, error
+/// message) lives only on the variants that actually carry it.
+sealed class LoginState extends Equatable {
+  const LoginState({this.loginMethod = LoginMethod.password, this.passwordVisible = false});
 
-class LoginState extends Equatable {
-  final String? username;
-  final LoginStatus status;
-  final bool passwordVisible;
-  final String? email;
-  final String? otpCode;
-  final bool isOtpSent;
   final LoginMethod loginMethod;
-
-  const LoginState({
-    this.username,
-    this.status = LoginStatus.initial,
-    this.passwordVisible = false,
-    this.email,
-    this.otpCode,
-    this.isOtpSent = false,
-    this.loginMethod = LoginMethod.password,
-  });
-
-  LoginState copyWith({
-    String? username,
-    LoginStatus? status,
-    bool? passwordVisible,
-    String? email,
-    String? otpCode,
-    bool? isOtpSent,
-    LoginMethod? loginMethod,
-  }) {
-    return LoginState(
-      username: username ?? this.username,
-      status: status ?? this.status,
-      passwordVisible: passwordVisible ?? this.passwordVisible,
-      email: email ?? this.email,
-      otpCode: otpCode ?? this.otpCode,
-      isOtpSent: isOtpSent ?? this.isOtpSent,
-      loginMethod: loginMethod ?? this.loginMethod,
-    );
-  }
-
-  @override
-  bool get stringify => true;
-
-  @override
-  List<Object?> get props => [username, status, passwordVisible, email, otpCode, isOtpSent, loginMethod];
+  final bool passwordVisible;
 }
 
-class LoginInitialState extends LoginState {
-  const LoginInitialState() : super(status: LoginStatus.initial);
-}
-
-class LoginLoadingState extends LoginState {
-  const LoginLoadingState({super.username}) : super(status: LoginStatus.loading);
+final class LoginInitialState extends LoginState {
+  const LoginInitialState({super.loginMethod, super.passwordVisible});
 
   @override
-  List<Object?> get props => [username, status];
+  List<Object?> get props => [loginMethod, passwordVisible];
 }
 
-class LoginLoadedState extends LoginState {
-  const LoginLoadedState({super.username}) : super(status: LoginStatus.success);
+final class LoginLoadingState extends LoginState {
+  const LoginLoadingState({this.username, super.loginMethod, super.passwordVisible});
+
+  final String? username;
 
   @override
-  List<Object?> get props => [username, status];
+  List<Object?> get props => [username, loginMethod, passwordVisible];
 }
 
-class LoginOtpSentState extends LoginState {
-  const LoginOtpSentState({super.email}) : super(status: LoginStatus.success, isOtpSent: true);
+final class LoginLoadedState extends LoginState {
+  const LoginLoadedState({this.username, super.loginMethod, super.passwordVisible});
+
+  final String? username;
 
   @override
-  List<Object?> get props => [email, status];
+  List<Object?> get props => [username, loginMethod, passwordVisible];
 }
 
-class LoginOtpVerifiedState extends LoginState {
-  const LoginOtpVerifiedState({super.email, super.otpCode}) : super(status: LoginStatus.success);
+final class LoginOtpSentState extends LoginState {
+  const LoginOtpSentState({required this.email, super.passwordVisible}) : super(loginMethod: LoginMethod.otp);
+
+  final String email;
 
   @override
-  List<Object?> get props => [email, otpCode, status];
+  List<Object?> get props => [email, passwordVisible];
 }
 
-class LoginErrorState extends LoginState {
+final class LoginOtpVerifiedState extends LoginState {
+  const LoginOtpVerifiedState({required this.email, this.otpCode, super.passwordVisible})
+    : super(loginMethod: LoginMethod.otp);
+
+  final String email;
+  final String? otpCode;
+
+  @override
+  List<Object?> get props => [email, otpCode, passwordVisible];
+}
+
+final class LoginErrorState extends LoginState {
+  const LoginErrorState({required this.message, super.loginMethod, super.passwordVisible});
+
   final String message;
 
-  const LoginErrorState({required this.message}) : super(status: LoginStatus.failure);
-
   @override
-  List<Object?> get props => [message];
+  List<Object?> get props => [message, loginMethod, passwordVisible];
 }

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -552,7 +552,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
 
   Widget _submitButton(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
-      buildWhen: (previous, current) => previous.status != current.status,
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       builder: (context, state) {
         final isLoading = state is LoginLoadingState;
         return FilledButton(
@@ -675,14 +675,11 @@ class OtpEmailScreen extends StatelessWidget {
         ),
       ),
       body: BlocListener<LoginBloc, LoginState>(
-        listenWhen: (previous, current) =>
-            previous.status != current.status ||
-            previous.isOtpSent != current.isOtpSent ||
-            previous.email != current.email,
+        listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
         listener: (context, state) {
-          if (state.status == LoginStatus.success && state.isOtpSent == true && state.email != null) {
+          if (state is LoginOtpSentState) {
             context.go('${ApplicationRoutesConstants.loginOtpVerify}/${state.email}');
-          } else if (state.status == LoginStatus.failure) {
+          } else if (state is LoginErrorState) {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(S.of(context).failed)));
           }
         },
@@ -719,11 +716,11 @@ class OtpEmailScreen extends StatelessWidget {
 
   Widget _submitOtpButton(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
-      buildWhen: (previous, current) => previous.status != current.status,
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       builder: (context, state) {
         return ResponsiveSubmitButton(
           buttonText: S.of(context).send_otp_code,
-          isLoading: state.status == LoginStatus.loading,
+          isLoading: state is LoginLoadingState,
           onPressed: () {
             if (_formKey.currentState?.saveAndValidate() ?? false) {
               final email = _formKey.currentState!.value['email'] as String;
@@ -788,11 +785,11 @@ class OtpVerifyScreen extends StatelessWidget {
 
   Widget _submitVerifyButton(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
-      buildWhen: (previous, current) => previous.status != current.status && current.loginMethod == LoginMethod.otp,
+      buildWhen: (previous, current) => previous.runtimeType != current.runtimeType,
       builder: (context, state) {
         return ResponsiveSubmitButton(
           buttonText: S.of(context).verify_otp_code,
-          isLoading: state.status == LoginStatus.loading,
+          isLoading: state is LoginLoadingState,
           onPressed: () {
             if (_formKey.currentState?.saveAndValidate() ?? false) {
               final otpCode = _formKey.currentState!.value['otpCode'] as String;

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -201,7 +201,7 @@ void main() {
   //region bloc
   /// Login Bloc Tests
   group("LoginBloc", () {
-    test("initial state is LoginState", () {
+    test("initial state is LoginInitialState", () {
       expect(_buildBloc(repository).state, const LoginInitialState());
     });
 
@@ -255,7 +255,7 @@ void main() {
   //endregion bloc
 
   group('LoginBloc test 2', () {
-    test('initial state is LoginState', () {
+    test('initial state is LoginInitialState', () {
       expect(_buildBloc(repository).state, const LoginInitialState());
     });
 

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -136,59 +136,45 @@ void main() {
   //region state
   /// Login State Tests
   group("LoginState", () {
-    // LoginState
-    test("supports value comparisons", () {
-      expect(const LoginState(), const LoginState());
-      const state = LoginState(status: LoginStatus.initial, passwordVisible: false);
-      expect(const LoginState(), state);
-    });
-
-    // LoginInitialState
-    test("LoginInitialState", () {
+    test("LoginInitialState equality and props", () {
       expect(const LoginInitialState(), const LoginInitialState());
+      expect(const LoginInitialState().props, const <Object?>[LoginMethod.password, false]);
     });
 
-    // LoginLoadingState
-    test("LoginLoadingState", () {
-      expect(const LoginLoadingState(), const LoginLoadingState());
+    test("LoginLoadingState carries username", () {
+      expect(const LoginLoadingState(username: "u"), const LoginLoadingState(username: "u"));
+      expect(const LoginLoadingState(username: "u").props, const <Object?>["u", LoginMethod.password, false]);
     });
 
-    // LoginLoadedState
-    test("LoginLoadedState", () {
-      expect(const LoginLoadedState(), const LoginLoadedState());
+    test("LoginLoadedState carries username", () {
+      expect(const LoginLoadedState(username: "u"), const LoginLoadedState(username: "u"));
+      expect(const LoginLoadedState(username: "u").props, const <Object?>["u", LoginMethod.password, false]);
     });
 
-    // LoginErrorState
-    test("LoginErrorState", () {
+    test("LoginOtpSentState carries email", () {
+      expect(const LoginOtpSentState(email: "e@x"), const LoginOtpSentState(email: "e@x"));
+      expect(const LoginOtpSentState(email: "e@x").loginMethod, LoginMethod.otp);
+    });
+
+    test("LoginOtpVerifiedState carries email + otpCode", () {
+      expect(
+        const LoginOtpVerifiedState(email: "e@x", otpCode: "123"),
+        const LoginOtpVerifiedState(email: "e@x", otpCode: "123"),
+      );
+    });
+
+    test("LoginErrorState carries message", () {
       expect(const LoginErrorState(message: "test"), const LoginErrorState(message: "test"));
-      expect(const LoginErrorState(message: "test").props, ["test"]);
+      expect(const LoginErrorState(message: "test").props, const <Object?>["test", LoginMethod.password, false]);
     });
 
-    test("copyWith retains the same values if no arguments are provided", () {
-      const state = LoginState(status: LoginStatus.initial, passwordVisible: false);
-      expect(state.copyWith(), state);
+    test("Initial bloc state is LoginInitialState", () {
+      expect(_buildBloc(_FakeAuthRepository()).state, const LoginInitialState());
     });
 
-    test("copyWith replaces non-null parameters", () {
-      const state = LoginState(status: LoginStatus.initial, passwordVisible: false);
-      const secondState = LoginState(status: LoginStatus.success, passwordVisible: true);
-      expect(state.copyWith(status: LoginStatus.success, passwordVisible: true), secondState);
-    });
-
-    test("Initial state is LoginState", () {
-      expect(_buildBloc(_FakeAuthRepository()).state, const LoginState());
-    });
-
-    test("props", () {
-      expect(const LoginState(status: LoginStatus.initial, passwordVisible: false, username: "test").props, [
-        "test",
-        LoginStatus.initial,
-        false,
-        null,
-        null,
-        false,
-        LoginMethod.password,
-      ]);
+    test("passwordVisible flows through variants", () {
+      expect(const LoginInitialState(passwordVisible: true).passwordVisible, true);
+      expect(const LoginLoadingState(passwordVisible: true).passwordVisible, true);
     });
   });
   //endregion state
@@ -216,7 +202,7 @@ void main() {
   /// Login Bloc Tests
   group("LoginBloc", () {
     test("initial state is LoginState", () {
-      expect(_buildBloc(repository).state, const LoginState());
+      expect(_buildBloc(repository).state, const LoginInitialState());
     });
 
     group("LoginFormSubmitted", () {
@@ -270,7 +256,7 @@ void main() {
 
   group('LoginBloc test 2', () {
     test('initial state is LoginState', () {
-      expect(_buildBloc(repository).state, const LoginState());
+      expect(_buildBloc(repository).state, const LoginInitialState());
     });
 
     group('LoginFormSubmitted', () {
@@ -325,7 +311,7 @@ void main() {
           return _buildBlocWithSendOtp(sendOtpRepo);
         },
         act: (bloc) => bloc.add(event),
-        expect: () => [const LoginLoadingState(username: email), isA<LoginErrorState>()],
+        expect: () => [const LoginLoadingState(username: email, loginMethod: LoginMethod.otp), isA<LoginErrorState>()],
       );
     });
 
@@ -334,14 +320,17 @@ void main() {
       const otpCode = "123456";
       const event = VerifyOtpSubmitted(email: email, otpCode: otpCode);
 
-      const loadingState = LoginState(status: LoginStatus.loading);
+      const loadingState = LoginLoadingState(username: email, loginMethod: LoginMethod.otp);
 
       blocTest<LoginBloc, LoginState>(
         'given invalid OTP when submitted then emits [loading, error]',
         setUp: () => repository.verifyResult = const Success(AuthTokenEntity(idToken: null)),
         build: () => _buildBloc(repository),
         act: (bloc) => bloc.add(event),
-        expect: () => [loadingState, const LoginErrorState(message: "OTP validation error")],
+        expect: () => [
+          loadingState,
+          const LoginErrorState(message: "OTP validation error", loginMethod: LoginMethod.otp),
+        ],
       );
     });
 
@@ -350,7 +339,7 @@ void main() {
         'given OTP method when changed then updates login method',
         build: () => _buildBloc(repository),
         act: (bloc) => bloc.add(const ChangeLoginMethod(method: LoginMethod.otp)),
-        expect: () => [const LoginState(loginMethod: LoginMethod.otp, status: LoginStatus.initial, isOtpSent: false)],
+        expect: () => [const LoginInitialState(loginMethod: LoginMethod.otp)],
       );
     });
 
@@ -359,7 +348,7 @@ void main() {
         'when toggled then updates password visibility',
         build: () => _buildBloc(repository),
         act: (bloc) => bloc.add(const TogglePasswordVisibility()),
-        expect: () => [const LoginState(passwordVisible: true)],
+        expect: () => [const LoginInitialState(passwordVisible: true)],
       );
     });
   });

--- a/test/features/auth/presentation/widgets/login_otp_email_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_email_widget_test.dart
@@ -36,7 +36,7 @@ void main() {
     mockLoginBloc = MockLoginBloc();
 
     // Set basic state for login bloc
-    when(() => mockLoginBloc.state).thenReturn(const LoginState());
+    when(() => mockLoginBloc.state).thenReturn(const LoginInitialState());
     mockGoRouter = GoRouter(
       initialLocation: ApplicationRoutesConstants.loginOtp,
       routes: [
@@ -116,7 +116,7 @@ void main() {
     });
 
     testWidgets('should show loading state when sending OTP', (tester) async {
-      when(() => mockLoginBloc.state).thenReturn(const LoginState(status: LoginStatus.loading));
+      when(() => mockLoginBloc.state).thenReturn(const LoginLoadingState(loginMethod: LoginMethod.otp));
       await tester.pumpWidget(testWidget);
       await tester.pump();
 
@@ -129,7 +129,7 @@ void main() {
 
       final loginStateController = StreamController<LoginState>.broadcast();
       when(() => mockLoginBloc.stream).thenAnswer((_) => loginStateController.stream);
-      when(() => mockLoginBloc.state).thenReturn(const LoginState());
+      when(() => mockLoginBloc.state).thenReturn(const LoginInitialState());
 
       await tester.pumpWidget(testWidget);
       await tester.pumpAndSettle();
@@ -138,9 +138,7 @@ void main() {
       await tester.tap(find.byType(ResponsiveSubmitButton));
       await tester.pump();
 
-      loginStateController.add(
-        const LoginState(status: LoginStatus.loading, email: 'test@example.com', loginMethod: LoginMethod.otp),
-      );
+      loginStateController.add(const LoginLoadingState(username: 'test@example.com', loginMethod: LoginMethod.otp));
       await tester.pump();
 
       loginStateController.add(const LoginOtpSentState(email: 'test@example.com'));
@@ -170,7 +168,9 @@ void main() {
     });
 
     testWidgets('should show error state', (tester) async {
-      when(() => mockLoginBloc.state).thenReturn(const LoginState(status: LoginStatus.failure));
+      when(
+        () => mockLoginBloc.state,
+      ).thenReturn(const LoginErrorState(message: 'failed', loginMethod: LoginMethod.otp));
       await tester.pumpWidget(testWidget);
       await tester.pumpAndSettle();
 

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -36,7 +36,7 @@ void main() {
     mockLoginBloc = MockLoginBloc();
 
     // Set basic state for login bloc
-    when(() => mockLoginBloc.state).thenReturn(const LoginState());
+    when(() => mockLoginBloc.state).thenReturn(const LoginInitialState());
     mockGoRouter = GoRouter(
       initialLocation: "${ApplicationRoutesConstants.loginOtpVerify}/test@example.com",
       routes: [
@@ -180,7 +180,7 @@ void main() {
       TestUtils().setupUnitTest();
       final loginStateController = StreamController<LoginState>.broadcast();
       when(() => mockLoginBloc.stream).thenAnswer((_) => loginStateController.stream);
-      when(() => mockLoginBloc.state).thenReturn(const LoginState());
+      when(() => mockLoginBloc.state).thenReturn(const LoginInitialState());
 
       await tester.pumpWidget(testWidget);
       await tester.pumpAndSettle();
@@ -190,15 +190,7 @@ void main() {
       await tester.tap(submitButtonFinder);
       await tester.pump();
 
-      loginStateController.add(
-        const LoginState(
-          email: "test@example.com",
-          otpCode: "123456",
-          status: LoginStatus.loading,
-          isOtpSent: true,
-          loginMethod: LoginMethod.otp,
-        ),
-      );
+      loginStateController.add(const LoginLoadingState(username: "test@example.com", loginMethod: LoginMethod.otp));
       await tester.pump();
 
       await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
@@ -219,7 +211,7 @@ void main() {
       TestUtils().setupUnitTest();
       final loginStateController = StreamController<LoginState>.broadcast();
       when(() => mockLoginBloc.stream).thenAnswer((_) => loginStateController.stream);
-      when(() => mockLoginBloc.state).thenReturn(const LoginState());
+      when(() => mockLoginBloc.state).thenReturn(const LoginInitialState());
 
       await tester.pumpWidget(testWidget);
       await tester.pumpAndSettle();
@@ -229,15 +221,7 @@ void main() {
       await tester.tap(submitButtonFinder);
       await tester.pump();
 
-      loginStateController.add(
-        const LoginState(
-          email: "test@example.com",
-          otpCode: "123456",
-          status: LoginStatus.loading,
-          isOtpSent: true,
-          loginMethod: LoginMethod.otp,
-        ),
-      );
+      loginStateController.add(const LoginLoadingState(username: "test@example.com", loginMethod: LoginMethod.otp));
       await tester.pump();
 
       loginStateController.add(const LoginErrorState(message: "Invalid OTP Token"));


### PR DESCRIPTION
## Summary
- Replaces mixed `copyWith` + subclass introspection in `LoginState` with a pure Dart 3 sealed hierarchy (`LoginInitialState`, `LoginLoadingState`, `LoginLoadedState`, `LoginOtpSentState`, `LoginOtpVerifiedState`, `LoginErrorState`).
- Fixes the documented `#70` bug: `TogglePasswordVisibility` previously dropped the active OTP variant; now uses an exhaustive switch that recreates the current variant with `passwordVisible` flipped.
- Listeners/builders switched from status-equality to `runtimeType` checks, matching the rest of the migrated features (#76, #83, #105–#112).

## Implementation notes
- Base sealed class carries `loginMethod` + `passwordVisible` (documented concurrent state access exception — same pattern as other migrated blocs).
- `_onSendOtpRequested` and `_onVerifyOtpSubmitted` always thread `LoginMethod.otp` through their emits (loading + error states), matching their semantic flow.
- Both lib and test sides updated; analyze + format clean; full suite green (1386 tests).

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed`
- [x] `fvm dart analyze` — no issues
- [x] `fvm flutter test` — 1386 passed
- [x] Sealed state tests cover each variant's equality + props

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)