### PR TITLE
chore(bloc): close out sealed-state migration (phase 4c/4d)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,6 @@ Every feature follows: **Event → BLoC → State → UI**
 
 ### State Modeling — MAIN RULE
 
-> ⚠️ **Migration in progress (May 2026):** The project is transitioning to sealed state hierarchies as the default state-modeling pattern. Some BLoCs may still be on the legacy single-state + status enum pattern during this transition; new code MUST follow the rule below, and existing BLoCs are being migrated under the tech-debt audit. Once the migration completes, this warning will be removed.
-
 **Default to sealed state hierarchies** that leverage Dart 3's `sealed` modifier and exhaustive `switch` expressions. The compiler enforces handling of every state variant; UIs render via pattern matching.
 
 ```dart

--- a/lib/features/dashboard/application/dashboard_state.dart
+++ b/lib/features/dashboard/application/dashboard_state.dart
@@ -4,6 +4,15 @@ part of 'dashboard_cubit.dart';
 enum SystemDashboardStatus { initial, loading, loaded, error }
 
 /// State for the system dashboard cubit.
+///
+/// **Documented exception to the sealed-by-default rule** (see CLAUDE.md → "State Modeling — MAIN RULE").
+/// This state is a transactional snapshot: every field is part of one coherent dashboard
+/// reading (connectivity, circuit-breaker counts, cache stats, feature flags, endpoint
+/// health, app config, interceptors) and they all evolve together on each `load()`.
+/// Splitting into sealed variants would either duplicate the bundle across `loading`/
+/// `loaded`/`error` or drop the last-known snapshot when an error fires — both worse than
+/// the single-state design. The `errorMessage` field exists alongside the data precisely
+/// so a transient refresh failure can surface without wiping the previously loaded view.
 class SystemDashboardState extends Equatable {
   const SystemDashboardState({
     this.status = SystemDashboardStatus.initial,


### PR DESCRIPTION
## Summary
Wraps up the sealed-by-default migration that ran from #103 through #113.

- **Phase 4c — Dashboard exception documented.** `SystemDashboardState` is the codebase's one remaining single-state + status enum BLoC. Adds a dartdoc block explaining *why* it stays single-state: it's a transactional snapshot. Every field is part of one coherent dashboard reading; splitting into sealed variants would either duplicate the bundle across `loading`/`loaded`/`error` or wipe the last-known view on a transient refresh failure. This is the textbook "transactional snapshot" exception per the MAIN RULE.

- **Phase 4d — Remove the migration warning banner.** CLAUDE.md's "Migration in progress (May 2026)" banner is no longer accurate: every other BLoC (auth login/forgot-password/change-password, account, register, lifecycle, dynamic-form, user, settings, authority, menu) is now on a pure sealed hierarchy. The MAIN RULE becomes the steady-state convention.

## Coverage
| Feature | State pattern |
| --- | --- |
| auth/login | sealed (#113) |
| auth/forgot-password | sealed (#110) |
| auth/change-password | sealed (#107) |
| auth/register | sealed (#106) |
| account | sealed + documented exception (#108) |
| lifecycle | sealed (#109) |
| dynamic-form | sealed (#111) |
| user | sealed (#112; split deferred to #75) |
| settings | sealed (#104) |
| authority | sealed (#105) |
| dashboard | **single-state — documented transactional-snapshot exception (this PR)** |

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` clean
- [x] `fvm dart analyze` — no issues
- [x] Doc-only change; no code paths affected

After merge: close #81 (project-wide state-pattern inconsistency RFC) as resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)