### PR TITLE
fix(dashboard): clear stale errorMessage on successful reload (fixes #74)

### DIFF
--- a/lib/features/dashboard/application/dashboard_cubit.dart
+++ b/lib/features/dashboard/application/dashboard_cubit.dart
@@ -109,6 +109,7 @@ class SystemDashboardCubit extends Cubit<SystemDashboardState> {
           endpointHealthList: endpointHealthList,
           featureFlags: flags,
           interceptors: interceptors,
+          clearErrorMessage: true,
         ),
       );
 

--- a/lib/features/dashboard/application/dashboard_state.dart
+++ b/lib/features/dashboard/application/dashboard_state.dart
@@ -55,6 +55,7 @@ class SystemDashboardState extends Equatable {
     AppConfigSummary? appConfig,
     List<InterceptorInfo>? interceptors,
     String? errorMessage,
+    bool clearErrorMessage = false,
   }) {
     return SystemDashboardState(
       status: status ?? this.status,
@@ -68,7 +69,7 @@ class SystemDashboardState extends Equatable {
       featureFlags: featureFlags ?? this.featureFlags,
       appConfig: appConfig ?? this.appConfig,
       interceptors: interceptors ?? this.interceptors,
-      errorMessage: errorMessage ?? this.errorMessage,
+      errorMessage: clearErrorMessage ? null : (errorMessage ?? this.errorMessage),
     );
   }
 

--- a/test/features/dashboard/application/dashboard_cubit_test.dart
+++ b/test/features/dashboard/application/dashboard_cubit_test.dart
@@ -113,6 +113,21 @@ void main() {
     );
 
     blocTest<SystemDashboardCubit, SystemDashboardState>(
+      'load() clears stale errorMessage when refresh succeeds after a previous error',
+      build: buildCubit,
+      seed: () => const SystemDashboardState(status: SystemDashboardStatus.error, errorMessage: 'previous failure'),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        isA<SystemDashboardState>()
+            .having((s) => s.status, 'status', SystemDashboardStatus.loading)
+            .having((s) => s.errorMessage, 'errorMessage', 'previous failure'),
+        isA<SystemDashboardState>()
+            .having((s) => s.status, 'status', SystemDashboardStatus.loaded)
+            .having((s) => s.errorMessage, 'errorMessage', isNull),
+      ],
+    );
+
+    blocTest<SystemDashboardCubit, SystemDashboardState>(
       'load() includes circuit breaker endpoint health',
       setUp: () {
         final breaker = CircuitBreaker();


### PR DESCRIPTION
## Summary
- After a failed `load()` set `state.errorMessage`, subsequent successful refreshes kept the stale string in state because `copyWith(field: value ?? this.field)` cannot distinguish "not provided" from "provided as null" — the documented `#74` bug.
- `SystemDashboardState.copyWith` now takes a `clearErrorMessage` bool that explicitly nulls the field; the success path in `load()` passes `clearErrorMessage: true`.
- Added a regression test that seeds an error state, triggers a successful refresh, and asserts `errorMessage` returns to `null` on the `loaded` emission.

## Scope rationale
The other 8 BLoCs originally listed in `#74` (account, settings, users, change_password, forgot_password, lifecycle, dynamic_form, login) were all migrated to sealed hierarchies in PRs `#103–#113`, where the `copyWith` null-clearing class of bug is **structurally impossible** — each variant carries only its own fields. Dashboard is the lone single-state holdout (documented transactional-snapshot exception, `#114`), so this targeted single-field fix is sufficient to close `#74`.

Adding a generic sentinel pattern for one nullable field on one state would be over-engineering; the `clearErrorMessage` bool is the pragmatic, honest minimum.

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` clean
- [x] `fvm dart analyze` — no issues
- [x] `fvm flutter test` — 1387 passed (1386 + new regression)
- [x] New regression test covers the exact stale-error scenario from `#74`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)