### PR TITLE
fix(http): single source of truth for the interceptor chain (closes #60, #63, #64)

### DIFF
--- a/lib/features/dashboard/application/dashboard_cubit.dart
+++ b/lib/features/dashboard/application/dashboard_cubit.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc_advance/core/feature_flags/feature_flag_service.dar
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/cache/shared_prefs_cache_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/circuit_breaker.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/resilience_interceptor.dart';
 
@@ -154,16 +155,15 @@ class SystemDashboardCubit extends Cubit<SystemDashboardState> {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  /// Returns a hardcoded description of the interceptor chain order.
+  /// Snapshot of the live interceptor chain. Pulled from
+  /// [ApiClient.interceptorChainSnapshot] so the dashboard cannot drift
+  /// out of sync when interceptors are added, removed, or conditionally
+  /// included (fixes #64).
   List<InterceptorInfo> _buildInterceptorList() {
-    return const [
-      InterceptorInfo(name: 'AuthInterceptor', order: 1, detail: 'Attaches JWT token to requests'),
-      InterceptorInfo(name: 'TokenRefreshInterceptor', order: 2, detail: 'Refreshes expired access tokens'),
-      InterceptorInfo(name: 'ConnectivityInterceptor', order: 3, detail: 'Rejects requests when offline'),
-      InterceptorInfo(name: 'ResilienceInterceptor', order: 4, detail: 'Retry + circuit breaker'),
-      InterceptorInfo(name: 'CacheInterceptor', order: 5, detail: 'GET response caching with TTL'),
-      InterceptorInfo(name: 'DevConsoleInterceptor', order: 6, detail: 'Logs requests to dev console'),
-      InterceptorInfo(name: 'MockInterceptor', order: 7, active: false, detail: 'Serves mock data in dev/test'),
+    final snapshot = ApiClient.interceptorChainSnapshot;
+    return [
+      for (var i = 0; i < snapshot.length; i++)
+        InterceptorInfo(name: snapshot[i].name, order: i + 1, active: snapshot[i].active, detail: snapshot[i].detail),
     ];
   }
 

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -13,16 +13,30 @@ import 'package:flutter_bloc_advance/infrastructure/http/interceptors/mock_inter
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/resilience_interceptor.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/token_refresh_interceptor.dart';
 
+/// Metadata describing one entry in the [ApiClient] interceptor chain.
+///
+/// Used by the system dashboard and other observers that want to render
+/// the chain without hard-coding names/descriptions. Order matches the
+/// order in which the interceptor was added to Dio.
+class InterceptorChainEntry {
+  const InterceptorChainEntry({required this.name, required this.detail, this.active = true});
+
+  final String name;
+  final String detail;
+  final bool active;
+}
+
 /// Dio-based HTTP client with interceptor chain.
 ///
-/// Interceptor order:
+/// Interceptor order (single source of truth — see `_chainEntries` below):
 /// 1. [ConnectivityInterceptor] — rejects requests immediately when offline
 /// 2. [AuthInterceptor] — injects JWT token
 /// 3. [TokenRefreshInterceptor] — handles 401 responses with token refresh
 /// 4. [ResilienceInterceptor] — smart retry + circuit breaker
 /// 5. [MockInterceptor] — (dev/test only) short-circuits with mock data
-/// 6. [DevConsoleInterceptor] — records requests in debug console
-/// 7. [LoggingInterceptor] — structured request/response logging
+/// 6. [CacheInterceptor] — GET response caching with TTL
+/// 7. [DevConsoleInterceptor] — records requests in debug console
+/// 8. [LoggingInterceptor] — structured request/response logging
 ///
 /// Error mapping happens in the convenience methods ([get], [post], etc.)
 /// which catch [DioException] and rethrow as [AppException] types so that
@@ -34,6 +48,16 @@ class ApiClient {
 
   static Dio? _dio;
   static Dio? _testDio;
+  static List<InterceptorChainEntry> _interceptorChainSnapshot = const [];
+
+  /// Snapshot of the active interceptor chain, in order. Populated the
+  /// first time [instance] is read (i.e. when Dio is built).
+  ///
+  /// Consumers like `SystemDashboardCubit` should read this instead of
+  /// hard-coding names — keeps the dashboard in sync with the chain
+  /// even when interceptors are added, removed, or conditionally
+  /// included (e.g. [MockInterceptor] outside production).
+  static List<InterceptorChainEntry> get interceptorChainSnapshot => List.unmodifiable(_interceptorChainSnapshot);
 
   /// Callback invoked when the session has expired (token refresh failed).
   ///
@@ -73,16 +97,55 @@ class ApiClient {
       ),
     );
 
-    dio.interceptors.addAll([
-      ConnectivityInterceptor(),
-      AuthInterceptor(),
-      TokenRefreshInterceptor(dio: dio, onSessionExpired: onSessionExpired),
-      ResilienceInterceptor(),
-      if (!ProfileConstants.isProduction) MockInterceptor(),
-      CacheInterceptor(),
-      DevConsoleInterceptor(),
-      LoggingInterceptor(),
-    ]);
+    // Single source of truth for the chain: each entry pairs the live
+    // [Interceptor] with the human-readable metadata that the dashboard
+    // shows. Adding/removing an interceptor here automatically updates
+    // [interceptorChainSnapshot] — no separate hardcoded list to drift.
+    final chain = <({Interceptor interceptor, InterceptorChainEntry meta})>[
+      (
+        interceptor: ConnectivityInterceptor(),
+        meta: const InterceptorChainEntry(name: 'ConnectivityInterceptor', detail: 'Rejects requests when offline'),
+      ),
+      (
+        interceptor: AuthInterceptor(),
+        meta: const InterceptorChainEntry(name: 'AuthInterceptor', detail: 'Attaches JWT token to requests'),
+      ),
+      (
+        interceptor: TokenRefreshInterceptor(dio: dio, onSessionExpired: onSessionExpired),
+        meta: const InterceptorChainEntry(name: 'TokenRefreshInterceptor', detail: 'Refreshes expired access tokens'),
+      ),
+      (
+        // Use the shared singleton so dashboard metrics (circuit breakers,
+        // reset actions) target the same instance as real HTTP traffic
+        // (fixes #60).
+        interceptor: ResilienceInterceptor.instance,
+        meta: const InterceptorChainEntry(name: 'ResilienceInterceptor', detail: 'Retry + circuit breaker'),
+      ),
+      if (!ProfileConstants.isProduction)
+        (
+          interceptor: MockInterceptor(),
+          meta: const InterceptorChainEntry(
+            name: 'MockInterceptor',
+            active: false,
+            detail: 'Serves mock data in dev/test',
+          ),
+        ),
+      (
+        interceptor: CacheInterceptor(),
+        meta: const InterceptorChainEntry(name: 'CacheInterceptor', detail: 'GET response caching with TTL'),
+      ),
+      (
+        interceptor: DevConsoleInterceptor(),
+        meta: const InterceptorChainEntry(name: 'DevConsoleInterceptor', detail: 'Records requests in dev console'),
+      ),
+      (
+        interceptor: LoggingInterceptor(),
+        meta: const InterceptorChainEntry(name: 'LoggingInterceptor', detail: 'Structured request/response logging'),
+      ),
+    ];
+
+    dio.interceptors.addAll(chain.map((e) => e.interceptor));
+    _interceptorChainSnapshot = chain.map((e) => e.meta).toList(growable: false);
 
     return dio;
   }

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -298,4 +298,50 @@ void main() {
       expect(decoded, equals(testString));
     });
   });
+
+  // Regression for #63 + #64: the snapshot is the single source of
+  // truth for the interceptor chain — what's exposed here is exactly
+  // what gets registered with Dio. Pin the order + names so future
+  // chain edits surface as a deliberate test update.
+  group('ApiClient.interceptorChainSnapshot (#63, #64)', () {
+    setUp(() {
+      ApiClient.reset();
+    });
+
+    test('is populated after the Dio instance is built', () {
+      // Force lazy build.
+      ApiClient.instance;
+      expect(ApiClient.interceptorChainSnapshot, isNotEmpty);
+    });
+
+    test('lists every interceptor in declared order (non-production includes MockInterceptor)', () {
+      ApiClient.instance;
+      final names = ApiClient.interceptorChainSnapshot.map((e) => e.name).toList();
+
+      expect(names, [
+        'ConnectivityInterceptor',
+        'AuthInterceptor',
+        'TokenRefreshInterceptor',
+        'ResilienceInterceptor',
+        'MockInterceptor',
+        'CacheInterceptor',
+        'DevConsoleInterceptor',
+        'LoggingInterceptor',
+      ]);
+    });
+
+    test('MockInterceptor entry is flagged active=false (dev/test fallback)', () {
+      ApiClient.instance;
+      final mock = ApiClient.interceptorChainSnapshot.firstWhere((e) => e.name == 'MockInterceptor');
+      expect(mock.active, isFalse);
+    });
+
+    test('snapshot is returned as an unmodifiable view', () {
+      ApiClient.instance;
+      expect(
+        () => ApiClient.interceptorChainSnapshot..add(const InterceptorChainEntry(name: 'X', detail: 'X')),
+        throwsUnsupportedError,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Three pre-existing drifts in the HTTP infrastructure (originally flagged by copilot on PR #59) are addressed in one PR because they share the same fix.

| Issue | Drift | Effect |
| --- | --- | --- |
| **#60** | `ApiClient` used `ResilienceInterceptor()` (fresh instance), dashboard reads `ResilienceInterceptor.instance` | Dashboard showed empty circuit-breaker metrics even when real traffic was tripping breakers — two different in-memory registries. |
| **#63** | Doc-comment listing chain order in `api_client.dart` showed 7 entries, real chain has 8 | `CacheInterceptor` missing from the documented order. |
| **#64** | `SystemDashboardCubit._buildInterceptorList()` was a hardcoded list whose order disagreed with the live chain | Connectivity listed third (actually first), `LoggingInterceptor` omitted entirely. Misled admins debugging request flow. |

## Fix

Move the chain into a single source of truth in `ApiClient._createDio`. Each entry is now a record pairing the live `Interceptor` with an `InterceptorChainEntry` metadata struct. The chain registers with Dio and `_interceptorChainSnapshot` is captured at the same point, exposed via `ApiClient.interceptorChainSnapshot`. `SystemDashboardCubit` reads from that snapshot.

**Drift is now structurally impossible** — adding or removing an interceptor requires updating the single list.

```dart
final chain = <({Interceptor interceptor, InterceptorChainEntry meta})>[
  (interceptor: ConnectivityInterceptor(),       meta: const InterceptorChainEntry(name: 'ConnectivityInterceptor', ...)),
  (interceptor: AuthInterceptor(),               meta: const InterceptorChainEntry(name: 'AuthInterceptor', ...)),
  (interceptor: TokenRefreshInterceptor(...),    meta: const InterceptorChainEntry(name: 'TokenRefreshInterceptor', ...)),
  (interceptor: ResilienceInterceptor.instance,  meta: const InterceptorChainEntry(name: 'ResilienceInterceptor', ...)),  // ← #60
  if (!isProduction) (interceptor: MockInterceptor(), meta: const InterceptorChainEntry(name: 'MockInterceptor', active: false, ...)),
  (interceptor: CacheInterceptor(),              meta: const InterceptorChainEntry(name: 'CacheInterceptor', ...)),
  (interceptor: DevConsoleInterceptor(),         meta: const InterceptorChainEntry(name: 'DevConsoleInterceptor', ...)),
  (interceptor: LoggingInterceptor(),            meta: const InterceptorChainEntry(name: 'LoggingInterceptor', ...)),
];

dio.interceptors.addAll(chain.map((e) => e.interceptor));
_interceptorChainSnapshot = chain.map((e) => e.meta).toList(growable: false);
```

Dashboard cubit just iterates the snapshot:
```dart
List<InterceptorInfo> _buildInterceptorList() {
  final snapshot = ApiClient.interceptorChainSnapshot;
  return [
    for (var i = 0; i < snapshot.length; i++)
      InterceptorInfo(name: snapshot[i].name, order: i + 1, active: snapshot[i].active, detail: snapshot[i].detail),
  ];
}
```

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` clean
- [x] `fvm dart analyze` — no issues
- [x] `fvm flutter test` — **1413 passed** (was 1409; +4 new)
- [x] New regression tests in `api_client_test.dart` pin:
  - snapshot is populated after Dio is built
  - order matches the declared sequence including non-production conditional `MockInterceptor`
  - `MockInterceptor` is flagged `active: false`
  - snapshot is returned as an unmodifiable view (defensive against external mutation)

Closes #60
Closes #63
Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)