### PR TITLE
docs: sync README + CLAUDE.md to v0.21.0 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Every feature follows: **Event → BLoC → State → UI**
 ### `Bloc` vs `Cubit`
 
 - Use **`Cubit`** when every interaction is an atomic, fire-and-forget call and the event stream adds no value (no debouncing, no concurrency policy, no historical event payload needed). Example: `SettingsCubit` (`changeLanguage`, `changeTheme`, `logout`).
-- Use **`Bloc`** when events carry meaningful payload, when an `EventTransformer` (debounce, restartable, droppable) is needed, or when the event log itself is valuable for replay/observability. Example: `UserBloc` (search + pagination + CRUD).
+- Use **`Bloc`** when events carry meaningful payload, when an `EventTransformer` (debounce, restartable, droppable) is needed, or when the event log itself is valuable for replay/observability. Examples: `UserListBloc` (search debounce + delete drop-concurrent), `UserEditorBloc` (fetch/save lifecycle), `LoginBloc` (multi-step auth flow).
 - Default to `Bloc` for any new feature touching network requests or user input streams; reach for `Cubit` only after confirming none of the above apply.
 
 ### State Modeling — MAIN RULE
@@ -89,30 +89,32 @@ Every feature follows: **Event → BLoC → State → UI**
 **Default to sealed state hierarchies** that leverage Dart 3's `sealed` modifier and exhaustive `switch` expressions. The compiler enforces handling of every state variant; UIs render via pattern matching.
 
 ```dart
-// State
-sealed class UserState extends Equatable {
-  const UserState();
+// State (real example: lib/features/users/application/user_list_state.dart)
+sealed class UserListState extends Equatable {
+  const UserListState();
 }
-final class UserInitial extends UserState { /* ... */ }
-final class UserLoading extends UserState { /* ... */ }
-final class UserLoaded extends UserState {
-  const UserLoaded(this.users);
+final class UserListInitial extends UserListState { /* ... */ }
+final class UserListLoading extends UserListState { /* ... */ }
+final class UserListLoaded extends UserListState {
+  const UserListLoaded({required this.users});
   final List<UserEntity> users;
   @override List<Object?> get props => [users];
 }
-final class UserFailure extends UserState {
-  const UserFailure(this.errorCode);
-  final String errorCode;
-  @override List<Object?> get props => [errorCode];
+final class UserListDeleteSuccess extends UserListState { /* ... */ }
+final class UserListFailure extends UserListState {
+  const UserListFailure({required this.error});
+  final String error;
+  @override List<Object?> get props => [error];
 }
 
 // UI
-BlocBuilder<UserBloc, UserState>(
+BlocBuilder<UserListBloc, UserListState>(
   builder: (context, state) => switch (state) {
-    UserInitial() => const SizedBox.shrink(),
-    UserLoading() => const Loading(),
-    UserLoaded(:final users) => UserList(users),
-    UserFailure(:final errorCode) => ErrorBanner(errorCode),
+    UserListInitial() => const SizedBox.shrink(),
+    UserListLoading() => const Loading(),
+    UserListLoaded(:final users) => UserList(users),
+    UserListDeleteSuccess() => const SizedBox.shrink(),
+    UserListFailure(:final error) => ErrorBanner(error),
   },
 );
 ```
@@ -139,7 +141,7 @@ When in doubt, prefer sealed and split the BLoC instead of growing the single st
 ## Environments
 
 - **dev/test** → mock data from `assets/mock/*.json`
-- **prod** → real API (configured in `lib/app/configuration/environment.dart`)
+- **prod** → real API (configured in `lib/infrastructure/config/environment.dart`)
 
 ## Adding a New Feature
 

--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ The production environment is configured in `lib/infrastructure/config/environme
 | --- | --- |
 | Flutter | 3.44.0 |
 | Dart | 3.12.0 |
-| State Management | flutter_bloc 9.1.1 |
-| Routing | go_router 17.1.0 |
-| HTTP | dio 5.7.0 (interceptor chain: auth, logging, mock) |
+| State Management | flutter_bloc 9.1.1, bloc_concurrency 0.3.0, stream_transform 2.1.1 |
+| Routing | go_router 17.2.3 |
+| HTTP | dio 5.9.2 (interceptor chain: connectivity, auth, token-refresh, resilience, mock, cache, dev-console, logging) |
 | Forms | flutter_form_builder 10.3.0+2 |
 | Localization | intl 0.20.2, intl_utils 2.8.14 |
-| Storage | shared_preferences 2.5.4 |
-| Charts | fl_chart 1.1.1 |
-| Testing | flutter_test, bloc_test, mocktail |
+| Storage | shared_preferences 2.5.5, flutter_secure_storage 10.2.0 |
+| Charts | fl_chart 1.2.0 |
+| Testing | flutter_test, bloc_test, mocktail, test 1.31.0 |
 
 ## Project Structure
 
@@ -338,7 +338,8 @@ If you are unsure where to start, documentation improvements, screenshot refresh
 | [Transformation Log](docs/clean-modernize-strengthen.md) | What changed, why, before/after comparison |
 | [Architecture Migration](docs/architecture-migration_en.md) | Feature-first migration guide |
 | [Feature-First Boundaries](docs/feature-first-clean-boundaries.md) | Clean architecture design document |
-| [Upgrade Guide](docs/upgrade_flutter_3.44.0.md) | Flutter 3.44.0 upgrade notes |
+| [Upgrade Guide — Flutter 3.44.0](docs/upgrade_flutter_3.44.0.md) | Flutter 3.41.8 → 3.44.0 upgrade notes (v0.21.0) |
+| [Upgrade Guide — Flutter 3.41.4](docs/upgrade_flutter_3.41.4.md) | Historical: Flutter 3.41.4 upgrade notes (v0.18.0) |
 
 ## References
 

--- a/docs/upgrade_flutter_3.44.0.md
+++ b/docs/upgrade_flutter_3.44.0.md
@@ -1,0 +1,174 @@
+# Upgrade Guide — Flutter 3.44.0
+
+**Date:** 2026-05-20
+**Flutter:** 3.41.8 → 3.44.0
+**Dart:** 3.11.5 → 3.12.0
+**App Version:** 0.20.0 → 0.21.0
+
+This guide captures what changed when the template upgraded to Flutter 3.44.0 / Dart 3.12.0 alongside the **enterprise BLoC audit** that shipped in [v0.21.0](https://github.com/cevheri/flutter-bloc-advanced/releases/tag/v0.21.0). If you maintain a fork or a downstream template, use this as a punch list.
+
+> **Full release notes** are on the [v0.21.0 release page](https://github.com/cevheri/flutter-bloc-advanced/releases/tag/v0.21.0).
+
+---
+
+## 1. Toolchain bumps
+
+| Component | Before | After |
+| --- | --- | --- |
+| Flutter | 3.41.8 | 3.44.0 |
+| Dart SDK | ^3.11.5 | ^3.12.0 |
+| FVM pin | `3.41.8` | `3.44.0` |
+
+Pin Flutter via [FVM](https://fvm.app):
+
+```bash
+fvm install 3.44.0
+fvm use 3.44.0
+fvm flutter --version   # confirm
+```
+
+The repo's `.fvmrc` and `pubspec.yaml` environment constraint already enforce this.
+
+---
+
+## 2. Resolution conflict — `test_api`
+
+Flutter 3.44 SDK pins `test_api: 0.7.11`. The previous `test: 1.30.0` dev-dependency transitively pinned `test_api: 0.7.10` — conflict.
+
+**Fix:** bump `test` to `1.31.0` (or `^1.31.0`). Done in [#126](https://github.com/cevheri/flutter-bloc-advanced/pull/126); your fork needs the same edit if you've pinned `test` to an older version.
+
+---
+
+## 3. Dart 3.12 lint: `prefer_initializing_formals`
+
+Dart 3.12 strengthens `prefer_initializing_formals`. Many constructors written as:
+
+```dart
+SomeBloc({required SomeUseCase someUseCase})
+  : _someUseCase = someUseCase,
+    super(...);
+```
+
+now flag at `info` level. Either:
+- Use initializing formals where the field name matches the parameter, or
+- Accept the info and move on (lints, not errors).
+
+The template's audit chose the initializing-formal style in commit `29d1178` to keep the analyzer clean.
+
+---
+
+## 4. New `ListTile` ↔ `DecoratedBox` assertion (the big one)
+
+Flutter 3.44 introduced a runtime assertion that fires when a `ListTile` finds a coloured `DecoratedBox` between itself and the nearest `Material`:
+
+```
+ListTile background color or ink splashes may be invisible.
+The ListTile is wrapped in a DecoratedBox that has a background color.
+```
+
+This breaks any custom card / form container that uses `Container(decoration: BoxDecoration(color: ...))` and renders a `ListTile` (or `SwitchListTile`, `CheckboxListTile`) underneath. In this template that included:
+
+- `AppFormCard` containing `FormBuilderSwitch` (which renders an internal `SwitchListTile`)
+- `AppCard` containing the settings screen's `ListTile`s
+
+### Fix patterns
+
+**`AppFormCard`** — outer `Container(decoration:)` replaced with `Material(shape: ...)`:
+
+```dart
+Material(
+  color: cs.surface,
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(AppRadius.lg),
+    side: BorderSide(color: cs.outlineVariant),
+  ),
+  clipBehavior: Clip.antiAlias,
+  child: ...,
+)
+```
+
+**`AppCard`** — the `AnimatedContainer` is kept for hover animations; an interior transparent `Material` gives ListTiles their required ancestor:
+
+```dart
+AnimatedContainer(
+  decoration: _decoration(colorScheme),
+  child: Material(
+    type: MaterialType.transparency,
+    child: Padding(...),
+  ),
+)
+```
+
+If your fork has its own card/list widgets, scan for `Container(decoration: BoxDecoration(color: ...))` ancestors of `ListTile` and apply one of the two patterns above. See [#125](https://github.com/cevheri/flutter-bloc-advanced/pull/125) for the full diff.
+
+---
+
+## 5. Android migrator flags
+
+Running `flutter pub get` under 3.44 auto-injects two opt-out flags into `android/gradle.properties`:
+
+```
+android.builtInKotlin=false
+android.newDsl=false
+```
+
+These opt out of two new AGP behaviours that the template doesn't yet adopt:
+- `builtInKotlin` — AGP 8.x's built-in Kotlin support (we still apply `id("kotlin-android")` explicitly).
+- `newDsl` — AGP's new DSL surface.
+
+**Commit these flags** so subsequent `pub get` runs don't repeatedly mark the tree dirty. Migration to the new behaviours is a separate future project — out of scope for the Flutter upgrade itself.
+
+---
+
+## 6. Dependency refresh (latest LTS)
+
+After the toolchain settled, we stripped every direct dependency to `any`, ran `flutter pub upgrade`, and re-pinned to the resolved latest. Notable bumps:
+
+| Package | Before | After | Notes |
+| --- | --- | --- | --- |
+| `go_router` | 17.2.2 | 17.2.3 | patch |
+| `flutter_secure_storage` | 10.0.0 | 10.2.0 | minor (+ darwin/windows backends) |
+| `package_info_plus` | 9.0.1 | **10.1.0** | **major** — API-compatible at our use site |
+
+Every other direct dep was already on latest. See [#126](https://github.com/cevheri/flutter-bloc-advanced/pull/126).
+
+If your fork uses `package_info_plus` beyond `PackageInfo.fromPlatform()`, check the [10.0 changelog](https://pub.dev/packages/package_info_plus/changelog) for breaking changes — there's a few platform-channel adjustments.
+
+---
+
+## 7. Test impact
+
+- Before fixes: **8 widget tests failed** under Flutter 3.44 due to the `ListTile` assertion (settings + user-editor + user-list pages).
+- After the design-system fix: **1417 tests pass**, `dart analyze` clean, `dart format --line-length=120` enforced.
+
+---
+
+## 8. BLoC architecture changes (v0.21.0)
+
+The Flutter upgrade landed alongside an enterprise audit that rewrote substantial parts of the BLoC layer. If you've vendored any of these:
+
+- `UserBloc` was split into `UserListBloc` + `UserEditorBloc` ([#75](https://github.com/cevheri/flutter-bloc-advanced/pull/122))
+- `LoginBloc` constructor now requires `persistAuthSessionUseCase` ([#71](https://github.com/cevheri/flutter-bloc-advanced/pull/116))
+- `DynamicFormBloc` constructor now requires `loadFormSchemaUseCase` + `submitFormUseCase` ([#72](https://github.com/cevheri/flutter-bloc-advanced/pull/120))
+- `AuthorityBloc` constructor takes `ListAuthoritiesUseCase` instead of the repository directly ([#73](https://github.com/cevheri/flutter-bloc-advanced/pull/117))
+- `LoginErrorState` and `SettingsFailure` now require a typed `errorCode: AppErrorCode` parameter ([#77](https://github.com/cevheri/flutter-bloc-advanced/pull/118))
+- Every error state moved to a Dart 3 sealed hierarchy ([#103–#114](https://github.com/cevheri/flutter-bloc-advanced/releases/tag/v0.21.0))
+
+The full breaking-changes table is in the [v0.21.0 release notes](https://github.com/cevheri/flutter-bloc-advanced/releases/tag/v0.21.0).
+
+---
+
+## Verification checklist
+
+After your upgrade, confirm:
+
+```bash
+fvm flutter --version           # 3.44.0
+fvm dart --version              # 3.12.0
+fvm flutter pub get             # no resolution conflicts
+fvm dart analyze                # no issues
+fvm flutter test                # all green
+fvm flutter build apk --target lib/main/main_prod.dart   # production build OK
+```
+
+If anything fails, check this guide's relevant section or open an issue.


### PR DESCRIPTION
## Summary

After the v0.21.0 release I scanned `README.md` and `CLAUDE.md` for statements that drifted during the sprint. Found 8 (4 each).

## README.md (drifted versions + broken link)

| Site | Was | Now |
| --- | --- | --- |
| Tech stack table — Routing | `go_router 17.1.0` | `go_router 17.2.3` |
| Tech stack table — HTTP | `dio 5.7.0 (interceptor chain: auth, logging, mock)` | `dio 5.9.2 (interceptor chain: connectivity, auth, token-refresh, resilience, mock, cache, dev-console, logging)` |
| Tech stack table — Storage | `shared_preferences 2.5.4` | `shared_preferences 2.5.5, flutter_secure_storage 10.2.0` |
| Tech stack table — Charts | `fl_chart 1.1.1` | `fl_chart 1.2.0` |
| Doc table | Broken link to `docs/upgrade_flutter_3.44.0.md` | Now points at a real file + the historical 3.41.4 doc is labelled as such |

Also added `bloc_concurrency`, `stream_transform`, and `test 1.31.0` to the table — they were already in use but not surfaced.

## CLAUDE.md (stale class references)

| Site | Was | Now |
| --- | --- | --- |
| L84 "Bloc vs Cubit" example | `UserBloc (search + pagination + CRUD)` | `UserListBloc`, `UserEditorBloc`, `LoginBloc` with one-line reasons each |
| L93–117 sealed-state code example | `UserState / UserLoaded / UserFailure` (classes deleted in #75) | `UserListState / UserListLoaded / UserListDeleteSuccess / UserListFailure` matching the real file at `lib/features/users/application/user_list_state.dart` |
| L142 environments path | `lib/app/configuration/environment.dart` | `lib/infrastructure/config/environment.dart` (moved during the feature-first migration) |

## New file — `docs/upgrade_flutter_3.44.0.md`

This is what the README's "Upgrade Guide" row was pointing at — the file didn't exist. Created as a companion to the v0.21.0 release notes:

- §1 toolchain bumps + FVM steps
- §2 `test_api` resolution conflict + fix
- §3 `prefer_initializing_formals` lint
- §4 **The big one** — Flutter 3.44 `ListTile`↔`DecoratedBox` assertion, with the AppFormCard + AppCard fix patterns and code snippets
- §5 Android migrator flags (`builtInKotlin`, `newDsl`) — commit them so subsequent `pub get` doesn't keep marking the tree dirty
- §6 Dep refresh table (`go_router`, `flutter_secure_storage`, `package_info_plus` major)
- §7 Test impact
- §8 BLoC architecture changes that affect fork maintainers (with PR links)
- §9 Verification checklist

## Test plan
- [x] `fvm dart format . --line-length=120 --set-exit-if-changed` clean (no code touched)
- [x] No code changes — pure documentation
- [x] Verified version numbers in the README table now match `pubspec.yaml` exactly
- [x] `CLAUDE.md` no longer references the deleted `UserBloc` symbol
- [x] `docs/upgrade_flutter_3.44.0.md` link in README resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)