### PR TITLE
fix: test/UX hygiene cluster from PR #59 (closes #61, #62, #65)

### DIFF
--- a/lib/app/dev_console/tabs/storage_tab.dart
+++ b/lib/app/dev_console/tabs/storage_tab.dart
@@ -7,6 +7,20 @@ import 'package:flutter_bloc_advance/shared/design_system/tokens/app_radius.dart
 class StorageTab extends StatefulWidget {
   const StorageTab({super.key});
 
+  /// Keys whose values must never be shown in plaintext in the dev
+  /// console. Match is case-insensitive substring — any key containing
+  /// one of these markers is masked (fixes #62, which left
+  /// `refreshToken` visible because only the literal `jwtToken` was
+  /// checked).
+  static const sensitiveKeyMarkers = ['token', 'secret', 'password', 'apikey', 'api_key'];
+
+  /// Returns true when [key] should be masked when rendered in the
+  /// storage tab. Exposed for unit testing.
+  static bool isSensitiveKey(String key) {
+    final lower = key.toLowerCase();
+    return sensitiveKeyMarkers.any(lower.contains);
+  }
+
   @override
   State<StorageTab> createState() => _StorageTabState();
 }
@@ -38,10 +52,12 @@ class _StorageTabState extends State<StorageTab> {
   }
 
   String _maskSensitive(String key, String value) {
-    if (key == StorageKeys.jwtToken.key && value.length > 20) {
+    if (!StorageTab.isSensitiveKey(key)) return value;
+    if (value.length > 20) {
       return '${value.substring(0, 10)}...[masked]...${value.substring(value.length - 10)}';
     }
-    return value;
+    // Short tokens get a flat mask — never leak a short secret in full.
+    return '[masked]';
   }
 
   @override

--- a/lib/infrastructure/http/interceptors/connectivity_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/connectivity_interceptor.dart
@@ -16,12 +16,21 @@ class ConnectivityException implements Exception {
 ///
 /// Must be added as the FIRST interceptor in the chain so that requests
 /// are rejected immediately when offline, instead of waiting for a timeout.
+///
+/// The connectivity check is injected via [statusProvider] so tests can
+/// deterministically exercise the offline-rejection branch without
+/// mutating the global [ConnectivityService] singleton (fixes #65).
 class ConnectivityInterceptor extends Interceptor {
+  ConnectivityInterceptor({ConnectivityStatus Function()? statusProvider})
+    : _statusProvider = statusProvider ?? (() => ConnectivityService.instance.currentStatus);
+
   static final _log = AppLogger.getLogger('ConnectivityInterceptor');
+
+  final ConnectivityStatus Function() _statusProvider;
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    final status = ConnectivityService.instance.currentStatus;
+    final status = _statusProvider();
 
     if (status == ConnectivityStatus.offline) {
       _log.warn('Request blocked — device is offline: {} {}', [options.method, options.path]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.20.3+1
+version: 0.21.25+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.41.8 • channel stable • https://github.com/flutter/flutter.git

--- a/test/app/dev_console/tabs/storage_tab_test.dart
+++ b/test/app/dev_console/tabs/storage_tab_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_bloc_advance/app/dev_console/tabs/storage_tab.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StorageTab.isSensitiveKey (#62)', () {
+    test('flags storage keys containing "token" — including refreshToken', () {
+      expect(StorageTab.isSensitiveKey('jwtToken'), isTrue);
+      expect(StorageTab.isSensitiveKey('refreshToken'), isTrue);
+      expect(StorageTab.isSensitiveKey('accessToken'), isTrue);
+    });
+
+    test('flags storage keys containing "secret" / "password" / "apikey"', () {
+      expect(StorageTab.isSensitiveKey('clientSecret'), isTrue);
+      expect(StorageTab.isSensitiveKey('userPassword'), isTrue);
+      expect(StorageTab.isSensitiveKey('xApiKey'), isTrue);
+      expect(StorageTab.isSensitiveKey('api_key'), isTrue);
+    });
+
+    test('match is case-insensitive', () {
+      expect(StorageTab.isSensitiveKey('USER_TOKEN'), isTrue);
+      expect(StorageTab.isSensitiveKey('Password'), isTrue);
+    });
+
+    test('non-sensitive keys are not flagged', () {
+      expect(StorageTab.isSensitiveKey('username'), isFalse);
+      expect(StorageTab.isSensitiveKey('language'), isFalse);
+      expect(StorageTab.isSensitiveKey('theme'), isFalse);
+      expect(StorageTab.isSensitiveKey('roles'), isFalse);
+    });
+  });
+}

--- a/test/core/feature_flags/feature_flag_service_test.dart
+++ b/test/core/feature_flags/feature_flag_service_test.dart
@@ -85,15 +85,23 @@ void main() {
         expect(FeatureFlagService.instance.lastFetched, isNotNull);
       });
 
-      test('should notify listeners', () {
+      test('should notify listeners and stop notifying after removal', () {
+        // Closure identity matters — pass the same reference to both
+        // addListener and removeListener (fixes #61, where two distinct
+        // closures meant removeListener was a no-op and the listener
+        // leaked into later tests).
         int notifyCount = 0;
-        FeatureFlagService.instance.addListener(() => notifyCount++);
+        void listener() => notifyCount++;
+        FeatureFlagService.instance.addListener(listener);
 
         FeatureFlagService.instance.updateFlags({'a': true});
         expect(notifyCount, 1);
 
-        // Clean up listener
-        FeatureFlagService.instance.removeListener(() => notifyCount++);
+        FeatureFlagService.instance.removeListener(listener);
+
+        // Triggering another update must NOT call the listener again.
+        FeatureFlagService.instance.updateFlags({'b': true});
+        expect(notifyCount, 1, reason: 'listener should not fire after removeListener');
       });
     });
 

--- a/test/infrastructure/http/interceptors/connectivity_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/connectivity_interceptor_test.dart
@@ -97,25 +97,23 @@ void main() {
         }
       });
 
-      test('should reject with connectionError type when offline', () {
-        // Test interceptor directly with a handler that captures the rejection
-        final options = RequestOptions(path: '/api/users', method: 'GET');
+      test('should reject with connectionError type when offline (#65 — injected status)', () async {
+        // Fresh interceptor configured to report offline deterministically.
+        final offlineInterceptor = ConnectivityInterceptor(statusProvider: () => ConnectivityStatus.offline);
+        final testDio = Dio(BaseOptions(baseUrl: 'https://test.api'));
+        testDio.interceptors.add(offlineInterceptor);
 
-        // We create a scenario by directly testing what the interceptor would do.
-        // Since ConnectivityService is a singleton, we verify the rejection structure
-        // by examining the code behavior when status would be offline.
-
-        // Verify the interceptor creates the correct DioException structure
-        final dioException = DioException(
-          requestOptions: options,
-          type: DioExceptionType.connectionError,
-          error: const ConnectivityException(),
-          message: 'No internet connection. Please check your network and try again.',
+        await expectLater(
+          testDio.get('/test'),
+          throwsA(
+            allOf([
+              isA<DioException>(),
+              predicate<DioException>((e) => e.type == DioExceptionType.connectionError),
+              predicate<DioException>((e) => e.error is ConnectivityException),
+              predicate<DioException>((e) => (e.message ?? '').contains('No internet connection')),
+            ]),
+          ),
         );
-
-        expect(dioException.type, DioExceptionType.connectionError);
-        expect(dioException.error, isA<ConnectivityException>());
-        expect(dioException.message, contains('No internet connection'));
       });
     });
 


### PR DESCRIPTION
## Summary

Three small, independent fixes from the original PR #59 copilot review, batched into one PR because each is bounded and shares the same "infrastructure correctness" theme.

| Issue | Fix |
| --- | --- |
| **#61** | Test was passing different closure references to `addListener` / `removeListener` → cleanup was a silent no-op, listener leaked into later tests. |
| **#62** | Dev console storage tab masked only the literal `jwtToken` key — `refreshToken` was rendered in plaintext. |
| **#65** | `ConnectivityInterceptor` hardcoded `ConnectivityService.instance`, making the offline-rejection branch untestable. |

## #61 — closure-identity in feature_flag_service_test

```dart
// before
.addListener(() => notifyCount++);
.removeListener(() => notifyCount++);  // ← different closure, no-op

// after
void listener() => notifyCount++;
.addListener(listener);
.removeListener(listener);

// + verification that removal actually disconnects
.updateFlags({'b': true});
expect(notifyCount, 1, reason: 'listener should not fire after removeListener');
```

## #62 — generic sensitive-key masking in storage_tab

```dart
// new public static on StorageTab
static const sensitiveKeyMarkers = ['token', 'secret', 'password', 'apikey', 'api_key'];

static bool isSensitiveKey(String key) {
  final lower = key.toLowerCase();
  return sensitiveKeyMarkers.any(lower.contains);
}
```

- `refreshToken` is now masked (the originally reported bug).
- Future keys containing `secret`/`password`/`apikey` are masked by default.
- Short tokens get a flat `[masked]` instead of leaking in full.

## #65 — injectable status check on ConnectivityInterceptor

```dart
ConnectivityInterceptor({ConnectivityStatus Function()? statusProvider})
  : _statusProvider = statusProvider ?? (() => ConnectivityService.instance.currentStatus);
```

Production wiring (`ApiClient._createDio` → `ConnectivityInterceptor()`) is unchanged because the default falls back to the singleton. Tests now inject `() => ConnectivityStatus.offline` and exercise the real Dio rejection path end-to-end:

```dart
final offlineInterceptor = ConnectivityInterceptor(statusProvider: () => ConnectivityStatus.offline);
final testDio = Dio(BaseOptions(baseUrl: 'https://test.api'));
testDio.interceptors.add(offlineInterceptor);

await expectLater(
  testDio.get('/test'),
  throwsA(allOf([
    isA<DioException>(),
    predicate<DioException>((e) => e.type == DioExceptionType.connectionError),
    predicate<DioException>((e) => e.error is ConnectivityException),
  ])),
);
```

This replaces the previous "verify the DioException structure separately" placeholder that couldn't actually trip the offline branch.

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` clean
- [x] `fvm dart analyze` — no issues
- [x] `fvm flutter test` — **1417 passed** (was 1413; +4 net)
  - New `storage_tab_test.dart` pins the `isSensitiveKey` contract for `refreshToken`, `clientSecret`, `userPassword`, `xApiKey`, plus negative cases (`username`/`language`/`theme`/`roles`)
  - Updated `connectivity_interceptor_test.dart`: real offline-rejection test
  - Updated `feature_flag_service_test.dart`: extra `updateFlags` assertion verifies removal actually disconnected the listener

Closes #61
Closes #62
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)