### PR TITLE
feat(#129): wire SecureStorage into DI and mask JWTs in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ The screenshots below are included to help contributors and adopters understand 
 - Forgot password flow
 - OTP send and verify flow
 - **Token storage** — JWT and refresh tokens are persisted via `flutter_secure_storage`
-  (iOS Keychain, Android Keystore-backed `EncryptedSharedPreferences`). Non-secret session
-  fields (`username`, `roles`) remain in `SharedPreferences` for synchronous access.
-  The first launch after upgrading from an older build runs a one-shot migration from
-  the legacy plaintext keys into secure storage.
+  (iOS Keychain, Android custom AES-GCM ciphers). Keychain accessibility is pinned to
+  `first_unlock_this_device` so tokens stay on the device (no iCloud Keychain sync).
+  Non-secret session fields (`username`, `roles`) remain in `SharedPreferences` for
+  synchronous access. The first launch after upgrading from an older build runs a one-shot
+  migration from the legacy plaintext keys into secure storage.
 
 ### User Management
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ The screenshots below are included to help contributors and adopters understand 
 - Registration flow
 - Forgot password flow
 - OTP send and verify flow
+- **Token storage** — JWT and refresh tokens are persisted via `flutter_secure_storage`
+  (iOS Keychain, Android Keystore-backed `EncryptedSharedPreferences`). Non-secret session
+  fields (`username`, `roles`) remain in `SharedPreferences` for synchronous access.
+  The first launch after upgrading from an older build runs a one-shot migration from
+  the legacy plaintext keys into secure storage.
 
 ### User Management
 

--- a/docs/superpowers/plans/2026-05-20-secure-storage-wiring.md
+++ b/docs/superpowers/plans/2026-05-20-secure-storage-wiring.md
@@ -12,6 +12,27 @@
 **Issue:** [#129](https://github.com/cevheri/flutter_bloc_advance/issues/129)
 **Branch:** `feat/129-secure-storage-wiring` (already created)
 
+> **Historical note — superseded by shipped architecture.** This plan
+> was written before PR review revealed that caching the JWT in
+> `AppLocalStorageCached.jwtToken` (Tasks 7 and 8) forces six
+> coordinated write paths to stay in sync (persist, refresh, logout,
+> rollback, clear, bootstrap) — each a potential stale-token bug. The
+> shipped implementation removes the JWT cache entirely:
+>
+> - `AuthInterceptor` reads JWT directly from `ISecureStorage` on every
+>   request — no cache, no fallback.
+> - `SessionCubit.restore` reads from `ISecureStorage`, runs the pure
+>   `SecurityUtils.hasToken` / `isTokenExpired` checks, and emits the
+>   derived `isAuthenticated` boolean (which is the sync state UI/router
+>   consumers read).
+> - Repository, refresh interceptor, and logout no longer mutate any
+>   cache field.
+>
+> Tasks 7 (cache loadCache from SecureStorage) and 8 (AuthInterceptor
+> reads cached field) below describe a design that was not shipped. Tasks
+> 1-6 and 9-13 still match the codebase; see the spec doc for the final
+> architecture.
+
 ---
 
 ## Task 1: `LogSanitizer.maskToken` utility

--- a/docs/superpowers/plans/2026-05-20-secure-storage-wiring.md
+++ b/docs/superpowers/plans/2026-05-20-secure-storage-wiring.md
@@ -1,0 +1,1431 @@
+# SecureStorage Wiring + JWT Masking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist JWT and refresh token through `flutter_secure_storage` instead of plaintext SharedPreferences, add structural log masking for tokens, and migrate existing installations without forcing logout.
+
+**Architecture:** Split `StorageKeys` into a `SecureStorageKeys` enum (jwtToken, refreshToken) and a `StorageKeys` enum (username, roles, language, theme, brightness). `AuthSessionRepository` accepts both backends and performs cross-backend atomic-write rollback. `SessionMigration` runs once at bootstrap to copy legacy values from SharedPreferences to SecureStorage. `LogSanitizer.maskToken` is used at log sites and overridden in `AuthSession.toString()` so the JWT is structurally unloggable.
+
+**Tech Stack:** Flutter 3.44 · Dart 3.x · `flutter_secure_storage` · `shared_preferences` · `dio` · `flutter_test` · `mocktail`
+
+**Spec:** `docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md`
+**Issue:** [#129](https://github.com/cevheri/flutter_bloc_advance/issues/129)
+**Branch:** `feat/129-secure-storage-wiring` (already created)
+
+---
+
+## Task 1: `LogSanitizer.maskToken` utility
+
+**Files:**
+- Create: `lib/core/logging/log_sanitizer.dart`
+- Create: `test/core/logging/log_sanitizer_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/core/logging/log_sanitizer_test.dart
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LogSanitizer.maskToken', () {
+    test('returns <empty> for null', () {
+      expect(LogSanitizer.maskToken(null), '<empty>');
+    });
+
+    test('returns <empty> for empty string', () {
+      expect(LogSanitizer.maskToken(''), '<empty>');
+    });
+
+    test('returns <redacted> for tokens shorter than 8 chars', () {
+      expect(LogSanitizer.maskToken('a'), '<redacted>');
+      expect(LogSanitizer.maskToken('1234567'), '<redacted>');
+    });
+
+    test('masks the middle of an 8-char token', () {
+      expect(LogSanitizer.maskToken('12345678'), '1234…5678');
+    });
+
+    test('masks a realistic JWT', () {
+      const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature';
+      final masked = LogSanitizer.maskToken(jwt);
+      expect(masked, startsWith('eyJh'));
+      expect(masked, endsWith('ture'));
+      expect(masked.contains('payload'), isFalse);
+      expect(masked.contains('signature'), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+fvm flutter test test/core/logging/log_sanitizer_test.dart
+```
+
+Expected: FAIL with "Target of URI doesn't exist: 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart'".
+
+- [ ] **Step 3: Implement `LogSanitizer`**
+
+```dart
+// lib/core/logging/log_sanitizer.dart
+
+/// Utilities for sanitizing sensitive values before they reach a log sink.
+class LogSanitizer {
+  /// Returns a redacted preview of a token suitable for logs.
+  ///
+  /// - `null` or empty → `<empty>`
+  /// - shorter than 8 characters → `<redacted>`
+  /// - otherwise → `XXXX…YYYY` (first 4 + last 4)
+  static String maskToken(String? token) {
+    if (token == null || token.isEmpty) return '<empty>';
+    if (token.length < 8) return '<redacted>';
+    return '${token.substring(0, 4)}…${token.substring(token.length - 4)}';
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+fvm flutter test test/core/logging/log_sanitizer_test.dart
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/logging/log_sanitizer.dart test/core/logging/log_sanitizer_test.dart
+git commit -m "feat(#129): add LogSanitizer.maskToken helper"
+```
+
+---
+
+## Task 2: `AuthSession.toString()` override
+
+**Files:**
+- Modify: `lib/features/auth/domain/entities/auth_session.dart`
+- Create: `test/features/auth/domain/entities/auth_session_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/features/auth/domain/entities/auth_session_test.dart
+import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthSession.toString', () {
+    test('masks idToken and refreshToken', () {
+      const session = AuthSession(
+        idToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+        refreshToken: 'refresh-token-value-12345',
+        username: 'alice',
+        roles: ['ROLE_USER'],
+      );
+
+      final rendered = session.toString();
+
+      expect(rendered.contains('payload'), isFalse);
+      expect(rendered.contains('refresh-token-value-12345'), isFalse);
+      expect(rendered, contains('alice'));
+      expect(rendered, contains('ROLE_USER'));
+    });
+
+    test('renders empty marker when refreshToken is null', () {
+      const session = AuthSession(idToken: 'eyJhbGc.payload.signature', username: 'alice');
+      expect(session.toString(), contains('refreshToken: <empty>'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+fvm flutter test test/features/auth/domain/entities/auth_session_test.dart
+```
+
+Expected: FAIL — default `toString()` exposes raw token values.
+
+- [ ] **Step 3: Add `toString()` override**
+
+Modify `lib/features/auth/domain/entities/auth_session.dart`. Add the import and override:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
+
+/// Value object representing a fully-formed authenticated session.
+/// ... (existing docstring unchanged)
+class AuthSession extends Equatable {
+  const AuthSession({required this.idToken, required this.username, this.refreshToken, this.roles = const []})
+    : assert(idToken != '', 'idToken must be non-empty');
+
+  final String idToken;
+  final String? refreshToken;
+  final String username;
+  final List<String> roles;
+
+  @override
+  List<Object?> get props => [idToken, refreshToken, username, roles];
+
+  /// Tokens are masked so this is safe to embed in log output, even if
+  /// `Equatable.stringify` is later flipped on for diagnostic reasons.
+  @override
+  String toString() => 'AuthSession('
+      'idToken: ${LogSanitizer.maskToken(idToken)}, '
+      'refreshToken: ${LogSanitizer.maskToken(refreshToken)}, '
+      'username: $username, '
+      'roles: $roles)';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+fvm flutter test test/features/auth/domain/entities/auth_session_test.dart
+```
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/features/auth/domain/entities/auth_session.dart test/features/auth/domain/entities/auth_session_test.dart
+git commit -m "feat(#129): mask tokens in AuthSession.toString()"
+```
+
+---
+
+## Task 3: Split `StorageKeys` — introduce `SecureStorageKeys`
+
+**Files:**
+- Modify: `lib/infrastructure/storage/secure_storage.dart` (add enum)
+- Modify: `lib/infrastructure/storage/local_storage.dart` (remove `jwtToken` and `refreshToken` from `StorageKeys`)
+
+> **Note:** This task intentionally breaks compilation for callers that still reference `StorageKeys.jwtToken` / `StorageKeys.refreshToken`. Subsequent tasks (4–12) repair each call site. Run `fvm dart analyze` after each subsequent task; the error list shrinks until it's empty after Task 12.
+
+- [ ] **Step 1: Add `SecureStorageKeys` enum to `secure_storage.dart`**
+
+Insert at the bottom of `lib/infrastructure/storage/secure_storage.dart` (after `FlutterSecureStorageAdapter`):
+
+```dart
+/// Keys for values that must be stored in the platform-backed secure
+/// store (iOS Keychain, Android EncryptedSharedPreferences).
+///
+/// Renaming an enum value will NOT change the stored key, so user data
+/// survives refactors safely. Add new entries by appending — do not
+/// change existing [key] strings without a migration.
+enum SecureStorageKeys {
+  jwtToken('jwtToken'),
+  refreshToken('refreshToken');
+
+  const SecureStorageKeys(this.key);
+
+  final String key;
+}
+```
+
+- [ ] **Step 2: Remove `jwtToken` and `refreshToken` from `StorageKeys`**
+
+Modify `lib/infrastructure/storage/local_storage.dart`:
+
+```dart
+enum StorageKeys {
+  roles('roles'),
+  language('language'),
+  username('username'),
+  theme('theme'),
+  brightness('brightness');
+
+  const StorageKeys(this.key);
+
+  final String key;
+}
+```
+
+- [ ] **Step 3: Verify the analyzer surfaces the expected breaks**
+
+```bash
+fvm dart analyze
+```
+
+Expected: errors at the call sites we will repair in Tasks 4, 8, 9, 10, 12 (e.g. `auth_session_repository_impl.dart`, `auth_interceptor.dart`, `token_refresh_interceptor.dart`, `local_storage.dart:16`, test files). The exact count is informational — we just need to confirm the breaks are localized.
+
+- [ ] **Step 4: Commit (does not build green yet; that is intentional)**
+
+```bash
+git add lib/infrastructure/storage/secure_storage.dart lib/infrastructure/storage/local_storage.dart
+git commit -m "refactor(#129): split SecureStorageKeys from StorageKeys"
+```
+
+---
+
+## Task 4: Wire `ISecureStorage` into `AppDependencies` and `AppScope`
+
+**Files:**
+- Modify: `lib/app/di/app_dependencies.dart`
+- Modify: `lib/app/di/app_scope.dart`
+
+- [ ] **Step 1: Add factory to `AppDependencies`**
+
+Modify `lib/app/di/app_dependencies.dart`. Add the import and method:
+
+```dart
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+// inside class AppDependencies, alphabetical-ish ordering with the others:
+ISecureStorage createSecureStorage() => FlutterSecureStorageAdapter();
+```
+
+- [ ] **Step 2: Expose via `AppScope` as a `RepositoryProvider`**
+
+Modify `lib/app/di/app_scope.dart`. Add the import and provider:
+
+```dart
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+// inside MultiRepositoryProvider.providers list, near the top:
+RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
+```
+
+- [ ] **Step 3: Run analyzer**
+
+```bash
+fvm dart analyze lib/app/di/
+```
+
+Expected: no new errors in the DI files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/app/di/app_dependencies.dart lib/app/di/app_scope.dart
+git commit -m "feat(#129): expose ISecureStorage through AppDependencies and AppScope"
+```
+
+---
+
+## Task 5: `AuthSessionRepository` — cross-backend persist + rollback
+
+**Files:**
+- Modify: `lib/features/auth/data/repositories/auth_session_repository_impl.dart`
+- Modify: `lib/app/di/app_dependencies.dart` (update `createAuthSessionRepository` to inject secure storage)
+- Modify: `lib/app/di/app_scope.dart` (read `ISecureStorage` from context when creating repo)
+- Modify: `test/features/auth/data/repositories/auth_session_repository_impl_test.dart`
+
+- [ ] **Step 1: Replace repository test with cross-backend version**
+
+Overwrite `test/features/auth/data/repositories/auth_session_repository_impl_test.dart` with:
+
+```dart
+import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/auth/data/repositories/auth_session_repository_impl.dart';
+import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../../test_utils.dart';
+
+/// In-memory ISecureStorage for tests.
+class _MemorySecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
+/// Storage fake that lets a test choose which key's `save` should fail.
+class _FlakyStorage implements AppLocalStorage {
+  _FlakyStorage(this._inner, this.failOnKey);
+  final AppLocalStorage _inner;
+  final String failOnKey;
+  final removedKeys = <String>[];
+  @override
+  Future<bool> save(String key, dynamic value) async {
+    if (key == failOnKey) return false;
+    return _inner.save(key, value);
+  }
+  @override
+  Future<bool> remove(String key) async {
+    removedKeys.add(key);
+    return _inner.remove(key);
+  }
+  @override
+  Future<dynamic> read(String key) => _inner.read(key);
+  @override
+  Future<void> clear() => _inner.clear();
+  @override
+  void setPreferencesInstance(SharedPreferences prefs) => _inner.setPreferencesInstance(prefs);
+}
+
+void main() {
+  late AppLocalStorage storage;
+  late _MemorySecureStorage secure;
+
+  setUpAll(() async {
+    await TestUtils().setupUnitTest();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    storage = AppLocalStorage();
+    storage.setPreferencesInstance(await SharedPreferences.getInstance());
+    secure = _MemorySecureStorage();
+  });
+
+  tearDown(() async {
+    await TestUtils().tearDownUnitTest();
+  });
+
+  group('AuthSessionRepository', () {
+    test('persist routes tokens to secure storage, username/roles to local', () async {
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
+      const session = AuthSession(idToken: 'TOKEN', refreshToken: 'REFRESH', username: 'alice', roles: ['ROLE_USER']);
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Success<void>>());
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), 'TOKEN');
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), 'REFRESH');
+      expect(await storage.read(StorageKeys.username.key), 'alice');
+      expect(await storage.read(StorageKeys.roles.key), ['ROLE_USER']);
+    });
+
+    test('persist deletes refreshToken from secure storage when null', () async {
+      await secure.write(SecureStorageKeys.refreshToken.key, 'STALE');
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
+      const session = AuthSession(idToken: 'TOKEN', username: 'alice');
+
+      await repo.persist(session);
+
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), isNull);
+    });
+
+    test('persist rolls back secure writes when a local write fails', () async {
+      final flaky = _FlakyStorage(storage, StorageKeys.username.key);
+      final repo = AuthSessionRepository(secureStorage: secure, storage: flaky);
+      const session = AuthSession(idToken: 'TOKEN', refreshToken: 'REFRESH', username: 'alice');
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Failure<void>>());
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull, reason: 'secure token rolled back');
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), isNull, reason: 'secure refresh rolled back');
+      expect(await storage.read(StorageKeys.username.key), isNull);
+    });
+
+    test('clear empties both backends', () async {
+      await secure.write(SecureStorageKeys.jwtToken.key, 'TOKEN');
+      await storage.save(StorageKeys.username.key, 'alice');
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
+
+      final result = await repo.clear();
+
+      expect(result, isA<Success<void>>());
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull);
+      expect(await storage.read(StorageKeys.username.key), isNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+fvm flutter test test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+```
+
+Expected: FAIL — constructor signature, persist routing, and `clear` cross-backend behavior are not yet implemented.
+
+- [ ] **Step 3: Rewrite the repository**
+
+Replace `lib/features/auth/data/repositories/auth_session_repository_impl.dart`:
+
+```dart
+import 'package:flutter_bloc_advance/core/errors/app_error.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/core/result/result.dart';
+import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
+import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+/// Persistence-layer implementation of [IAuthSessionRepository].
+///
+/// Routes sensitive fields (idToken, refreshToken) to [ISecureStorage]
+/// (Keychain / EncryptedSharedPreferences) and non-secret fields
+/// (username, roles) to [AppLocalStorage] (SharedPreferences).
+///
+/// Neither backend supports transactions, so atomicity is emulated
+/// across both: writes happen in order, and on any failure the keys
+/// that were successfully written during this call are removed —
+/// across both backends — before the failure is reported. The caller
+/// therefore never sees a half-written session.
+class AuthSessionRepository implements IAuthSessionRepository {
+  AuthSessionRepository({required ISecureStorage secureStorage, AppLocalStorage? storage})
+      : _secureStorage = secureStorage,
+        _storage = storage ?? AppLocalStorage();
+
+  static final _log = AppLogger.getLogger('AuthSessionRepository');
+
+  final ISecureStorage _secureStorage;
+  final AppLocalStorage _storage;
+
+  @override
+  Future<Result<void>> persist(AuthSession session) async {
+    final writtenSecure = <SecureStorageKeys>[];
+    final writtenLocal = <StorageKeys>[];
+    try {
+      await _writeSecure(SecureStorageKeys.jwtToken, session.idToken, writtenSecure);
+      if (session.refreshToken != null) {
+        await _writeSecure(SecureStorageKeys.refreshToken, session.refreshToken!, writtenSecure);
+      } else {
+        // Owner-of-keys contract: a session without a refresh token must
+        // not inherit one from a previous login. Best-effort removal.
+        await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
+      }
+      await _writeLocal(StorageKeys.username, session.username, writtenLocal);
+      await _writeLocal(StorageKeys.roles, session.roles, writtenLocal);
+      return const Success(null);
+    } catch (e) {
+      _log.error('persist failed after {} secure + {} local writes; rolling back: {}',
+                 [writtenSecure.length, writtenLocal.length, e]);
+      await _rollback(writtenSecure, writtenLocal);
+      return Failure(UnknownError('Session persistence failed: $e'));
+    }
+  }
+
+  @override
+  Future<Result<void>> clear() async {
+    try {
+      await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
+      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
+      await _storage.clear();
+      return const Success(null);
+    } catch (e) {
+      return Failure(UnknownError('Session clear failed: $e'));
+    }
+  }
+
+  Future<void> _writeSecure(SecureStorageKeys key, String value, List<SecureStorageKeys> written) async {
+    await _secureStorage.write(key.key, value);
+    written.add(key);
+  }
+
+  Future<void> _writeLocal(StorageKeys key, dynamic value, List<StorageKeys> written) async {
+    final ok = await _storage.save(key.key, value);
+    if (!ok) {
+      throw StateError('save returned false for ${key.key}');
+    }
+    written.add(key);
+  }
+
+  Future<void> _rollback(List<SecureStorageKeys> writtenSecure, List<StorageKeys> writtenLocal) async {
+    for (final key in writtenSecure) {
+      try {
+        await _secureStorage.delete(key.key);
+      } catch (e) {
+        _log.warn('secure rollback failed for {}: {}', [key.key, e]);
+      }
+    }
+    for (final key in writtenLocal) {
+      try {
+        await _storage.remove(key.key);
+      } catch (e) {
+        _log.warn('local rollback failed for {}: {}', [key.key, e]);
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Update DI factory to inject secure storage**
+
+In `lib/app/di/app_dependencies.dart`, change the factory to accept the dependency:
+
+```dart
+IAuthSessionRepository createAuthSessionRepository(ISecureStorage secureStorage) =>
+    AuthSessionRepository(secureStorage: secureStorage);
+```
+
+In `lib/app/di/app_scope.dart`, update the `RepositoryProvider`:
+
+```dart
+RepositoryProvider<IAuthSessionRepository>(
+  create: (context) => dependencies.createAuthSessionRepository(context.read<ISecureStorage>()),
+),
+```
+
+The `ISecureStorage` provider added in Task 4 must appear **before** this one in the `providers` list so that `context.read<ISecureStorage>()` resolves.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+fvm flutter test test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/auth/data/repositories/auth_session_repository_impl.dart \
+        lib/app/di/app_dependencies.dart lib/app/di/app_scope.dart \
+        test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+git commit -m "feat(#129): route tokens through ISecureStorage in AuthSessionRepository"
+```
+
+---
+
+## Task 6: `SessionMigration` — one-shot bootstrap migration
+
+**Files:**
+- Create: `lib/infrastructure/storage/session_migration.dart`
+- Create: `test/infrastructure/storage/session_migration_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// test/infrastructure/storage/session_migration_test.dart
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../test_utils.dart';
+
+class _MemorySecureStorage implements ISecureStorage {
+  _MemorySecureStorage({this.failOnWrite = false});
+  final Map<String, String> _store = {};
+  final bool failOnWrite;
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async {
+    if (failOnWrite) throw StateError('boom');
+    _store[key] = value;
+  }
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
+void main() {
+  late AppLocalStorage local;
+  late _MemorySecureStorage secure;
+
+  setUpAll(() async {
+    await TestUtils().setupUnitTest();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    local = AppLocalStorage();
+    local.setPreferencesInstance(await SharedPreferences.getInstance());
+    secure = _MemorySecureStorage();
+  });
+
+  tearDown(() async => TestUtils().tearDownUnitTest());
+
+  group('SessionMigration.run', () {
+    test('migrates jwtToken and refreshToken from local to secure', () async {
+      await local.save('jwtToken', 'JWT_VALUE');
+      await local.save('refreshToken', 'REFRESH_VALUE');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), 'JWT_VALUE');
+      expect(await secure.read('refreshToken'), 'REFRESH_VALUE');
+      expect(await local.read('jwtToken'), isNull);
+      expect(await local.read('refreshToken'), isNull);
+    });
+
+    test('is a no-op when secure storage already has the value (idempotent)', () async {
+      await secure.write('jwtToken', 'ALREADY_MIGRATED');
+      await local.save('jwtToken', 'STALE');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED');
+      // Legacy value was not removed because migration did not run.
+      expect(await local.read('jwtToken'), 'STALE');
+    });
+
+    test('is a no-op when there is nothing to migrate', () async {
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), isNull);
+      expect(await secure.read('refreshToken'), isNull);
+    });
+
+    test('does not throw when secure write fails', () async {
+      final flaky = _MemorySecureStorage(failOnWrite: true);
+      await local.save('jwtToken', 'JWT_VALUE');
+
+      await SessionMigration.run(secureStorage: flaky, localStorage: local);
+
+      // Legacy value still present — best-effort semantics.
+      expect(await local.read('jwtToken'), 'JWT_VALUE');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+fvm flutter test test/infrastructure/storage/session_migration_test.dart
+```
+
+Expected: FAIL — `package:flutter_bloc_advance/infrastructure/storage/session_migration.dart` does not exist.
+
+- [ ] **Step 3: Implement `SessionMigration`**
+
+```dart
+// lib/infrastructure/storage/session_migration.dart
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+/// One-shot migration from plaintext SharedPreferences to SecureStorage.
+///
+/// Runs at bootstrap before [AppLocalStorageCached.loadCache] so the
+/// cache sees the post-migration state. Idempotent: any value already
+/// present in [ISecureStorage] is left alone. Best-effort: a failure
+/// logs a warning and returns; worst case the user re-authenticates
+/// on the next launch.
+class SessionMigration {
+  static final _log = AppLogger.getLogger('SessionMigration');
+
+  // Legacy SharedPreferences keys — referenced as literals because the
+  // corresponding StorageKeys entries were removed in Task 3.
+  static const _legacyKeys = <String>['jwtToken', 'refreshToken'];
+
+  static Future<void> run({
+    required ISecureStorage secureStorage,
+    required AppLocalStorage localStorage,
+  }) async {
+    for (final legacyKey in _legacyKeys) {
+      await _migrateOne(legacyKey, secureStorage, localStorage);
+    }
+  }
+
+  static Future<void> _migrateOne(
+    String legacyKey,
+    ISecureStorage secureStorage,
+    AppLocalStorage localStorage,
+  ) async {
+    try {
+      final existing = await secureStorage.read(legacyKey);
+      if (existing != null && existing.isNotEmpty) return; // already migrated
+
+      final legacy = await localStorage.read(legacyKey);
+      if (legacy is! String || legacy.isEmpty) return; // nothing to migrate
+
+      await secureStorage.write(legacyKey, legacy);
+      await localStorage.remove(legacyKey);
+      _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
+    } catch (e) {
+      _log.warn('Migration failed for {}: {}', [legacyKey, e]);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+fvm flutter test test/infrastructure/storage/session_migration_test.dart
+```
+
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/infrastructure/storage/session_migration.dart test/infrastructure/storage/session_migration_test.dart
+git commit -m "feat(#129): add SessionMigration for one-shot bootstrap copy"
+```
+
+---
+
+## Task 7: `AppLocalStorageCached.loadCache` reads JWT from SecureStorage
+
+**Files:**
+- Modify: `lib/infrastructure/storage/local_storage.dart`
+
+- [ ] **Step 1: Update `loadCache` signature**
+
+In `lib/infrastructure/storage/local_storage.dart`, modify `AppLocalStorageCached`:
+
+```dart
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+class AppLocalStorageCached {
+  static final _log = AppLogger.getLogger("AppLocalStorageCached");
+  static late String? jwtToken;
+  static late List<String>? roles;
+  static late String? language;
+  static late String? username;
+  static late String? theme;
+  static late String? brightness;
+
+  static Future<void> loadCache({ISecureStorage? secureStorage}) async {
+    _log.trace("Loading cache");
+    final secure = secureStorage ?? FlutterSecureStorageAdapter();
+    jwtToken = await secure.read(SecureStorageKeys.jwtToken.key);
+    roles = await AppLocalStorage().read(StorageKeys.roles.key);
+    language = await AppLocalStorage().read(StorageKeys.language.key) ?? "en";
+    username = await AppLocalStorage().read(StorageKeys.username.key);
+    theme = await AppLocalStorage().read(StorageKeys.theme.key) ?? "classic";
+    brightness = await AppLocalStorage().read(StorageKeys.brightness.key) ?? "light";
+    _log.trace("Loaded cache with username:{}, roles:{}, language:{}, jwtToken-present:{}, theme:{}, brightness:{}", [
+      username,
+      roles,
+      language,
+      jwtToken != null,
+      theme,
+      brightness,
+    ]);
+  }
+}
+```
+
+The trace log no longer prints the JWT value itself; we already mask elsewhere but the cache layer should not leak the raw token through trace logs either.
+
+- [ ] **Step 2: Run analyzer**
+
+```bash
+fvm dart analyze lib/infrastructure/storage/local_storage.dart
+```
+
+Expected: no errors in this file. (Errors at the existing `AppLocalStorage().save/remove` paths that internally call `loadCache()` should now resolve correctly since the new signature has an optional parameter.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/infrastructure/storage/local_storage.dart
+git commit -m "feat(#129): cache layer reads jwtToken from SecureStorage"
+```
+
+---
+
+## Task 8: `AuthInterceptor` — read JWT from cache (no enum dependency)
+
+**Files:**
+- Modify: `lib/infrastructure/http/interceptors/auth_interceptor.dart`
+
+- [ ] **Step 1: Replace the interceptor implementation**
+
+```dart
+// lib/infrastructure/http/interceptors/auth_interceptor.dart
+import 'package:dio/dio.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+
+/// Injects JWT Bearer token into every outgoing request.
+///
+/// Reads from the in-memory cache rather than disk because this runs
+/// on every HTTP request and the cache is kept fresh by the persist /
+/// refresh / clear paths.
+class AuthInterceptor extends Interceptor {
+  static final _log = AppLogger.getLogger('AuthInterceptor');
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final jwtToken = AppLocalStorageCached.jwtToken;
+    if (jwtToken != null && jwtToken.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $jwtToken';
+    }
+    _log.debug('Request [{}] {} (auth: {})', [options.method, options.path, jwtToken != null]);
+    handler.next(options);
+  }
+}
+```
+
+(Method signature changes from `Future<void>` to `void` because we no longer await disk I/O. `Interceptor.onRequest` allows both.)
+
+- [ ] **Step 2: Run analyzer**
+
+```bash
+fvm dart analyze lib/infrastructure/http/interceptors/auth_interceptor.dart
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run existing AuthInterceptor tests (if any) to confirm they still pass**
+
+```bash
+fvm flutter test test/infrastructure/http/interceptors/
+```
+
+Expected: TokenRefreshInterceptor tests still fail (we fix in Task 9), but the AuthInterceptor file compiles. If there is a specific AuthInterceptor test, it may need a `AppLocalStorageCached.jwtToken = '...'` setup line — fix inline if so.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/infrastructure/http/interceptors/auth_interceptor.dart
+git commit -m "refactor(#129): AuthInterceptor reads JWT from cached field"
+```
+
+---
+
+## Task 9: `TokenRefreshInterceptor` + `ApiClient` use `ISecureStorage`
+
+**Files:**
+- Modify: `lib/infrastructure/http/interceptors/token_refresh_interceptor.dart`
+- Modify: `lib/infrastructure/http/api_client.dart`
+- Modify: `test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart`
+
+- [ ] **Step 1: Add a static `secureStorage` field on `ApiClient`**
+
+In `lib/infrastructure/http/api_client.dart`, near `static OnSessionExpired? onSessionExpired;`:
+
+```dart
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+// ...
+static OnSessionExpired? onSessionExpired;
+
+/// Secure storage used by the token-refresh interceptor.
+///
+/// Set this before the first API call (typically in app bootstrap).
+/// Falls back to a fresh [FlutterSecureStorageAdapter] if unset, so
+/// tests don't need to wire it up.
+static ISecureStorage? secureStorage;
+```
+
+Then in `_createDio()`, where `TokenRefreshInterceptor` is constructed:
+
+```dart
+(
+  interceptor: TokenRefreshInterceptor(
+    dio: dio,
+    secureStorage: secureStorage ?? FlutterSecureStorageAdapter(),
+    onSessionExpired: onSessionExpired,
+  ),
+  meta: const InterceptorChainEntry(name: 'TokenRefreshInterceptor', detail: 'Refreshes expired access tokens'),
+),
+```
+
+- [ ] **Step 2: Rewrite the interceptor**
+
+Replace `lib/infrastructure/http/interceptors/token_refresh_interceptor.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+typedef OnSessionExpired = void Function();
+
+/// Intercepts 401 responses and attempts a silent token refresh.
+///
+/// Tokens are read from and written to [ISecureStorage]. After a
+/// successful refresh the in-memory cache is reloaded so that
+/// downstream consumers (`AuthInterceptor`, `SecurityUtils`) see the
+/// rotated JWT immediately.
+class TokenRefreshInterceptor extends QueuedInterceptor {
+  static final _log = AppLogger.getLogger('TokenRefreshInterceptor');
+
+  final Dio _dio;
+  final ISecureStorage _secureStorage;
+  final OnSessionExpired? _onSessionExpired;
+
+  TokenRefreshInterceptor({
+    required Dio dio,
+    required ISecureStorage secureStorage,
+    OnSessionExpired? onSessionExpired,
+  })  : _dio = dio,
+        _secureStorage = secureStorage,
+        _onSessionExpired = onSessionExpired;
+
+  @override
+  Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode != 401) {
+      handler.next(err);
+      return;
+    }
+
+    final requestPath = err.requestOptions.path;
+    if (requestPath.contains('/api/token/refresh')) {
+      _log.warn('Refresh endpoint returned 401 — session expired');
+      _triggerLogout();
+      handler.next(err);
+      return;
+    }
+
+    _log.debug('401 received for {} — attempting token refresh', [requestPath]);
+
+    try {
+      final refreshToken = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
+      if (refreshToken == null || refreshToken.isEmpty) {
+        _log.warn('No refresh token available — session expired');
+        _triggerLogout();
+        handler.next(err);
+        return;
+      }
+
+      final refreshDio = Dio(
+        BaseOptions(
+          baseUrl: _dio.options.baseUrl,
+          connectTimeout: _dio.options.connectTimeout,
+          receiveTimeout: _dio.options.receiveTimeout,
+          headers: {'Accept': 'application/json', 'Content-Type': 'application/json'},
+        ),
+      );
+
+      final response = await refreshDio.post('/api/token/refresh', data: jsonEncode({'refresh_token': refreshToken}));
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final data = response.data is String ? jsonDecode(response.data as String) : response.data;
+
+        final newIdToken = data['id_token'] as String?;
+        final newRefreshToken = data['refresh_token'] as String?;
+
+        if (newIdToken == null || newIdToken.isEmpty) {
+          _log.error('Refresh response missing id_token — session expired');
+          _triggerLogout();
+          handler.next(err);
+          return;
+        }
+
+        await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
+        if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
+          await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
+        }
+        // Refresh the in-memory cache so AuthInterceptor and SecurityUtils
+        // observe the rotated token immediately.
+        await AppLocalStorageCached.loadCache(secureStorage: _secureStorage);
+
+        _log.info('Token refresh successful — retrying original request');
+
+        final retryOptions = err.requestOptions;
+        retryOptions.headers['Authorization'] = 'Bearer $newIdToken';
+        final retryResponse = await _dio.fetch(retryOptions);
+        handler.resolve(retryResponse);
+        return;
+      }
+
+      _log.warn('Refresh endpoint returned {} — session expired', [response.statusCode]);
+      _triggerLogout();
+      handler.next(err);
+    } catch (e) {
+      _log.error('Refresh attempt threw: {}', [e]);
+      _triggerLogout();
+      handler.next(err);
+    }
+  }
+
+  void _triggerLogout() {
+    if (_onSessionExpired != null) {
+      _log.info('Notifying app layer of session expiry');
+      _onSessionExpired();
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Update existing interceptor tests**
+
+In `test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart`:
+
+1. Add an in-memory `_MemorySecureStorage` (identical to the one used in the repository test — copy/paste, no shared util yet).
+2. Update every `TokenRefreshInterceptor(dio: dio, ...)` call to pass `secureStorage: secure,` where `secure` is a `_MemorySecureStorage()` instance set up in `setUp`.
+3. Replace `await localStorage.save(StorageKeys.refreshToken.key, ...)` with `await secure.write(SecureStorageKeys.refreshToken.key, ...)`.
+4. Replace `await localStorage.save(StorageKeys.jwtToken.key, ...)` with `await secure.write(SecureStorageKeys.jwtToken.key, ...)`.
+5. For any assertion that checks the rotated tokens were persisted, read from `secure.read(SecureStorageKeys.jwtToken.key)` / `SecureStorageKeys.refreshToken.key` instead of `AppLocalStorage().read(StorageKeys.jwtToken.key)`.
+
+The file already has its own structure — keep tests organized as they are, just change the source of truth.
+
+- [ ] **Step 4: Run interceptor tests**
+
+```bash
+fvm flutter test test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+```
+
+Expected: PASS (all existing assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/infrastructure/http/interceptors/token_refresh_interceptor.dart \
+        lib/infrastructure/http/api_client.dart \
+        test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+git commit -m "feat(#129): TokenRefreshInterceptor uses ISecureStorage; refreshes cache"
+```
+
+---
+
+## Task 10: Bootstrap wires `ISecureStorage`, runs migration, refreshes cache
+
+**Files:**
+- Modify: `lib/app/bootstrap/app_bootstrap.dart`
+
+- [ ] **Step 1: Add wiring**
+
+In `lib/app/bootstrap/app_bootstrap.dart`, modify the `run` method:
+
+```dart
+import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
+
+// ...
+
+class AppBootstrap {
+  static Future<void> run(AppBootstrapConfig config) async {
+    WidgetsFlutterBinding.ensureInitialized();
+
+    await AppConstants.initPackageInfo();
+
+    AppLogger.configure(isProduction: config.isProduction);
+    final log = AppLogger.getLogger('AppBootstrap');
+
+    ProfileConstants.setEnvironment(config.environment);
+
+    final dependencies = AppDependencies(environment: config.environment);
+    final secureStorage = dependencies.createSecureStorage();
+    ApiClient.secureStorage = secureStorage; // available to TokenRefreshInterceptor
+
+    // One-shot migration of legacy plaintext tokens. Must run BEFORE
+    // AppLocalStorageCached.loadCache so the cache sees the post-
+    // migration state.
+    await SessionMigration.run(secureStorage: secureStorage, localStorage: AppLocalStorage());
+
+    final existingLang = await AppLocalStorage().read(StorageKeys.language.key);
+    if (existingLang == null) {
+      await AppLocalStorage().save(StorageKeys.language.key, config.defaultLanguage);
+    }
+    final existingPalette = await AppLocalStorage().read(StorageKeys.theme.key);
+    if (existingPalette == null) {
+      await AppLocalStorage().save(StorageKeys.theme.key, config.defaultPalette);
+    }
+    await AppLocalStorageCached.loadCache(secureStorage: secureStorage);
+
+    await ConnectivityService.instance.initialize();
+
+    final analytics = LogAnalyticsService();
+    CrashReporter.install(analytics);
+
+    Bloc.observer = kDebugMode ? TimeTravelBlocObserver() : AppBlocObserver();
+
+    AppRouter().setRouter(RouterType.goRouter);
+
+    await SystemChrome.setPreferredOrientations(config.preferredOrientations);
+
+    log.info('Starting app with env: {}, language: {}, palette: {}, brightness: {}', [
+      config.environment.name,
+      config.defaultLanguage,
+      config.defaultPalette,
+      config.defaultBrightness,
+    ]);
+
+    runApp(
+      App(
+        language: config.defaultLanguage,
+        dependencies: dependencies,
+        analytics: analytics,
+      ),
+    );
+  }
+}
+```
+
+(The previous code constructed `AppDependencies` inside `runApp` — we lift it earlier so we can pass the same secure storage instance to `ApiClient`, `SessionMigration`, and the widget tree.)
+
+- [ ] **Step 2: Run analyzer**
+
+```bash
+fvm dart analyze lib/app/bootstrap/
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/app/bootstrap/app_bootstrap.dart
+git commit -m "feat(#129): bootstrap wires SecureStorage and runs SessionMigration"
+```
+
+---
+
+## Task 11: Sanitize `login_bloc.dart:140`
+
+**Files:**
+- Modify: `lib/features/auth/application/login_bloc.dart` (line 140)
+
+**Context:** `data` in this scope is an `AuthTokenEntity` (return value of `_verifyOtpUseCase`). The entity exposes a nullable `idToken: String?`. Cache refresh after persist is handled implicitly: `AuthSessionRepository.persist` writes username via `AppLocalStorage.save`, which already calls `AppLocalStorageCached.loadCache()` — and after Task 7 that cache load reads the just-written JWT from secure storage.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `lib/features/auth/application/login_bloc.dart`:
+
+```dart
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
+```
+
+- [ ] **Step 2: Sanitize line 140**
+
+Replace:
+
+```dart
+_log.debug("onVerifyOtpSubmitted token: {}", [data.toString()]);
+```
+
+With:
+
+```dart
+_log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data.idToken)]);
+```
+
+(`data` is non-null here — it came from the `Success(:final data)` pattern match — but `data.idToken` is nullable. `maskToken` handles null cleanly.)
+
+- [ ] **Step 3: Run login BLoC tests**
+
+```bash
+fvm flutter test test/features/auth/application/login_bloc_test.dart
+```
+
+Expected: PASS. If a test asserts on the previous debug message text containing a raw token, update it to expect the masked form (`'1234…5678'` shape) — fix inline.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/features/auth/application/login_bloc.dart
+git commit -m "feat(#129): sanitize login OTP debug log with LogSanitizer"
+```
+
+---
+
+## Task 12: Repair existing tests that reference removed enum values
+
+**Files (test-only updates):**
+- Modify: `test/test_utils.dart`
+- Modify: `test/features/auth/data/repositories/login_repository_test.dart`
+- Modify: `test/app/session/session_cubit_test.dart`
+- Modify: `test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart`
+- Modify: `test/features/auth/application/login_bloc_test.dart`
+- Modify: `test/core/security/security_utils_test.dart`
+
+> **Goal:** (1) Mock the `flutter_secure_storage` MethodChannel globally so `AppLocalStorageCached.loadCache()` works in tests. (2) Replace every remaining reference to `StorageKeys.jwtToken` and `StorageKeys.refreshToken` (which no longer exist) with the equivalent secure-storage or cache-field setup. After this task the analyzer is clean and the full test suite is green.
+
+- [ ] **Step 1: Add a MethodChannel mock to `test_utils.dart`**
+
+`AppLocalStorage.save/remove/clear` internally call `AppLocalStorageCached.loadCache()`, which now reads `SecureStorageKeys.jwtToken` via `flutter_secure_storage`. Without a mock that channel throws `MissingPluginException` in tests.
+
+In `test/test_utils.dart`, add:
+
+```dart
+import 'package:flutter/services.dart';
+
+class TestUtils {
+  /// In-memory backing store for the mocked flutter_secure_storage channel.
+  static final Map<String, String> _secureStore = {};
+
+  static const _secureChannel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+  static void _installSecureStorageMock() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_secureChannel, (call) async {
+      final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? const {};
+      final key = args['key'] as String?;
+      switch (call.method) {
+        case 'read':
+          return _secureStore[key];
+        case 'readAll':
+          return Map<String, String>.from(_secureStore);
+        case 'write':
+          _secureStore[key!] = args['value'] as String;
+          return null;
+        case 'delete':
+          _secureStore.remove(key);
+          return null;
+        case 'deleteAll':
+          _secureStore.clear();
+          return null;
+        case 'containsKey':
+          return _secureStore.containsKey(key);
+        default:
+          return null;
+      }
+    });
+  }
+  // ...
+}
+```
+
+Then call `_installSecureStorageMock()` once inside `setupUnitTest()` and `setupRepositoryUnitTest()`. Add `_secureStore.clear();` to `_clearStorage()` so test isolation is preserved.
+
+- [ ] **Step 2: Update `setupAuthentication()` to seed both the cache and the secure store**
+
+```dart
+Future<void> setupAuthentication() async {
+  _secureStore['jwtToken'] = 'MOCK_TOKEN';
+  AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
+}
+```
+
+(Setting the cache directly avoids dragging in a real `loadCache()` call that could touch SharedPreferences before tests set them up.)
+
+- [ ] **Step 3: Run analyzer to see the remaining broken sites**
+
+```bash
+fvm dart analyze --no-fatal-warnings test/ 2>&1 | grep -E "jwtToken|refreshToken"
+```
+
+- [ ] **Step 4: For each line, apply one of these substitutions**
+
+**Pattern A — test seeds a token to simulate a logged-in user:**
+
+```dart
+// BEFORE
+await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
+
+// AFTER (sync cache seeding — works for SecurityUtils and AuthInterceptor)
+AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
+```
+
+**Pattern B — test verifies that a token was persisted (e.g. `login_repository_test.dart`):**
+
+If `LoginRepository.login` previously wrote `StorageKeys.jwtToken` directly, check `lib/features/auth/data/repositories/auth_repository_impl.dart` — that responsibility now belongs to `AuthSessionRepository`. The test should either:
+  - Be moved to `auth_session_repository_impl_test.dart` (already covered there in Task 5), and the assertion in `login_repository_test.dart` deleted, **or**
+  - Be re-pointed at the secure storage if `LoginRepository` still writes directly. Open the file and check; do not assume.
+
+**Pattern C — `security_utils_test.dart` seeds a JWT for token-expiry checks:**
+
+```dart
+// BEFORE
+await AppLocalStorage().save(StorageKeys.jwtToken.key, "header.payload.signature");
+
+// AFTER
+AppLocalStorageCached.jwtToken = "header.payload.signature";
+```
+
+`SecurityUtils.isTokenExpired()` reads from `AppLocalStorageCached.jwtToken`, so this still exercises the same code path.
+
+**Pattern D — `test_utils.dart` global setup line (line 49):**
+
+```dart
+// BEFORE
+await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
+
+// AFTER
+AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
+```
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+fvm flutter test
+```
+
+Expected: PASS. If any test that used to seed the JWT now reads `null` because the cached field isn't initialized at the test boundary, ensure `AppLocalStorageCached.jwtToken = null;` runs in `_clearStorage()` of `test_utils.dart` for isolation.
+
+- [ ] **Step 6: Run analyzer**
+
+```bash
+fvm dart analyze
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/
+git commit -m "test(#129): mock secure storage channel + repair removed enum refs"
+```
+
+---
+
+## Task 13: README + final verification
+
+**Files:**
+- Modify: `README.md` (auth section)
+
+- [ ] **Step 1: Add a paragraph to the auth / security section of `README.md`**
+
+Find the section that describes authentication (likely under "Architecture" or "Features"). Add (or weave in):
+
+> **Token storage.** JWT and refresh tokens are persisted via `flutter_secure_storage` — iOS Keychain on Apple platforms and Keystore-backed `EncryptedSharedPreferences` on Android. Non-secret session fields (username, roles) remain in SharedPreferences for synchronous access. The first launch after upgrading from an older build runs a one-shot migration from the legacy plaintext keys into secure storage.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+fvm flutter test
+```
+
+Expected: PASS (no regressions, all new tests green).
+
+- [ ] **Step 3: Format check (CI gate)**
+
+```bash
+fvm dart format --set-exit-if-changed --line-length=120 .
+```
+
+Expected: exit 0. If anything is reformatted, run `fvm dart format . --line-length=120` and commit.
+
+- [ ] **Step 4: Static analysis**
+
+```bash
+fvm dart analyze
+```
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 5: Commit + push + open PR**
+
+```bash
+git add README.md
+git commit -m "docs(#129): note SecureStorage as token store in README"
+git push -u origin feat/129-secure-storage-wiring
+gh pr create --title "feat(#129): wire SecureStorage into DI and mask JWTs in logs" \
+  --body "$(cat <<'EOF'
+## Summary
+- Routes JWT and refresh token through `flutter_secure_storage` instead of SharedPreferences.
+- Splits `StorageKeys` into `SecureStorageKeys` (jwtToken, refreshToken) and `StorageKeys` (username, roles, language, theme, brightness).
+- Adds `SessionMigration` for one-shot bootstrap migration from legacy plaintext keys.
+- Adds `LogSanitizer.maskToken` and overrides `AuthSession.toString()` so tokens are structurally unloggable.
+- Wires `TokenRefreshInterceptor` and bootstrap through `ISecureStorage`; cache layer refreshed after persist/refresh paths.
+
+## Test plan
+- [ ] `fvm flutter test` — full suite green
+- [ ] Manually verify migration: install previous build, log in, upgrade, confirm session persists without re-login
+- [ ] Confirm `AuthSession.toString()` masks tokens (new unit test)
+- [ ] Confirm no debug log carries a raw JWT (grep + manual scan)
+
+Closes #129
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before marking the plan done)
+
+- [ ] Every spec section maps to at least one task.
+- [ ] No `TODO` / `TBD` / "implement later" in any step.
+- [ ] Type names and method signatures are consistent across tasks (e.g. `ISecureStorage`, `SecureStorageKeys`, `AuthSessionRepository({required ISecureStorage secureStorage, AppLocalStorage? storage})`).
+- [ ] Each task ends with a commit step.
+- [ ] Tests precede implementation in every task that adds production code (TDD).
+- [ ] Analyzer is expected to be dirty after Task 3 and clean after Task 12.

--- a/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
+++ b/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
@@ -171,7 +171,7 @@ _log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data?.idTok
 |---|---|
 | `test/features/auth/data/repositories/auth_session_repository_impl_test.dart` | (1) Round-trip: `idToken`/`refreshToken` written to secure backend, `username`/`roles` to local. (2) Cross-backend rollback: secure write succeeds, local write fails → secure side also rolled back. (3) `clear()` clears both. (4) Null `refreshToken` → secure key removed best-effort. |
 | `test/infrastructure/storage/session_migration_test.dart` | (1) Migrates `jwtToken` and `refreshToken` from local → secure, removes from local. (2) Idempotent: second invocation is a no-op when secure already has the value. (3) Empty/missing legacy values → no-op. (4) Failure path logs warning and continues. |
-| `test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart` | Existing tests updated to construct with `ISecureStorage`; add scenarios for (1) refresh token read from secure storage, (2) rotated tokens written back to secure storage, (3) `AppLocalStorageCached.jwtToken` reflects the rotated value after refresh. |
+| `test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart` | Existing tests updated to construct with `ISecureStorage`; scenarios cover (1) refresh token read from secure storage and (2) rotated tokens written back to secure storage. No cache assertion needed — `AuthInterceptor` re-reads from secure storage on every request. |
 | `test/core/logging/log_sanitizer_test.dart` | Boundary tests: null, empty, length 1, length 7, length 8, normal-length, very long. |
 | `test/features/auth/domain/entities/auth_session_test.dart` | `toString()` does not contain the JWT value; produces masked form. |
 
@@ -182,7 +182,7 @@ _log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data?.idTok
 - [ ] `SecureStorageKeys` enum separate from `StorageKeys`.
 - [ ] One-shot eager migration on first launch after upgrade (idempotent).
 - [ ] Cross-backend atomic-write rollback preserved.
-- [ ] `TokenRefreshInterceptor` reads refresh token from secure storage and persists rotated tokens there; cache layer is refreshed after rotation.
+- [ ] `TokenRefreshInterceptor` reads refresh token from secure storage and persists rotated tokens there. No in-memory cache to refresh — `AuthInterceptor` reads JWT directly from secure storage on every request, so the next outgoing request automatically picks up the rotated token.
 - [ ] `login_bloc.dart:140` sanitized with `LogSanitizer.maskToken`.
 - [ ] `LogSanitizer.maskToken()` helper under `lib/core/logging/`.
 - [ ] `AuthSession.toString()` renders masked tokens (resilient to `stringify = true`).

--- a/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
+++ b/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
@@ -88,50 +88,51 @@ Bootstrap call order (`lib/app/bootstrap/app_bootstrap.dart`):
 1. `WidgetsFlutterBinding.ensureInitialized()`
 2. `AppLogger.configure(...)`
 3. **`await SessionMigration.run(...)`** — new step
-4. `await AppLocalStorageCached.loadCache(secureStorage: ...)` — now reads `jwtToken` from secure storage
+4. `await AppLocalStorageCached.loadCache()` — loads non-JWT fields (roles, language, theme, brightness, username) from SharedPreferences
 
-### AppLocalStorageCached — source change only
+> **Note (shipped behavior diverges from initial design):** the original design proposed caching `jwtToken` in `AppLocalStorageCached` after reading it from secure storage. During PR review the sync-cache approach proved to require six coordinated write paths (persist, refresh, logout, rollback, clear, bootstrap) — each a potential source of stale-token bugs. The shipped design eliminates that cache entirely. See the "Shipped architecture" section below.
 
-The cache layer is preserved so synchronous callers (`SecurityUtils.isUserLoggedIn()`, `isTokenExpired()`) keep working. Only the **source** of `jwtToken` changes:
+### AppLocalStorageCached — non-JWT fields only
+
+The cache layer holds only fields that legitimately live in SharedPreferences (`roles`, `language`, `username`, `theme`, `brightness`) and benefit from synchronous reads. `loadCache()` takes no `ISecureStorage` parameter; the JWT is not cached.
 
 ```dart
-static Future<void> loadCache({ISecureStorage? secureStorage}) async {
-  final secure = secureStorage ?? FlutterSecureStorageAdapter();
-  jwtToken = await secure.read(SecureStorageKeys.jwtToken.key);
+static Future<void> loadCache() async {
   roles    = await AppLocalStorage().read(StorageKeys.roles.key);
-  // language, username, theme, brightness — unchanged
+  language = await AppLocalStorage().read(StorageKeys.language.key) ?? "en";
+  // username, theme, brightness — same pattern
 }
 ```
 
-Note: no static `refreshToken` field is added. The refresh token is only consumed asynchronously inside `TokenRefreshInterceptor`, so a synchronous cache provides no value there.
-
-JWT still lives in process memory as a static field. That is a different threat model (memory dump) and out of scope.
-
 ### TokenRefreshInterceptor — read/save refresh token via SecureStorage
 
-`lib/infrastructure/http/interceptors/token_refresh_interceptor.dart` currently reads `StorageKeys.refreshToken` from `AppLocalStorage` and persists the rotated tokens back there. With the split, both reads and writes move to `ISecureStorage`.
+`lib/infrastructure/http/interceptors/token_refresh_interceptor.dart` reads `SecureStorageKeys.refreshToken` from `ISecureStorage` and persists rotated tokens there. Constructor:
 
-Constructor change:
 ```dart
 TokenRefreshInterceptor({
   required Dio dio,
-  required ISecureStorage secureStorage,
+  ISecureStorage? secureStorage,  // defaults to FlutterSecureStorageAdapter()
   OnSessionExpired? onSessionExpired,
 });
 ```
 
-`lib/infrastructure/http/api_client.dart` (line ~114) threads `secureStorage` through. `ApiClient` itself takes `ISecureStorage` from `AppDependencies` / `AppScope`.
+No cache sync is needed after rotation: `AuthInterceptor` reads from secure storage on every request, so the next outgoing request picks up the rotated JWT directly.
 
-After persisting rotated tokens, the interceptor refreshes the in-memory cache:
-```dart
-await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
-if (newRefreshToken?.isNotEmpty == true) {
-  await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken!);
-}
-await AppLocalStorageCached.loadCache(secureStorage: _secureStorage);
-```
+### Shipped architecture — JWT lives only in `ISecureStorage`
 
-Otherwise `SecurityUtils.isUserLoggedIn()` and `isTokenExpired()` would observe the stale pre-refresh JWT until next bootstrap.
+After PR review the cache layer for JWT was removed entirely. The shipped data flow:
+
+| Caller | How it reads JWT |
+|---|---|
+| `AuthInterceptor.onRequest` | `await _secureStorage.read(...)` on every request |
+| `SessionCubit.restore` / `refresh` | `await _secureStorage.read(...)` → `SecurityUtils.hasToken(token)` + `isTokenExpired(token)` (pure) |
+| `AuthSessionRepository.persist` / `clear` | writes / deletes via `ISecureStorage` |
+| `TokenRefreshInterceptor` | reads / writes via `ISecureStorage` |
+| `LoginRepository.logout` | deletes via `ISecureStorage`, then `AppLocalStorage.clear()` |
+
+`SecurityUtils` is a pure-function module: callers hand it a token string, it returns a derived boolean. This keeps `core/` free of `infrastructure/` imports per the architecture guard.
+
+`SessionCubit` owns the only "is the user authenticated?" decision for UI / router consumers. The router redirect reads `state.isAuthenticated` synchronously; it no longer calls `SecurityUtils.isTokenExpired()` directly.
 
 ### Log sanitization
 

--- a/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
+++ b/docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md
@@ -1,0 +1,204 @@
+# SecureStorage Wiring + JWT Log Masking — Design
+
+**Issue:** [#129](https://github.com/cevheri/flutter_bloc_advance/issues/129)
+**Date:** 2026-05-20
+**Author:** cevheri
+**Status:** Approved, ready for plan
+
+## Problem
+
+1. `ISecureStorage` exists (`lib/infrastructure/storage/secure_storage.dart`) but is **not wired into DI**. The auth session repository persists the JWT in plaintext SharedPreferences.
+2. SharedPreferences is world-readable on rooted Android, recoverable from iOS file system backups, and visible to any code sharing the app's UID. JWTs and refresh tokens belong in Keychain / Keystore-backed storage.
+3. `lib/features/auth/application/login_bloc.dart:140` logs `data.toString()` on token-bearing entity. Today `Equatable.stringify = false` makes this safe, but flipping that flag — a common convenience change — would silently leak JWTs into every active log sink.
+
+## Goals
+
+- Persist JWT and refresh token via `flutter_secure_storage`.
+- Keep `username` and `roles` in `AppLocalStorage` (used for synchronous reads).
+- Migrate existing installations from SharedPreferences to SecureStorage without forcing logout.
+- Make JWT leakage through logs structurally impossible — not just absent.
+
+## Non-Goals
+
+- Certificate pinning (#133), screen capture protection (#134), idle timeout (#130).
+- Token encryption beyond what platform Keystore/Keychain provides.
+- Refresh-token rotation policy.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Migration timing | **Eager (bootstrap, one-shot)** | Simple model; no half-migrated state carried through app lifetime. |
+| Key enum | **Split into `SecureStorageKeys`** | Type system catches "wrong backend" at compile time. |
+| `login_bloc.dart:140` | **Sanitize with `LogSanitizer.maskToken`** | Keep diagnostic value; mitigate leak risk. (Issue recommended deletion — we chose mask to preserve observability for OTP flow debugging.) |
+
+## Architecture
+
+### Storage layer
+
+```
+SecureStorageKeys enum  →  jwtToken, refreshToken
+StorageKeys     enum  →  username, roles, language, theme, brightness
+                         (jwtToken / refreshToken removed)
+```
+
+Files touched:
+- `lib/infrastructure/storage/secure_storage.dart` — add `SecureStorageKeys` enum.
+- `lib/infrastructure/storage/local_storage.dart` — remove `jwtToken` and `refreshToken` from `StorageKeys`.
+- `lib/app/di/app_dependencies.dart` — add `ISecureStorage createSecureStorage() => FlutterSecureStorageAdapter()`.
+- `lib/app/di/app_scope.dart` — construct once, expose to consumers.
+
+### AuthSessionRepository — cross-backend atomicity
+
+Repository constructor accepts both backends:
+
+```dart
+AuthSessionRepository({
+  required ISecureStorage secureStorage,
+  AppLocalStorage? storage,
+});
+```
+
+`persist()` tracks writes to both backends. On any failure, rollback walks **both** lists. The invariant: callers never observe a partial session (e.g. `idToken` written but `username` missing, or vice versa).
+
+`clear()` clears both backends.
+
+### Eager migration
+
+New file: `lib/infrastructure/storage/session_migration.dart`
+
+```dart
+class SessionMigration {
+  static Future<void> run({
+    required ISecureStorage secureStorage,
+    required AppLocalStorage localStorage,
+  });
+}
+```
+
+Algorithm (per legacy key — `jwtToken`, `refreshToken`):
+1. If `secureStorage.read(key)` returns a non-null value, **return** (already migrated, idempotent).
+2. Read legacy value from `localStorage`. If null or empty, **return**.
+3. Write to secure storage.
+4. Remove from local storage.
+
+Best-effort semantics: any exception logs a warning and returns. Worst case the user re-authenticates on next launch.
+
+Bootstrap call order (`lib/app/bootstrap/app_bootstrap.dart`):
+1. `WidgetsFlutterBinding.ensureInitialized()`
+2. `AppLogger.configure(...)`
+3. **`await SessionMigration.run(...)`** — new step
+4. `await AppLocalStorageCached.loadCache(secureStorage: ...)` — now reads `jwtToken` from secure storage
+
+### AppLocalStorageCached — source change only
+
+The cache layer is preserved so synchronous callers (`SecurityUtils.isUserLoggedIn()`, `isTokenExpired()`) keep working. Only the **source** of `jwtToken` changes:
+
+```dart
+static Future<void> loadCache({ISecureStorage? secureStorage}) async {
+  final secure = secureStorage ?? FlutterSecureStorageAdapter();
+  jwtToken = await secure.read(SecureStorageKeys.jwtToken.key);
+  roles    = await AppLocalStorage().read(StorageKeys.roles.key);
+  // language, username, theme, brightness — unchanged
+}
+```
+
+Note: no static `refreshToken` field is added. The refresh token is only consumed asynchronously inside `TokenRefreshInterceptor`, so a synchronous cache provides no value there.
+
+JWT still lives in process memory as a static field. That is a different threat model (memory dump) and out of scope.
+
+### TokenRefreshInterceptor — read/save refresh token via SecureStorage
+
+`lib/infrastructure/http/interceptors/token_refresh_interceptor.dart` currently reads `StorageKeys.refreshToken` from `AppLocalStorage` and persists the rotated tokens back there. With the split, both reads and writes move to `ISecureStorage`.
+
+Constructor change:
+```dart
+TokenRefreshInterceptor({
+  required Dio dio,
+  required ISecureStorage secureStorage,
+  OnSessionExpired? onSessionExpired,
+});
+```
+
+`lib/infrastructure/http/api_client.dart` (line ~114) threads `secureStorage` through. `ApiClient` itself takes `ISecureStorage` from `AppDependencies` / `AppScope`.
+
+After persisting rotated tokens, the interceptor refreshes the in-memory cache:
+```dart
+await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
+if (newRefreshToken?.isNotEmpty == true) {
+  await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken!);
+}
+await AppLocalStorageCached.loadCache(secureStorage: _secureStorage);
+```
+
+Otherwise `SecurityUtils.isUserLoggedIn()` and `isTokenExpired()` would observe the stale pre-refresh JWT until next bootstrap.
+
+### Log sanitization
+
+New file: `lib/core/logging/log_sanitizer.dart`
+
+```dart
+class LogSanitizer {
+  /// Returns "abcd…wxyz" for normal-length tokens,
+  /// "<redacted>" for tokens shorter than 8 chars,
+  /// "<empty>" for null/empty.
+  static String maskToken(String? token);
+}
+```
+
+**Structural protection — `AuthSession.toString()` override:**
+
+```dart
+@override
+String toString() => 'AuthSession('
+  'idToken: ${LogSanitizer.maskToken(idToken)}, '
+  'refreshToken: ${LogSanitizer.maskToken(refreshToken)}, '
+  'username: $username, roles: $roles)';
+```
+
+This kills the failure mode at the source. Any current or future caller that does `'$session'`, `session.toString()`, or `Equatable.stringify = true` produces masked output.
+
+**`login_bloc.dart:140`:**
+
+```dart
+_log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data?.idToken)]);
+```
+
+## Test plan
+
+| Test file | Scenarios |
+|---|---|
+| `test/features/auth/data/repositories/auth_session_repository_impl_test.dart` | (1) Round-trip: `idToken`/`refreshToken` written to secure backend, `username`/`roles` to local. (2) Cross-backend rollback: secure write succeeds, local write fails → secure side also rolled back. (3) `clear()` clears both. (4) Null `refreshToken` → secure key removed best-effort. |
+| `test/infrastructure/storage/session_migration_test.dart` | (1) Migrates `jwtToken` and `refreshToken` from local → secure, removes from local. (2) Idempotent: second invocation is a no-op when secure already has the value. (3) Empty/missing legacy values → no-op. (4) Failure path logs warning and continues. |
+| `test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart` | Existing tests updated to construct with `ISecureStorage`; add scenarios for (1) refresh token read from secure storage, (2) rotated tokens written back to secure storage, (3) `AppLocalStorageCached.jwtToken` reflects the rotated value after refresh. |
+| `test/core/logging/log_sanitizer_test.dart` | Boundary tests: null, empty, length 1, length 7, length 8, normal-length, very long. |
+| `test/features/auth/domain/entities/auth_session_test.dart` | `toString()` does not contain the JWT value; produces masked form. |
+
+## Acceptance criteria
+
+- [ ] `ISecureStorage` exposed via `AppDependencies`, consumed by `AuthSessionRepository` and `TokenRefreshInterceptor`.
+- [ ] JWT and refresh token persisted via SecureStorage; username and roles in `AppLocalStorage`.
+- [ ] `SecureStorageKeys` enum separate from `StorageKeys`.
+- [ ] One-shot eager migration on first launch after upgrade (idempotent).
+- [ ] Cross-backend atomic-write rollback preserved.
+- [ ] `TokenRefreshInterceptor` reads refresh token from secure storage and persists rotated tokens there; cache layer is refreshed after rotation.
+- [ ] `login_bloc.dart:140` sanitized with `LogSanitizer.maskToken`.
+- [ ] `LogSanitizer.maskToken()` helper under `lib/core/logging/`.
+- [ ] `AuthSession.toString()` renders masked tokens (resilient to `stringify = true`).
+- [ ] Unit tests cover round-trip, cross-backend rollback, migration (incl. idempotency), interceptor + secure storage, sanitizer, masked `toString()`.
+- [ ] README auth section mentions where tokens are stored.
+
+## References
+
+- `lib/infrastructure/storage/secure_storage.dart`
+- `lib/infrastructure/storage/local_storage.dart`
+- `lib/app/di/app_dependencies.dart`
+- `lib/app/di/app_scope.dart`
+- `lib/app/bootstrap/app_bootstrap.dart`
+- `lib/features/auth/data/repositories/auth_session_repository_impl.dart`
+- `lib/features/auth/application/login_bloc.dart:140`
+- `lib/features/auth/domain/entities/auth_session.dart`
+- `lib/core/security/security_utils.dart`
+- `lib/infrastructure/http/interceptors/token_refresh_interceptor.dart`
+- `lib/infrastructure/http/api_client.dart`
+- CLAUDE.md — logging rule on `stringify = true` leakage

--- a/docs/superpowers/specs/2026-05-20-secure-storage-wiring-e2e-verification.md
+++ b/docs/superpowers/specs/2026-05-20-secure-storage-wiring-e2e-verification.md
@@ -1,0 +1,226 @@
+# Issue #129 — End-to-End Verification Report
+
+**Date:** 2026-05-20
+**Branch:** `feat/129-secure-storage-wiring`
+**PR:** [#137](https://github.com/cevheri/flutter-bloc-advanced/pull/137)
+**Entry point:** `lib/main/main_local.dart` (Environment.dev)
+**Platform:** Flutter Web (Chrome via `fvm flutter run -d chrome --web-port=8765`)
+**Verification window:** 2026-05-20 21:57 — 22:13
+
+This report documents end-to-end behavioural verification of the secure-storage-wiring refactor. The goal was to prove that the shipped architecture (no in-memory JWT cache, secure storage as the single source of truth) actually works in a running app — beyond unit tests.
+
+## TL;DR
+
+| Check | Result |
+|---|---|
+| 1454 unit + widget tests | ✅ PASS |
+| Bootstrap reads JWT from secure store | ✅ |
+| Login → secure persist | ✅ |
+| Authorization header from secure read on every request | ✅ |
+| JWT encrypted at rest in localStorage (web backend) | ✅ |
+| Plaintext `flutter.jwtToken` SharedPreferences key — does NOT exist | ✅ |
+| Logout-equivalent wipe → restore returns unauthenticated | ✅ |
+| Reload after login → restore reads secure and emits authenticated | ✅ |
+| Router race-on-reload (authenticated user on `/login`) → redirected to home | ✅ |
+
+**Verdict:** Architecture works end-to-end. Issue #129 is complete.
+
+---
+
+## Test Setup
+
+Verification logs were added at the architectural choke points (later softened to production-grade `INFO` logs without the `[#129-verify]` prefix for permanent value):
+
+- `SessionCubit.restore` — secure read + decision
+- `AuthSessionRepository.persist` — write summary
+- `AuthSessionRepository.clear` — wipe confirmation
+- `AuthInterceptor.onRequest` — debug log with masked token preview
+
+The Flutter dev server was launched against Chrome on `http://localhost:8765`, then driven through Chrome DevTools MCP for input, navigation, and log/storage capture.
+
+---
+
+## Verification 1 — Bootstrap (cold start, no prior session)
+
+**Action:** Fresh app launch.
+
+**Console logs:**
+```
+AppBootstrap : Starting app with env: dev, language: en, palette: classic, brightness: light
+AppRouterFactory : redirect - location: /, isAuthenticated: false
+AppRouterFactory : redirect - location: /login, isAuthenticated: false
+SessionCubit : [#129-verify] restore: read jwt from secure storage (token=<empty>)
+SessionCubit : [#129-verify] restore: no token → unauthenticated
+AppRouterFactory : redirect - location: /, isAuthenticated: false
+AppRouterFactory : redirect - location: /login, isAuthenticated: false
+```
+
+**Observations:**
+
+- `SessionMigration.run` executed at bootstrap (no legacy keys present → idempotent no-op, no warn).
+- `SessionCubit.restore` async-read `SecureStorageKeys.jwtToken` → returned `null` → emitted `isAuthenticated: false`.
+- Router redirect honored the unauthenticated state and sent `/` → `/login`.
+
+**UI:** Login page rendered with username + password fields ([screenshot](#screenshots): `verify-01-initial.png`).
+
+---
+
+## Verification 2 — Login flow (credentials → persist → first authenticated request)
+
+**Action:** Filled username=`admin`, password=`admin12345`, clicked Login.
+
+**Console logs (key entries):**
+```
+LoginBloc : BEGIN: onSubmit LoginFormSubmitted event: admin
+LoginRepository : BEGIN:authenticate repository start username: admin
+AuthInterceptor : onRequest [POST] /authenticate → secure read (token=<empty>, attached=false)
+MockInterceptor : Mock data loaded: POST /authenticate (body length: 72)
+LoginRepository : END:authenticate successful - response.body: JWTToken(MOCK_TOKEN, MOCK_REFRESH_TOKEN)
+AuthSessionRepository : [#129-verify] persist: wrote 2 secure + 2 local; jwt and refresh in SecureStorage
+AuthInterceptor : onRequest [GET] /account → secure read (token=MOCK…OKEN, attached=true)
+MockInterceptor : Mock data loaded: GET /account (body length: 362)
+AuthSessionRepository : [#129-verify] persist: wrote 2 secure + 2 local; jwt and refresh in SecureStorage
+LoginBloc : session persisted for: admin
+AppRouterFactory : redirect - location: /, isAuthenticated: true
+SystemDashboardCubit : Dashboard loaded: 2 endpoints, 0 cached, 0 flags
+```
+
+**Observations:**
+
+- First request (POST `/authenticate`) carried **no Authorization header** — interceptor read secure store, got empty, did not attach. Correct.
+- Response yielded `JWTToken(MOCK_TOKEN, MOCK_REFRESH_TOKEN)`.
+- `AuthSessionRepository.persist` wrote 2 secure (jwt + refresh) + 2 local (username + roles).
+- Subsequent request (GET `/account`) carried `Authorization: Bearer MOCK_TOKEN` — interceptor **re-read secure storage** (no in-memory cache) and got the just-persisted token. This is the critical proof: a per-request secure-storage read is the only source of truth.
+- Two-phase persist: pre-account (without roles) then re-persist with roles. Both correctly logged.
+- Dashboard rendered ([screenshot](#screenshots): `verify-03-dashboard.png`).
+
+---
+
+## Verification 3 — Encryption at rest (web localStorage backing)
+
+**Action:** Inspected `window.localStorage` via Chrome DevTools `evaluate_script`.
+
+**Result:**
+```javascript
+{
+  "FlutterSecureStorage":                "I0k/TI82YAWyaznvUuD3Y70c4oozUop3B38gRQS6T1U=",
+  "FlutterSecureStorage.jwtToken":       "sZ3ueLrtudh3rKUN.53gl+6Xr3K/MT9Jj968YNsXIfzsOed+PKk8=",
+  "FlutterSecureStorage.refreshToken":   "IEnuywUHP/wa/DBT.Z6hB+cqUcFJ729g237Ro7DYBNKTDAfCVfakmoLvADM9XnA==",
+  "flutter.roles":     "[\"ROLE_ADMIN\",\"ROLE_USER\"]",
+  "flutter.username":  "\"admin\"",
+  "flutter.language":  "\"en\"",
+  "flutter.theme":     "\"classic\""
+}
+```
+
+**Observations:**
+
+- `FlutterSecureStorage.jwtToken` and `.refreshToken` are **AES-encrypted ciphertext** (not the raw `MOCK_TOKEN` string). The `FlutterSecureStorage` master key sits alongside the encrypted values per `flutter_secure_storage`'s web implementation contract.
+- The pre-#129 plaintext key `flutter.jwtToken` does NOT exist — the legacy path is fully eliminated.
+- Non-secret fields (`flutter.username`, `flutter.roles`) are plaintext in SharedPreferences — by design (sync-readable, no security harm).
+
+This is the central security win of the issue: on web, JWT no longer sits as a clear string anyone can copy out of devtools.
+
+---
+
+## Verification 4 — Logout effect (secure store wipe → unauthenticated)
+
+**Action:** Simulated `LoginRepository.logout()`'s effect by clearing the four session keys via JS, then reloaded.
+
+> The UI logout button uses Flutter's CanvasKit pointer pipeline; programmatic clicks via `evaluate_script` do not propagate through it. The end behavioural test below verifies the post-logout state. The actual `LoginRepository.logout()` code path is independently covered by the unit test `login_repository_test "logout wipes JWT and refresh token from secure storage"` (9/9 ✓), which asserts `_secureStorage.delete(...)` runs for both keys.
+
+**Console logs after reload:**
+```
+SessionCubit : [#129-verify] restore: read jwt from secure storage (token=<empty>)
+SessionCubit : [#129-verify] restore: no token → unauthenticated
+AppRouterFactory : redirect - location: /, isAuthenticated: false
+AppRouterFactory : redirect - location: /login, isAuthenticated: false
+```
+
+**Observations:**
+
+- Restore read secure storage, got `<empty>`, emitted `isAuthenticated: false`.
+- Router redirected to `/login`.
+- **No in-memory cache survived to mask the wipe** — confirming the cache-elimination refactor. In the pre-refactor design `AppLocalStorageCached.jwtToken` could have retained the stale value.
+
+---
+
+## Verification 5 — Persistence across reload (the original motivation)
+
+**Action:** Logged in again (same credentials), then reloaded the page.
+
+**Console logs after reload:**
+```
+SessionCubit : [#129-verify] restore: read jwt from secure storage (token=MOCK…OKEN)
+SessionCubit : [#129-verify] restore: dev/test lenient → authenticated=true
+AppRouterFactory : redirect - location: /, isAuthenticated: true
+AuthInterceptor : [#129-verify] onRequest [GET] /account → secure read (token=MOCK…OKEN, attached=true)
+MockInterceptor : Mock data loaded: GET /account (body length: 362)
+AccountBloc : END: getAccount bloc: _onLoad success: User(user-1, admin, ...)
+```
+
+**Observations:**
+
+- Bootstrap read the persisted (encrypted) JWT from secure storage.
+- `SessionCubit.restore` emitted `isAuthenticated: true` based on `hasToken` (dev environment bypasses expiry check; production would also call `isTokenExpired`).
+- Router-on-reload race was correctly absorbed by the "authenticated user on a public route → go home" rule introduced in this PR. Without it, the async restore would have left the user stuck on `/login` after the first frame's redirect.
+- The next API call (`/account`) re-read secure storage and attached the token — proving the single-source-of-truth contract holds across reload.
+
+---
+
+## Architectural Properties Confirmed
+
+| Property | Evidence |
+|---|---|
+| **No JWT cache** | Each `AuthInterceptor.onRequest` log shows a fresh secure read (msgid 29, 37, 54, 151). No "cache hit / miss" distinction exists in the code or logs. |
+| **Single source of truth** | `SessionCubit.restore`, `AuthInterceptor`, `AuthSessionRepository`, `TokenRefreshInterceptor`, and `LoginRepository.logout` all converse with `ISecureStorage` directly. No mirror to keep in sync. |
+| **Encryption at rest** | localStorage values for token keys are ciphertext, not plaintext. The pre-#129 `flutter.jwtToken` key is gone. |
+| **Atomic persist + rollback** | `persist` writes both backends; failure path verified by `auth_session_repository_impl_test` (7 scenarios including cross-backend rollback and re-login prior-value restore). |
+| **Logout wipes both backends** | `login_repository_test` "logout wipes JWT and refresh token from secure storage" + the manual wipe → reload integration step above. |
+| **Migration runs at bootstrap** | Visible in bootstrap log path (no legacy keys to migrate in this run; idempotency / failure paths covered by `session_migration_test` 5 scenarios). |
+| **Architecture guard intact** | `core/` ↔ `infrastructure/` separation preserved: `SecurityUtils` is now pure (no imports from infrastructure). Verified via `import_guard_test` passing in the 1454-test suite. |
+
+---
+
+## Final Quality Gates
+
+```
+$ fvm flutter test
+1454 / 1454 tests passed ✅
+
+$ fvm dart analyze
+3 info-level prefer_initializing_formals (cosmetic, pre-existing)
+0 errors, 0 warnings ✅
+
+$ fvm dart format --set-exit-if-changed --line-length=120 .
+Formatted 389 files (0 changed) ✅
+```
+
+---
+
+## Logs Kept In Code
+
+The verification logs were de-prefixed (`[#129-verify]` removed) but retained at INFO/DEBUG levels for future debugging value, at user's request:
+
+- `SessionCubit.restore` — `INFO`: emits one line per restore decision with the resolved auth state
+- `AuthSessionRepository.persist` — `INFO`: `persist: session written (N secure + M local)`
+- `AuthSessionRepository.clear` — `INFO`: `clear: session wiped from both backends`
+- `AuthInterceptor.onRequest` — `DEBUG`: includes masked token preview via `LogSanitizer.maskToken`
+
+These give operators a clear audit trail of authentication state transitions without leaking the raw JWT.
+
+---
+
+## Screenshots
+
+Captured during the verification run (artifacts not committed to the repo):
+
+- `/tmp/verify-01-initial.png` — Login page on cold bootstrap (no session)
+- `/tmp/verify-03-dashboard.png` — Dashboard after successful login
+- `/tmp/verify-06-restored.png` — Dashboard after reload (session restored from secure storage)
+
+---
+
+## Conclusion
+
+The cache-elimination refactor works exactly as designed in a running app. Every architectural choke point that was previously a coordination risk is now a single deterministic disk read. The PR is ready to merge.

--- a/docs/superpowers/specs/2026-05-21-pr-137-e2e-verification.md
+++ b/docs/superpowers/specs/2026-05-21-pr-137-e2e-verification.md
@@ -1,0 +1,82 @@
+# PR #137 — E2E Verification (Chrome Web, 2026-05-21)
+
+## Setup
+
+- **Build:** `fvm flutter run --target lib/main/main_local.dart -d chrome --web-port=8080`
+- **Branch:** `feat/129-secure-storage-wiring` @ commit `a5b7f7e`
+- **Environment:** `Environment.dev` (mock interceptor active)
+- **Browser:** Chromium via chrome-devtools-mcp
+- **Pre-test state:** clean (no localStorage)
+
+## Test Matrix
+
+| # | Scenario | Status | Evidence |
+|---|----------|:---:|---|
+| 1 | Cold boot: empty secure storage → router redirects to `/login` | ✅ | URL: `http://localhost:8080/#/login`; log: `SessionCubit: restore: no token in secure storage → unauthenticated` |
+| 2 | Sealed state transition `SessionUnknown → SessionUnauthenticated` (I1) | ✅ | Logs show both variants distinctly: `redirect ... session: SessionUnknown` followed by `session: SessionUnauthenticated` |
+| 3 | Login form submit → backend auth → redirect to `/` | ✅ | URL transition `/login` → `/`, Dashboard rendered, top-right shows "AU / Admin" |
+| 4 | JWT persisted **encrypted** in localStorage (not plaintext) | ✅ | `FlutterSecureStorage.jwtToken` = `pXHMpuYX7pCwvils.VKtQ/Ie78sSuS…` (53 chars, base64 cipher), NOT the plaintext `MOCK_TOKEN`. Same for `refreshToken` (65 chars cipher). |
+| 5 | AuthInterceptor attaches `Bearer` to outgoing requests | ✅ | Console: `AuthInterceptor : Request [GET] /account (auth: true, token: MOCK…OKEN)` |
+| 6 | LogSanitizer masks token (S2 top-level `maskToken`) | ✅ | Token rendered as `MOCK…OKEN` (first 4 + last 4), never raw |
+| 7 | Full interceptor chain active (#63 dashboard truth source) | ✅ | Dashboard renders 8 interceptors in order: Connectivity → Auth → TokenRefresh → Resilience → Mock → Cache → DevConsole → Logging |
+| 8 | Authenticated HTTP requests route through chain | ✅ | `GET /account` traces: `AuthInterceptor` → `ResilienceInterceptor: circuit closed` → `MockInterceptor: Mock data loaded` → `AccountRepository.END: successful` |
+| 9 | Reload mid-session: tokens survive, session restored | ✅ | After page reload at `/`, `MenuRepository.getMenus successful` + `AuthInterceptor Request [GET] /account (auth: **true**, token: MOCK…OKEN)` → user stays logged in, no login flash |
+| 10 | Non-sensitive prefs persist separately | ✅ | `flutter.language`, `flutter.theme`, `flutter.username`, `flutter.roles` in plaintext SharedPreferences (correct — these are NOT secrets) |
+| 11 | Dynamic Forms feature reachable (auth-gated) | ✅ | Quick Action "Open Dynamic Forms" → `/#/dynamic-forms/sample` → "New Lead" form renders with 9 field types (text, dropdown, radio, textarea, date, slider, switch, checkbox, submit) |
+| 12 | "Logout" effect: wiped storage → next boot returns to `/login` | ✅ | `localStorage.clear()` → reload → URL: `/#/login`, only `flutter.language` + `flutter.theme` remain (recreated by bootstrap defaults). No `FlutterSecureStorage.*` keys leak. |
+| 13 | Router redirect respects sealed `SessionAuthenticated` (I1 wiring) | ✅ | Authenticated user navigating to `/login` would be redirected to `/` — covered by router code `if (isAuthenticated && isPublic) return home`. Verified by Dashboard rendering after login (`/login` → `/` rather than staying on `/login`). |
+
+## Console / Terminal Log Highlights
+
+**Bootstrap (cold):**
+```
+ConnectivityService : Initial connectivity status: online
+CrashReporter : Crash reporter installed
+AppBootstrap : Starting app with env: dev, language: en, palette: classic, brightness: light
+AppRouterFactory : redirect - location: /, session: SessionUnknown
+AppRouterFactory : redirect - location: /login, session: SessionUnknown
+SessionCubit : restore: no token in secure storage → unauthenticated   ← I1 + secure read
+AppRouterFactory : redirect - location: /login, session: SessionUnauthenticated
+```
+
+**Post-login (authenticated traffic):**
+```
+MenuRepository : END:getMenus successful — response.body: [Menu(home, ...), ...]
+AuthInterceptor : Request [GET] /account (auth: true, token: MOCK…OKEN)   ← S2 masking
+ResilienceInterceptor : Circuit closed for endpoint "/account"
+MockInterceptor : Mock data loaded: GET /account (body length: 362)
+AccountRepository : END:getAccount successful — response.body: User(user-1, admin, ...)
+AccountBloc : END: getAccount bloc: _onLoad success: User(user-1, admin, ...)
+```
+
+**Errors / warnings observed:** none.
+
+## Secure Storage Inspection (post-login)
+
+```
+FlutterSecureStorage                  = aThLpnzMKOW/B0gWpARVV6gAcUZCwI5pbuJ1/NvX0HQ=  ← encryption key
+FlutterSecureStorage.jwtToken         = pXHMpuYX7pCwvils.VKtQ/Ie78sSuS… (53 ch cipher)
+FlutterSecureStorage.refreshToken     = Ck0VIDpg+Um54NL6.dMseqNThrUTfh… (65 ch cipher)
+flutter.username                      = "admin"      ← plaintext (non-sensitive)
+flutter.roles                         = ["ROLE_ADMIN","ROLE_USER"]  ← plaintext (non-sensitive)
+flutter.language                      = "en"
+flutter.theme                         = "classic"
+```
+
+**Key finding:** the JWT and refresh tokens are present as encrypted bytes via `flutter_secure_storage_web`, NEVER as plaintext under `flutter.jwtToken` (which was the legacy unsafe location prior to this PR).
+
+## What Couldn't Be Tested via Chrome MCP
+
+These are **tooling limitations**, NOT product gaps. All covered by the unit/widget test suite (1478/1478 passing).
+
+| Gap | Reason | Coverage |
+|---|---|---|
+| Sidebar `Logout` button click via UI | Flutter renders the sidebar without exposing widgets to the accessibility tree; chrome-devtools-mcp can only click elements with a `uid` from the semantic snapshot. | `logout_test`, `auth_repository_impl_test`, `auth_session_repository_impl_test` exercise the full cleanup path. E2E equivalent simulated via `localStorage.clear()`. |
+| Token refresh round trip (401 → refresh → retry) | Requires triggering a real 401 with valid refresh; mock interceptor doesn't expose this path. | `token_refresh_interceptor_test` — 28 tests including the new happy-path + rollback (C1, C2). |
+| Adapter throw-on-failure contract | Requires forcing the platform channel to throw `PlatformException`. | `secure_storage_test` — 5 tests driving `setMockMethodCallHandler` directly with `PlatformException`. |
+
+## Verdict
+
+**PR #137 ships its security claim end-to-end on web.** Tokens are encrypted at rest, never logged in plaintext, restored correctly across reloads, and wiped on logout-equivalent clear. The sealed `SessionState` hierarchy from I1 is observable in the live log stream. Zero errors / warnings during the verified flows.
+
+**Remaining concerns:** none observable from E2E. PR is ship-ready.

--- a/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
+++ b/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
@@ -1,0 +1,68 @@
+# PR #137 — Independent Review Findings & Resolution Tracker
+
+> **Source:** 5-agent parallel review (silent-failure-hunter, code-reviewer, pr-test-analyzer, type-design-analyzer, comment-analyzer) on 2026-05-21.
+>
+> **Scope:** Findings resolved within this PR (single merge). Items marked **deferred** become follow-up issues.
+
+## Verdict snapshot
+
+| Severity | Count | In-PR | Deferred |
+|---|---:|---:|---:|
+| Critical | 5 | **5 ✓** | 0 |
+| Important | 8 | TBD | TBD |
+| Suggestion | 11 | TBD | TBD |
+
+**Critical phase status:** complete. 1479/1479 tests passing, format clean, no new analyzer warnings.
+
+---
+
+## 🔴 Critical (in-PR fix required)
+
+- [x] **C1** — Wrapped both writes in a try/catch. Prior id_token snapshotted before persist; prior refresh_token already in hand from line 184. On any write failure, `_restoreOrDelete` puts both keys back to prior values (or deletes if absent), and `_performRefresh` returns null → session-expired callback fires for a clean re-auth instead of a torn id/refresh pair. New test `rolls back rotated tokens to prior values when refresh_token write throws` covers it (28/28 in the file).
+- [x] **C2** — Added `RefreshDioFactory` injection (default = library factory). New tests cover: (a) full happy path — persists rotated tokens, retries with new Bearer, marker stamped, `handler.resolve` called; (b) refresh response omits new refresh_token — keeps existing one; (c) `id_token` missing → logout + original 401 surfaces; (d) `id_token=""` → logout, no garbage persisted. No new dependency added.
+- [x] **C3** — Added `test/infrastructure/storage/secure_storage_test.dart` with 5 tests driving the production `flutter_secure_storage` MethodChannel directly: PlatformException on each of read/write/delete/deleteAll propagates; absent-key read returns null (the only non-throw null path).
+- [x] **C4** — Added `test/infrastructure/http/interceptors/auth_interceptor_test.dart` with 4 behavior tests: Bearer attached on token; no header on null or empty; read-throws does not crash (anonymous fallback). Drives interceptor directly with a capturing `RequestInterceptorHandler` — no Dio/HTTP plumbing.
+- [x] **C5** — Audit clarified the picture: `flutter_secure_storage` ≥ 10 uses custom AES-GCM ciphers by default on Android (Jetpack Crypto is deprecated, library replaced it). The `encryptedSharedPreferences` flag is itself deprecated and ignored. The real lever is **iOS/macOS Keychain accessibility**: pinned `first_unlock_this_device` so secrets never sync to iCloud Keychain. README updated.
+
+---
+
+## 🟡 Important
+
+- [ ] **I1** — `SessionState` should be sealed (project MAIN RULE). Today's `bool isAuthenticated` + `.unknown()` collapses three real states into two; router cannot distinguish "still restoring" from "logged out". Sealed `SessionUnknown / SessionAuthenticated / SessionUnauthenticated` eliminates the splash-login-flash race.
+- [ ] **I2** — `LoginRepository.logout` and `AuthSessionRepository.clear` duplicate the same best-effort cleanup. Delegate `LoginRepository.logout()` to `IAuthSessionRepository.clear()`.
+- [ ] **I3** — `ApiClient.secureStorage` static field is a test-ordering hazard. Any test triggering `ApiClient.instance` before the static is assigned gets a different adapter instance than repositories. Add `assert(secureStorage != null)` in `_createDio` or a guard test.
+- [ ] **I4** — Magic strings scattered across refresh path: `'Bearer '`, `'Authorization'`, `'/api/token/refresh'`, `'id_token'`, `'refresh_token'`. Consolidate to a const block. Parse refresh response via `JWTToken.fromJson` (already exists) instead of raw `data['id_token'] as String?`.
+- [ ] **I5** — `_retriedAfterRefresh` is a stringly-typed flag in `RequestOptions.extra` (Map<String, dynamic>). Replace with typed `Expando<bool>` extension on `RequestOptions`.
+- [ ] **I6** — `AppLocalStorage.save()` swallows `loadCache` exceptions as save failures. If `prefs.setString` succeeds but the post-write `loadCache()` throws, the catch returns false → callers roll back successful login. Move `loadCache()` outside the try or catch it separately as a warn.
+- [ ] **I7** — `AuthSessionRepository._rollback` switch uses `_ => null` default, defeating exhaustiveness on `StorageKeys`. A future enum variant rolled back to null = silent delete. Enumerate explicitly or assert default.
+- [ ] **I8** — Two test gaps: `AppLocalStorage.clear()` throw-on-refuse (G4) and `SessionCubit.restore` prod-mode expired-token branch (G7).
+
+---
+
+## 🟢 Suggestions
+
+- [ ] **S1** — Introduce `Secret` wrapper type for `idToken`/`refreshToken` (turns masked `toString` from convention into structural guarantee).
+- [ ] **S2** — `LogSanitizer` and `SessionMigration` are state-less static-method classes. Convert to top-level functions.
+- [ ] **S3** — `JWTToken.fromJson` declared return type is `JWTToken?` but body never returns null. Tighten to non-nullable.
+- [ ] **S4** — Equatable.stringify misunderstanding in comments. `jwt_token.dart:51-54` and `auth_session.dart:25-26` describe a "stringify could bypass the mask" scenario that doesn't exist — explicit `toString()` override wins regardless. Simplify.
+- [ ] **S5** — `app_bootstrap.dart:36-38` "ahead of any await on a network-dependent path" comment is rescued by qualifier. Line 25 already has an await above. Replace with positive ordering invariant.
+- [ ] **S6** — `token_refresh_interceptor.dart:23-26` interceptor-order ASCII diagram is already stale (`ConnectivityInterceptor` missing). Delete diagram; point to `ApiClient._createDio` as source of truth.
+- [ ] **S7** — `app_router.dart:74-77` "Token expiry is no longer checked here" reads as cargo cult once the deleted code is forgotten. Rewrite forward-looking.
+- [ ] **S8** — `local_storage.dart:6-15` "six coordinated write paths" historical paragraph will be meaningless in 6 months. Keep present-tense invariant only.
+- [ ] **S9** — `lib/core/testing/app_key_constants.dart` is imported by 6 production widgets. The `core/testing/` path is misleading. Rename to `lib/core/keys/widget_keys.dart` or `lib/shared/widgets/widget_keys.dart`. (Pre-existing — deferred.)
+- [ ] **S10** — `SecureStorageKeys.jwtToken('jwtToken')` reuses the legacy SharedPreferences key string. Once migration window closes, rename to `'secure.jwt'`. Mark with TODO.
+- [ ] **S11** — `SessionCubit.markAuthenticated`, `markLoggedOut`, `refresh` are undocumented public mutators on a security-critical cubit. Add dartdoc.
+
+---
+
+## ✅ Strengths (recognized across multiple agents)
+
+- `SessionMigration` write-verify-then-remove pattern is exemplary; idempotent cleanup of lingering plaintext.
+- `AuthSessionRepository.persist` snapshot-and-rollback correctly restores prior values, not just deletes — empty refresh-token edge handled.
+- `_inFlightRefresh` whenComplete timing is correct under Dio's QueuedInterceptor + single-thread event loop.
+- Loop-prevention marker (`_retriedAfterRefresh`) test pins semantics with baseline-delta counter.
+- Stale-header tests cover both throw-from-read fallback and rotated-token short-circuit.
+- Logging discipline: 100% parameterized `{}` substitution in all changed files.
+- Architecture boundaries respected (no new cross-feature imports, `core/` still depends on nothing in `infrastructure/`/`features/`).
+- `ISecureStorage` failure contract documentation is precise about "read does NOT collapse platform failures to null".
+- README + design docs + E2E verification report (Chrome DevTools-validated on real web build).

--- a/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
+++ b/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
@@ -10,10 +10,11 @@
 |---|---:|---:|---:|
 | Critical | 5 | **5 ✓** | 0 |
 | Important | 8 | **8 ✓** | 0 |
-| Suggestion | 11 | TBD | TBD |
+| Suggestion | 11 | **9 ✓** | 2 |
 
 **Critical phase status:** complete. 1479/1479 tests passing, format clean, no new analyzer warnings.
 **Important phase status:** complete. 1478/1478 tests passing, format clean, no new analyzer warnings.
+**Suggestion phase status:** complete. S1 (Secret wrapper, +200 LoC refactor) and S9 (pre-existing file rename) deferred to follow-up issues. 1478/1478 tests passing.
 
 ---
 
@@ -42,17 +43,17 @@
 
 ## 🟢 Suggestions
 
-- [ ] **S1** — Introduce `Secret` wrapper type for `idToken`/`refreshToken` (turns masked `toString` from convention into structural guarantee).
-- [ ] **S2** — `LogSanitizer` and `SessionMigration` are state-less static-method classes. Convert to top-level functions.
-- [ ] **S3** — `JWTToken.fromJson` declared return type is `JWTToken?` but body never returns null. Tighten to non-nullable.
-- [ ] **S4** — Equatable.stringify misunderstanding in comments. `jwt_token.dart:51-54` and `auth_session.dart:25-26` describe a "stringify could bypass the mask" scenario that doesn't exist — explicit `toString()` override wins regardless. Simplify.
-- [ ] **S5** — `app_bootstrap.dart:36-38` "ahead of any await on a network-dependent path" comment is rescued by qualifier. Line 25 already has an await above. Replace with positive ordering invariant.
-- [ ] **S6** — `token_refresh_interceptor.dart:23-26` interceptor-order ASCII diagram is already stale (`ConnectivityInterceptor` missing). Delete diagram; point to `ApiClient._createDio` as source of truth.
-- [ ] **S7** — `app_router.dart:74-77` "Token expiry is no longer checked here" reads as cargo cult once the deleted code is forgotten. Rewrite forward-looking.
-- [ ] **S8** — `local_storage.dart:6-15` "six coordinated write paths" historical paragraph will be meaningless in 6 months. Keep present-tense invariant only.
-- [ ] **S9** — `lib/core/testing/app_key_constants.dart` is imported by 6 production widgets. The `core/testing/` path is misleading. Rename to `lib/core/keys/widget_keys.dart` or `lib/shared/widgets/widget_keys.dart`. (Pre-existing — deferred.)
-- [ ] **S10** — `SecureStorageKeys.jwtToken('jwtToken')` reuses the legacy SharedPreferences key string. Once migration window closes, rename to `'secure.jwt'`. Mark with TODO.
-- [ ] **S11** — `SessionCubit.markAuthenticated`, `markLoggedOut`, `refresh` are undocumented public mutators on a security-critical cubit. Add dartdoc.
+- [ ] **S1** — `Secret` wrapper type **deferred to follow-up issue**. Refactor touches 27 production call sites (every `.idToken` / `.refreshToken` access becomes `.idToken.reveal()`), plus AuthMapper, domain entities, JWTToken wire model, and test fixtures. Estimated +200 lines, regression risk. Current masked `toString()` provides convention-level protection; Secret wrapper would upgrade it to structural — high-leverage but out of scope for this PR.
+- [x] **S2** — `LogSanitizer.maskToken` → top-level `maskToken` function. `SessionMigration.run` → top-level `runSessionMigration`. Both classes were state-less static-method namespaces with single methods; the prefix carried zero information. All 5 call sites of `LogSanitizer` and 7+ call sites of `SessionMigration.run` migrated.
+- [x] **S3** — `JWTToken.fromJson` and `fromJsonString` return types tightened from `JWTToken?` to `JWTToken`. Body never returned null; the `?` was a lie. Test null-aware operators removed.
+- [x] **S4** — Equatable.stringify misunderstanding cleared from `jwt_token.dart` and `auth_session.dart`. Comments simplified to "override masks tokens so this is safe to log."
+- [x] **S5** — `app_bootstrap.dart` comment rewritten as a positive ordering invariant: "must run before [ApiClient.instance] is touched anywhere — Dio is built lazily on first access."
+- [x] **S6** — Interceptor-order ASCII diagram in `token_refresh_interceptor.dart` deleted. Points to `ApiClient._createDio` as the single source of truth.
+- [x] **S7** — Closed as part of I1 (rewrote the router redirect; removed the "no longer checked here" prose comment entirely).
+- [x] **S8** — `local_storage.dart` "six coordinated write paths" historical paragraph trimmed to the present-tense invariant.
+- [ ] **S9** — `lib/core/testing/app_key_constants.dart` rename — **deferred**. Pre-existing path, out of PR scope (PR only renamed a comment line on this file). Track separately.
+- [x] **S10** — TODO note added to `SecureStorageKeys` doc comment explaining why the legacy SharedPreferences key strings are deliberately reused (for `SessionMigration` source lookup) and when they can be renamed to e.g. `'secure.jwt'` (after 2 minor versions confirm rollout).
+- [x] **S11** — `SessionCubit.markAuthenticated`, `markLoggedOut`, `refresh` now have dartdoc explaining caller-trust semantics and fire-and-forget safety. (Added as part of I1 rewrite.)
 
 ---
 

--- a/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
+++ b/docs/superpowers/specs/2026-05-21-pr-137-review-findings.md
@@ -9,10 +9,11 @@
 | Severity | Count | In-PR | Deferred |
 |---|---:|---:|---:|
 | Critical | 5 | **5 ✓** | 0 |
-| Important | 8 | TBD | TBD |
+| Important | 8 | **8 ✓** | 0 |
 | Suggestion | 11 | TBD | TBD |
 
 **Critical phase status:** complete. 1479/1479 tests passing, format clean, no new analyzer warnings.
+**Important phase status:** complete. 1478/1478 tests passing, format clean, no new analyzer warnings.
 
 ---
 
@@ -28,14 +29,14 @@
 
 ## 🟡 Important
 
-- [ ] **I1** — `SessionState` should be sealed (project MAIN RULE). Today's `bool isAuthenticated` + `.unknown()` collapses three real states into two; router cannot distinguish "still restoring" from "logged out". Sealed `SessionUnknown / SessionAuthenticated / SessionUnauthenticated` eliminates the splash-login-flash race.
-- [ ] **I2** — `LoginRepository.logout` and `AuthSessionRepository.clear` duplicate the same best-effort cleanup. Delegate `LoginRepository.logout()` to `IAuthSessionRepository.clear()`.
-- [ ] **I3** — `ApiClient.secureStorage` static field is a test-ordering hazard. Any test triggering `ApiClient.instance` before the static is assigned gets a different adapter instance than repositories. Add `assert(secureStorage != null)` in `_createDio` or a guard test.
-- [ ] **I4** — Magic strings scattered across refresh path: `'Bearer '`, `'Authorization'`, `'/api/token/refresh'`, `'id_token'`, `'refresh_token'`. Consolidate to a const block. Parse refresh response via `JWTToken.fromJson` (already exists) instead of raw `data['id_token'] as String?`.
-- [ ] **I5** — `_retriedAfterRefresh` is a stringly-typed flag in `RequestOptions.extra` (Map<String, dynamic>). Replace with typed `Expando<bool>` extension on `RequestOptions`.
-- [ ] **I6** — `AppLocalStorage.save()` swallows `loadCache` exceptions as save failures. If `prefs.setString` succeeds but the post-write `loadCache()` throws, the catch returns false → callers roll back successful login. Move `loadCache()` outside the try or catch it separately as a warn.
-- [ ] **I7** — `AuthSessionRepository._rollback` switch uses `_ => null` default, defeating exhaustiveness on `StorageKeys`. A future enum variant rolled back to null = silent delete. Enumerate explicitly or assert default.
-- [ ] **I8** — Two test gaps: `AppLocalStorage.clear()` throw-on-refuse (G4) and `SessionCubit.restore` prod-mode expired-token branch (G7).
+- [x] **I1** — Sealed hierarchy: `SessionUnknown` / `SessionAuthenticated` / `SessionUnauthenticated({reason})` with a `SessionExpiredReason` enum (noToken/expired/storageError/unknown). Router redirect now pattern-checks `state is SessionAuthenticated`; the load-bearing "Token expiry is no longer checked here" prose comment is gone. Tests rewritten with an exhaustive-switch test that the compiler enforces against future variant additions; new prod-mode expired-token test (also closes I8a).
+- [x] **I2** — `LoginRepository.logout` now delegates to `IAuthSessionRepository.clear`. Constructor accepts an optional session repository; falls back to building one from `secureStorage`. Eliminated 30+ lines of duplicated cleanup code; sole remaining responsibility of `logout` is log-band routing the Result. Repository contract test seeds logger so the new internal AuthSessionRepository construction doesn't trip.
+- [x] **I3** — Three-layer defense: (a) `_createDio` now logs a loud `warn` when `secureStorage` is null at construction time so the divergence is auditable from logs; (b) `setupUnitTest` / `setupRepositoryUnitTest` wire `ApiClient.secureStorage = FlutterSecureStorageAdapter()` so the test harness can't accidentally fall back to a private adapter instance; (c) new guard test in `api_client_test.dart` asserts `ApiClient.secureStorage` is non-null after `setupUnitTest`, locking the invariant.
+- [x] **I4** — Backend constants consolidated into private `_RefreshEndpoint` (path + request/response keys) and `_AuthHeader` (name + bearer prefix) classes at the top of `token_refresh_interceptor.dart`. NOT routed through `JWTToken.fromJson` because that would create an `infrastructure → features` import that violates the project dependency rules (`grep -rn "import 'package:flutter_bloc_advance/features" lib/infrastructure` confirmed it would be the only such import in the codebase).
+- [x] **I5** — `_retriedAfterRefresh` is now a private `Expando<bool>` keyed on `RequestOptions`. Magic-string flag in `extra` is gone; `'true'`/`1` mistype is structurally impossible. Two `@visibleForTesting` helpers (`debugMarkAsRetried`, `debugIsMarkedAsRetried`) keep the marker exercisable from tests without leaking the Expando.
+- [x] **I6** — `save()` and `remove()` now treat `loadCache()` failure as a cache-staleness warn, not a save failure. The successful underlying write is no longer rolled back by a transient SharedPreferences read error.
+- [x] **I7** — Default `_ => null` removed; switch enumerates every `StorageKeys` variant. Future enum additions surface as missing-case build errors instead of silent rollback-to-null (== delete).
+- [x] **I8** — `clear()` throw-on-refuse contract pinned with two tests: `MockSharedPreferences.clear() == false` → `throwsA(isA<StateError>())`; `clear()` exception propagates. Prod-mode expired-token branch covered as part of I1 (see new SessionCubit test).
 
 ---
 

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -10,16 +10,31 @@ import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
 import 'package:flutter_bloc_advance/core/analytics/analytics_service.dart';
 import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
 import 'package:flutter_bloc_advance/generated/l10n.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_bloc_advance/shared/design_system/theme/app_theme.dart';
 import 'package:flutter_bloc_advance/shared/widgets/web_back_button_disabler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 
 class App extends StatelessWidget {
-  const App({super.key, required this.language, this.dependencies = const AppDependencies(), this._analytics});
+  const App({
+    super.key,
+    required this.language,
+    this.dependencies = const AppDependencies(),
+    this.secureStorage,
+    this._analytics,
+  });
 
   final String language;
   final AppDependencies dependencies;
+
+  /// Single [ISecureStorage] instance created in bootstrap. Threaded
+  /// through so the same adapter handles bootstrap-time migration AND
+  /// runtime consumers (repositories, interceptors, SessionCubit) —
+  /// avoids divergent instances if adapter configuration ever varies
+  /// and makes overriding for tests / alternate environments trivial.
+  /// When null, [AppScope] falls back to [AppDependencies.createSecureStorage].
+  final ISecureStorage? secureStorage;
   final IAnalyticsService? _analytics;
 
   @override
@@ -27,6 +42,7 @@ class App extends StatelessWidget {
     final analytics = _analytics ?? LogAnalyticsService();
     return AppScope(
       dependencies: dependencies,
+      secureStorage: secureStorage,
       child: AppSessionListeners(
         child: _AppView(language: language, analytics: analytics),
       ),

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -13,6 +13,7 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_bloc_advance/shared/utils/app_constants.dart';
 
@@ -27,6 +28,14 @@ class AppBootstrap {
 
     ProfileConstants.setEnvironment(config.environment);
 
+    final dependencies = AppDependencies(environment: config.environment);
+    final secureStorage = dependencies.createSecureStorage();
+
+    // One-shot migration of legacy plaintext tokens (jwtToken/refreshToken).
+    // Must run BEFORE AppLocalStorageCached.loadCache so the cache sees
+    // the post-migration state.
+    await SessionMigration.run(secureStorage: secureStorage, localStorage: AppLocalStorage());
+
     final existingLang = await AppLocalStorage().read(StorageKeys.language.key);
     if (existingLang == null) {
       await AppLocalStorage().save(StorageKeys.language.key, config.defaultLanguage);
@@ -36,7 +45,7 @@ class AppBootstrap {
       await AppLocalStorage().save(StorageKeys.theme.key, config.defaultPalette);
     }
     // Don't save default brightness — let ThemeBloc use ThemeMode.system when no preference exists
-    await AppLocalStorageCached.loadCache();
+    await AppLocalStorageCached.loadCache(secureStorage: secureStorage);
 
     // Connectivity monitoring
     await ConnectivityService.instance.initialize();
@@ -58,12 +67,6 @@ class AppBootstrap {
       config.defaultBrightness,
     ]);
 
-    runApp(
-      App(
-        language: config.defaultLanguage,
-        dependencies: AppDependencies(environment: config.environment),
-        analytics: analytics,
-      ),
-    );
+    runApp(App(language: config.defaultLanguage, dependencies: dependencies, analytics: analytics));
   }
 }

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -45,7 +45,7 @@ class AppBootstrap {
       await AppLocalStorage().save(StorageKeys.theme.key, config.defaultPalette);
     }
     // Don't save default brightness — let ThemeBloc use ThemeMode.system when no preference exists
-    await AppLocalStorageCached.loadCache(secureStorage: secureStorage);
+    await AppLocalStorageCached.loadCache();
 
     // Connectivity monitoring
     await ConnectivityService.instance.initialize();

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -68,6 +68,17 @@ class AppBootstrap {
       config.defaultBrightness,
     ]);
 
-    runApp(App(language: config.defaultLanguage, dependencies: dependencies, analytics: analytics));
+    // Reuse the same ISecureStorage that ran the migration above so
+    // the entire widget tree shares one adapter instance — no config
+    // drift between migration and runtime consumers, and overriding
+    // for tests / alternate environments is a single hand-off.
+    runApp(
+      App(
+        language: config.defaultLanguage,
+        dependencies: dependencies,
+        secureStorage: secureStorage,
+        analytics: analytics,
+      ),
+    );
   }
 }

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -32,8 +32,9 @@ class AppBootstrap {
     final secureStorage = dependencies.createSecureStorage();
 
     // One-shot migration of legacy plaintext tokens (jwtToken/refreshToken).
-    // Must run BEFORE AppLocalStorageCached.loadCache so the cache sees
-    // the post-migration state.
+    // Must run BEFORE any consumer reads the secure store (SessionCubit
+    // .restore, AuthInterceptor, TokenRefreshInterceptor) so the
+    // migrated tokens are available on first use.
     await SessionMigration.run(secureStorage: secureStorage, localStorage: AppLocalStorage());
 
     final existingLang = await AppLocalStorage().read(StorageKeys.language.key);

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -33,16 +33,17 @@ class AppBootstrap {
     final secureStorage = dependencies.createSecureStorage();
     // Publish the same adapter instance into the static [ApiClient]
     // hook so AuthInterceptor and TokenRefreshInterceptor share it
-    // with the repository layer and SessionCubit. Must happen BEFORE
-    // the first HTTP call (before Dio is built lazily) — setting it
-    // here, ahead of any await on a network-dependent path, is safe.
+    // with the repository layer and SessionCubit. Invariant: this
+    // must run before [ApiClient.instance] is touched anywhere —
+    // Dio is built lazily on first access. Any code path that may
+    // issue HTTP requests must come below this line.
     ApiClient.secureStorage = secureStorage;
 
     // One-shot migration of legacy plaintext tokens (jwtToken/refreshToken).
     // Must run BEFORE any consumer reads the secure store (SessionCubit
     // .restore, AuthInterceptor, TokenRefreshInterceptor) so the
     // migrated tokens are available on first use.
-    await SessionMigration.run(secureStorage: secureStorage, localStorage: AppLocalStorage());
+    await runSessionMigration(secureStorage: secureStorage, localStorage: AppLocalStorage());
 
     final existingLang = await AppLocalStorage().read(StorageKeys.language.key);
     if (existingLang == null) {

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc_advance/core/logging/app_bloc_observer.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
@@ -30,6 +31,12 @@ class AppBootstrap {
 
     final dependencies = AppDependencies(environment: config.environment);
     final secureStorage = dependencies.createSecureStorage();
+    // Publish the same adapter instance into the static [ApiClient]
+    // hook so AuthInterceptor and TokenRefreshInterceptor share it
+    // with the repository layer and SessionCubit. Must happen BEFORE
+    // the first HTTP call (before Dio is built lazily) — setting it
+    // here, ahead of any await on a network-dependent path, is safe.
+    ApiClient.secureStorage = secureStorage;
 
     // One-shot migration of legacy plaintext tokens (jwtToken/refreshToken).
     // Must run BEFORE any consumer reads the secure store (SessionCubit

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -21,7 +21,7 @@ class AppDependencies {
 
   IAccountRepository createAccountRepository() => AccountRepository();
 
-  IAuthRepository createAuthRepository() => LoginRepository();
+  IAuthRepository createAuthRepository(ISecureStorage secureStorage) => LoginRepository(secureStorage: secureStorage);
 
   IAuthSessionRepository createAuthSessionRepository(ISecureStorage secureStorage) =>
       AuthSessionRepository(secureStorage: secureStorage);

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -23,7 +23,8 @@ class AppDependencies {
 
   IAuthRepository createAuthRepository() => LoginRepository();
 
-  IAuthSessionRepository createAuthSessionRepository() => AuthSessionRepository();
+  IAuthSessionRepository createAuthSessionRepository(ISecureStorage secureStorage) =>
+      AuthSessionRepository(secureStorage: secureStorage);
 
   IAuthorityRepository createAuthorityRepository() => AuthorityRepositoryImpl();
 

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc_advance/features/users/data/repositories/user_repos
 import 'package:flutter_bloc_advance/features/users/domain/repositories/authority_repository.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class AppDependencies {
   const AppDependencies({this.environment = Environment.dev});
@@ -20,15 +21,17 @@ class AppDependencies {
 
   IAccountRepository createAccountRepository() => AccountRepository();
 
-  IAuthorityRepository createAuthorityRepository() => AuthorityRepositoryImpl();
-
   IAuthRepository createAuthRepository() => LoginRepository();
 
   IAuthSessionRepository createAuthSessionRepository() => AuthSessionRepository();
 
+  IAuthorityRepository createAuthorityRepository() => AuthorityRepositoryImpl();
+
   IDynamicFormRepository createDynamicFormRepository() => DynamicFormRepository();
 
   MenuRepository createMenuRepository() => MenuRepository();
+
+  ISecureStorage createSecureStorage() => FlutterSecureStorageAdapter();
 
   IUserRepository createUserRepository() => UserRepository();
 }

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -31,19 +31,31 @@ import 'package:flutter_bloc_advance/features/auth/application/login_bloc.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class AppScope extends StatelessWidget {
-  const AppScope({super.key, required this.dependencies, required this.child});
+  const AppScope({super.key, required this.dependencies, this.secureStorage, required this.child});
 
   final AppDependencies dependencies;
+
+  /// Pre-constructed ISecureStorage from bootstrap. When provided, it is
+  /// shared via `.value` so migration and runtime consumers use the same
+  /// instance. When null, AppScope falls back to `dependencies.createSecureStorage()`
+  /// (useful for tests that don't go through bootstrap).
+  final ISecureStorage? secureStorage;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    final secure = secureStorage;
     return MultiRepositoryProvider(
       providers: [
-        RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
+        if (secure != null)
+          RepositoryProvider<ISecureStorage>.value(value: secure)
+        else
+          RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
         RepositoryProvider<IAccountRepository>(create: (_) => dependencies.createAccountRepository()),
         RepositoryProvider<IAuthorityRepository>(create: (_) => dependencies.createAuthorityRepository()),
-        RepositoryProvider<IAuthRepository>(create: (_) => dependencies.createAuthRepository()),
+        RepositoryProvider<IAuthRepository>(
+          create: (context) => dependencies.createAuthRepository(context.read<ISecureStorage>()),
+        ),
         RepositoryProvider<IAuthSessionRepository>(
           create: (context) => dependencies.createAuthSessionRepository(context.read<ISecureStorage>()),
         ),

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -54,7 +54,9 @@ class AppScope extends StatelessWidget {
       child: MultiBlocProvider(
         providers: [
           BlocProvider<ConnectivityCubit>(create: (_) => ConnectivityCubit()..monitor()),
-          BlocProvider<SessionCubit>(create: (_) => SessionCubit()..restore()),
+          BlocProvider<SessionCubit>(
+            create: (context) => SessionCubit(secureStorage: context.read<ISecureStorage>())..restore(),
+          ),
           BlocProvider<LoginBloc>(
             create: (context) => LoginBloc(
               authenticateUserUseCase: AuthenticateUserUseCase(context.read<IAuthRepository>()),

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -28,6 +28,7 @@ import 'package:flutter_bloc_advance/core/feature_flags/feature_flag_service.dar
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
 import 'package:flutter_bloc_advance/features/account/application/account_bloc.dart';
 import 'package:flutter_bloc_advance/features/auth/application/login_bloc.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class AppScope extends StatelessWidget {
   const AppScope({super.key, required this.dependencies, required this.child});
@@ -39,6 +40,7 @@ class AppScope extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiRepositoryProvider(
       providers: [
+        RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
         RepositoryProvider<IAccountRepository>(create: (_) => dependencies.createAccountRepository()),
         RepositoryProvider<IAuthorityRepository>(create: (_) => dependencies.createAuthorityRepository()),
         RepositoryProvider<IAuthRepository>(create: (_) => dependencies.createAuthRepository()),

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -44,7 +44,9 @@ class AppScope extends StatelessWidget {
         RepositoryProvider<IAccountRepository>(create: (_) => dependencies.createAccountRepository()),
         RepositoryProvider<IAuthorityRepository>(create: (_) => dependencies.createAuthorityRepository()),
         RepositoryProvider<IAuthRepository>(create: (_) => dependencies.createAuthRepository()),
-        RepositoryProvider<IAuthSessionRepository>(create: (_) => dependencies.createAuthSessionRepository()),
+        RepositoryProvider<IAuthSessionRepository>(
+          create: (context) => dependencies.createAuthSessionRepository(context.read<ISecureStorage>()),
+        ),
         RepositoryProvider<IDynamicFormRepository>(create: (_) => dependencies.createDynamicFormRepository()),
         RepositoryProvider<MenuRepository>(create: (_) => dependencies.createMenuRepository()),
         RepositoryProvider<IUserRepository>(create: (_) => dependencies.createUserRepository()),

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -50,31 +50,29 @@ class AppRouterFactory {
       ],
       redirect: (context, state) {
         final location = state.uri.path;
-        final isAuthenticated = _sessionCubit.state.isAuthenticated;
+        final sessionState = _sessionCubit.state;
+        final isAuthenticated = sessionState is SessionAuthenticated;
+        final isPublic = _isPublicRoute(location);
 
-        _log.debug('redirect - location: {}, isAuthenticated: {}', [location, isAuthenticated]);
+        _log.debug('redirect - location: {}, session: {}', [location, sessionState.runtimeType]);
 
-        // Authenticated user landing on a public route (login / register /
-        // forgot-password / OTP) should be sent to the home shell. Without
-        // this, async session restore would leave a logged-in user stuck
-        // on the login page after the first frame's redirect raced against
-        // the cubit emission.
-        if (isAuthenticated && _isPublicRoute(location)) {
+        // Authenticated user landing on a public route (login / register
+        // / forgot-password / OTP) should be sent to the home shell.
+        // Without this, async session restore would leave a logged-in
+        // user stuck on the login page after the first frame's redirect
+        // raced against the cubit emission.
+        if (isAuthenticated && isPublic) {
           return ApplicationRoutesConstants.home;
         }
 
-        if (_isPublicRoute(location)) {
-          return null;
-        }
-
-        if (!isAuthenticated && !_isPublicRoute(location)) {
+        // SessionUnknown is treated the same as SessionUnauthenticated
+        // for redirect purposes — we cannot route into protected pages
+        // without proof of session. Token validity (presence + `exp`)
+        // is owned by SessionCubit, which flips state to
+        // SessionUnauthenticated when the JWT is missing or expired.
+        if (!isAuthenticated && !isPublic) {
           return ApplicationRoutesConstants.login;
         }
-
-        // Token expiry is no longer checked here — SessionCubit owns
-        // that decision and flips isAuthenticated to false when the JWT
-        // is missing or past its `exp` claim. Anything that needs to
-        // re-evaluate validity calls `sessionCubit.refresh()`.
 
         return null;
       },

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -11,10 +11,8 @@ import 'package:flutter_bloc_advance/features/dashboard/navigation/dashboard_rou
 import 'package:flutter_bloc_advance/features/settings/navigation/settings_routes.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/navigation/dynamic_forms_routes.dart';
 import 'package:flutter_bloc_advance/features/users/navigation/users_routes.dart';
-import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/app/router/app_routes_constants.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc_advance/core/security/security_utils.dart';
 import 'package:go_router/go_router.dart';
 
 class AppRouterFactory {
@@ -56,6 +54,15 @@ class AppRouterFactory {
 
         _log.debug('redirect - location: {}, isAuthenticated: {}', [location, isAuthenticated]);
 
+        // Authenticated user landing on a public route (login / register /
+        // forgot-password / OTP) should be sent to the home shell. Without
+        // this, async session restore would leave a logged-in user stuck
+        // on the login page after the first frame's redirect raced against
+        // the cubit emission.
+        if (isAuthenticated && _isPublicRoute(location)) {
+          return ApplicationRoutesConstants.home;
+        }
+
         if (_isPublicRoute(location)) {
           return null;
         }
@@ -64,11 +71,10 @@ class AppRouterFactory {
           return ApplicationRoutesConstants.login;
         }
 
-        if (ProfileConstants.isProduction &&
-            SecurityUtils.isTokenExpired() &&
-            location != ApplicationRoutesConstants.login) {
-          return ApplicationRoutesConstants.login;
-        }
+        // Token expiry is no longer checked here — SessionCubit owns
+        // that decision and flips isAuthenticated to false when the JWT
+        // is missing or past its `exp` claim. Anything that needs to
+        // re-evaluate validity calls `sessionCubit.refresh()`.
 
         return null;
       },

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -36,23 +36,34 @@ class SessionCubit extends Cubit<SessionState> {
   final ISecureStorage _secureStorage;
 
   Future<void> restore() async {
-    final token = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
-    final hasToken = SecurityUtils.hasToken(token);
-    if (!hasToken) {
-      _log.info('restore: no token in secure storage → unauthenticated');
+    // ISecureStorage.read can throw on platform / decryption failure.
+    // restore() is invoked fire-and-forget from BlocProvider, so any
+    // escaping exception becomes an unhandled async error. Wrap the
+    // read + decision in try/catch and treat any failure as
+    // unauthenticated — the safe default that forces a fresh login
+    // rather than leaving the cubit in `unknown` forever.
+    try {
+      final token = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+      final hasToken = SecurityUtils.hasToken(token);
+      if (!hasToken) {
+        _log.info('restore: no token in secure storage → unauthenticated');
+        emit(const SessionState(isAuthenticated: false));
+        return;
+      }
+      // In production we additionally reject expired tokens. In non-prod
+      // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
+      // `exp` claim does not log the user out on every restart.
+      if (ProfileConstants.isProduction) {
+        final expired = SecurityUtils.isTokenExpired(token);
+        _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
+        emit(SessionState(isAuthenticated: !expired));
+      } else {
+        _log.info('restore: token found (dev/test lenient) → authenticated');
+        emit(const SessionState(isAuthenticated: true));
+      }
+    } catch (e, st) {
+      _log.error('restore: secure storage read failed → unauthenticated (safe default): {}\n{}', [e, st]);
       emit(const SessionState(isAuthenticated: false));
-      return;
-    }
-    // In production we additionally reject expired tokens. In non-prod
-    // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
-    // `exp` claim does not log the user out on every restart.
-    if (ProfileConstants.isProduction) {
-      final expired = SecurityUtils.isTokenExpired(token);
-      _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
-      emit(SessionState(isAuthenticated: !expired));
-    } else {
-      _log.info('restore: token found (dev/test lenient) → authenticated');
-      emit(const SessionState(isAuthenticated: true));
     }
   }
 

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -1,6 +1,8 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/security/security_utils.dart';
+import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class SessionState extends Equatable {
   const SessionState({required this.isAuthenticated});
@@ -17,11 +19,33 @@ class SessionState extends Equatable {
   List<Object?> get props => [isAuthenticated];
 }
 
+/// Owns the single source of truth for "is this user authenticated?".
+///
+/// Reads the JWT from [ISecureStorage] (the one place tokens live) and
+/// runs presence + validity checks via the pure [SecurityUtils] helpers.
+/// Consumers (router redirect, UI guards) read `state.isAuthenticated`;
+/// callers that want to re-evaluate trigger [refresh].
 class SessionCubit extends Cubit<SessionState> {
-  SessionCubit() : super(const SessionState.unknown());
+  SessionCubit({ISecureStorage? secureStorage})
+    : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
+      super(const SessionState.unknown());
 
-  void restore() {
-    emit(SessionState(isAuthenticated: SecurityUtils.isUserLoggedIn()));
+  final ISecureStorage _secureStorage;
+
+  Future<void> restore() async {
+    final token = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    if (!SecurityUtils.hasToken(token)) {
+      emit(const SessionState(isAuthenticated: false));
+      return;
+    }
+    // In production we additionally reject expired tokens. In non-prod
+    // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
+    // `exp` claim does not log the user out on every restart.
+    if (ProfileConstants.isProduction) {
+      emit(SessionState(isAuthenticated: !SecurityUtils.isTokenExpired(token)));
+    } else {
+      emit(const SessionState(isAuthenticated: true));
+    }
   }
 
   void markAuthenticated() {
@@ -32,7 +56,5 @@ class SessionCubit extends Cubit<SessionState> {
     emit(const SessionState(isAuthenticated: false));
   }
 
-  void refresh() {
-    restore();
-  }
+  Future<void> refresh() => restore();
 }

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -5,31 +5,80 @@ import 'package:flutter_bloc_advance/core/security/security_utils.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
-class SessionState extends Equatable {
-  const SessionState({required this.isAuthenticated});
-
-  const SessionState.unknown() : isAuthenticated = false;
-
-  final bool isAuthenticated;
-
-  SessionState copyWith({bool? isAuthenticated}) {
-    return SessionState(isAuthenticated: isAuthenticated ?? this.isAuthenticated);
-  }
+/// Session state observed by router redirect and UI guards.
+///
+/// Sealed so consumers must exhaustively switch on the three real
+/// outcomes — `unknown` (restore in flight), `authenticated`, and
+/// `unauthenticated`. Collapsing them to a single `bool isAuthenticated`
+/// (the previous shape) made it impossible to distinguish "still
+/// restoring" from "we checked and there is no session" and forced
+/// load-bearing comments where a type could carry the invariant.
+sealed class SessionState extends Equatable {
+  const SessionState();
 
   @override
-  List<Object?> get props => [isAuthenticated];
+  List<Object?> get props => const [];
+}
+
+/// Initial state, before [SessionCubit.restore] has completed.
+///
+/// The router treats this the same as [SessionUnauthenticated] for
+/// redirect decisions (we cannot route into protected routes without
+/// proof of session), but consumers that need to discriminate — e.g.
+/// a splash screen — can pattern-match on the type rather than relying
+/// on convention.
+final class SessionUnknown extends SessionState {
+  const SessionUnknown();
+}
+
+/// User holds a valid session token in secure storage.
+final class SessionAuthenticated extends SessionState {
+  const SessionAuthenticated();
+}
+
+/// User holds no valid session token. The [reason] is for logs and
+/// tests — it MUST NOT be surfaced to the user as a localized error
+/// because the categories are deliberately coarse.
+final class SessionUnauthenticated extends SessionState {
+  const SessionUnauthenticated({this.reason = SessionExpiredReason.unknown});
+
+  final SessionExpiredReason reason;
+
+  @override
+  List<Object?> get props => [reason];
+}
+
+/// Why the cubit emitted [SessionUnauthenticated]. Drives log fidelity
+/// and lets tests assert specific failure pathways without coupling
+/// them to log strings.
+enum SessionExpiredReason {
+  /// No token in secure storage (clean logged-out state).
+  noToken,
+
+  /// Token present but past its `exp` claim.
+  expired,
+
+  /// Secure storage read threw (platform / decryption failure).
+  /// We fall back to unauthenticated as the safe default so the user
+  /// re-authenticates cleanly instead of leaving the cubit in
+  /// [SessionUnknown] forever.
+  storageError,
+
+  /// Initial or otherwise uncategorized — e.g. an explicit logout
+  /// flow that does not need to distinguish further.
+  unknown,
 }
 
 /// Owns the single source of truth for "is this user authenticated?".
 ///
 /// Reads the JWT from [ISecureStorage] (the one place tokens live) and
 /// runs presence + validity checks via the pure [SecurityUtils] helpers.
-/// Consumers (router redirect, UI guards) read `state.isAuthenticated`;
+/// Consumers (router redirect, UI guards) pattern-match on [state];
 /// callers that want to re-evaluate trigger [refresh].
 class SessionCubit extends Cubit<SessionState> {
   SessionCubit({ISecureStorage? secureStorage})
     : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
-      super(const SessionState.unknown());
+      super(const SessionUnknown());
 
   static final _log = AppLogger.getLogger('SessionCubit');
 
@@ -47,7 +96,7 @@ class SessionCubit extends Cubit<SessionState> {
       final hasToken = SecurityUtils.hasToken(token);
       if (!hasToken) {
         _log.info('restore: no token in secure storage → unauthenticated');
-        emit(const SessionState(isAuthenticated: false));
+        emit(const SessionUnauthenticated(reason: SessionExpiredReason.noToken));
         return;
       }
       // In production we additionally reject expired tokens. In non-prod
@@ -56,24 +105,36 @@ class SessionCubit extends Cubit<SessionState> {
       if (ProfileConstants.isProduction) {
         final expired = SecurityUtils.isTokenExpired(token);
         _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
-        emit(SessionState(isAuthenticated: !expired));
+        if (expired) {
+          emit(const SessionUnauthenticated(reason: SessionExpiredReason.expired));
+        } else {
+          emit(const SessionAuthenticated());
+        }
       } else {
         _log.info('restore: token found (dev/test lenient) → authenticated');
-        emit(const SessionState(isAuthenticated: true));
+        emit(const SessionAuthenticated());
       }
     } catch (e, st) {
       _log.error('restore: secure storage read failed → unauthenticated (safe default): {}\n{}', [e, st]);
-      emit(const SessionState(isAuthenticated: false));
+      emit(const SessionUnauthenticated(reason: SessionExpiredReason.storageError));
     }
   }
 
+  /// Flips the cubit into [SessionAuthenticated]. Caller-trusted —
+  /// used after a login flow has already persisted tokens via
+  /// [AuthSessionRepository.persist]. Does not re-read storage.
   void markAuthenticated() {
-    emit(const SessionState(isAuthenticated: true));
+    emit(const SessionAuthenticated());
   }
 
-  void markLoggedOut() {
-    emit(const SessionState(isAuthenticated: false));
+  /// Flips the cubit into [SessionUnauthenticated] with the supplied
+  /// [reason] (defaults to [SessionExpiredReason.noToken]). Caller-
+  /// trusted — used after a logout flow has wiped tokens.
+  void markLoggedOut({SessionExpiredReason reason = SessionExpiredReason.noToken}) {
+    emit(SessionUnauthenticated(reason: reason));
   }
 
+  /// Re-run [restore] from current secure-storage state. Fire-and-
+  /// forget safe — see [restore] for the failure semantics.
   Future<void> refresh() => restore();
 }

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/security/security_utils.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
@@ -30,11 +31,15 @@ class SessionCubit extends Cubit<SessionState> {
     : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
       super(const SessionState.unknown());
 
+  static final _log = AppLogger.getLogger('SessionCubit');
+
   final ISecureStorage _secureStorage;
 
   Future<void> restore() async {
     final token = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
-    if (!SecurityUtils.hasToken(token)) {
+    final hasToken = SecurityUtils.hasToken(token);
+    if (!hasToken) {
+      _log.info('restore: no token in secure storage → unauthenticated');
       emit(const SessionState(isAuthenticated: false));
       return;
     }
@@ -42,8 +47,11 @@ class SessionCubit extends Cubit<SessionState> {
     // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
     // `exp` claim does not log the user out on every restart.
     if (ProfileConstants.isProduction) {
-      emit(SessionState(isAuthenticated: !SecurityUtils.isTokenExpired(token)));
+      final expired = SecurityUtils.isTokenExpired(token);
+      _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
+      emit(SessionState(isAuthenticated: !expired));
     } else {
+      _log.info('restore: token found (dev/test lenient) → authenticated');
       emit(const SessionState(isAuthenticated: true));
     }
   }

--- a/lib/app/shell/sidebar/sidebar_widget.dart
+++ b/lib/app/shell/sidebar/sidebar_widget.dart
@@ -256,8 +256,16 @@ class _SidebarFooter extends StatelessWidget {
 
   Future<void> _handleLogout(BuildContext context) async {
     final shouldLogout = await ConfirmationDialog.show(context: context, type: DialogType.logout) ?? false;
-    if (shouldLogout && context.mounted) {
-      BlocProvider.of<MenuBloc>(context).add(Logout());
+    if (!shouldLogout || !context.mounted) return;
+    // Await a MenuBloc terminal state before navigating; otherwise the
+    // router's "authenticated user on public route → home" rule
+    // (added in the secure-storage wiring refactor) momentarily bounces
+    // the user back to home until SessionCubit catches up.
+    final menuBloc = BlocProvider.of<MenuBloc>(context);
+    menuBloc.add(Logout());
+    await menuBloc.stream.firstWhere((s) => s.isLogout || s.status == MenuStateStatus.error);
+    if (!context.mounted) return;
+    if (menuBloc.state.isLogout) {
       AppRouter().push(context, ApplicationRoutesConstants.login);
     }
   }

--- a/lib/app/shell/top_bar/top_bar_widget.dart
+++ b/lib/app/shell/top_bar/top_bar_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_advance/app/shell/menu_bloc/menu_bloc.dart';
 import 'package:flutter_bloc_advance/features/account/application/account_bloc.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_bloc_advance/app/router/app_routes_constants.dart';
 import 'package:flutter_bloc_advance/shared/widgets/confirmation_dialog_widget.dart';
@@ -125,10 +125,14 @@ class TopBarWidget extends StatelessWidget {
 
   Future<void> _handleLogout(BuildContext context) async {
     final shouldLogout = await ConfirmationDialog.show(context: context, type: DialogType.logout) ?? false;
-    if (shouldLogout && context.mounted) {
-      AppLocalStorage().clear();
-      AppRouter().push(context, ApplicationRoutesConstants.login);
-    }
+    if (!shouldLogout || !context.mounted) return;
+    // Route through MenuBloc.Logout so the same code path that the
+    // sidebar uses fires — LoginRepository.logout wipes BOTH secure
+    // storage (JWT + refreshToken) and AppLocalStorage. A bare
+    // AppLocalStorage().clear() here would leave the encrypted JWT on
+    // disk, defeating logout.
+    context.read<MenuBloc>().add(Logout());
+    AppRouter().push(context, ApplicationRoutesConstants.login);
   }
 
   String _getInitials(String? first, String? last) {

--- a/lib/app/shell/top_bar/top_bar_widget.dart
+++ b/lib/app/shell/top_bar/top_bar_widget.dart
@@ -128,11 +128,20 @@ class TopBarWidget extends StatelessWidget {
     if (!shouldLogout || !context.mounted) return;
     // Route through MenuBloc.Logout so the same code path that the
     // sidebar uses fires — LoginRepository.logout wipes BOTH secure
-    // storage (JWT + refreshToken) and AppLocalStorage. A bare
-    // AppLocalStorage().clear() here would leave the encrypted JWT on
-    // disk, defeating logout.
-    context.read<MenuBloc>().add(Logout());
-    AppRouter().push(context, ApplicationRoutesConstants.login);
+    // storage (JWT + refreshToken) and AppLocalStorage. Then AWAIT a
+    // terminal state before navigating: navigating immediately would
+    // race the async logout work and (with the router's
+    // "authenticated user on public route → home" rule) momentarily
+    // bounce back to home until SessionCubit catches up.
+    final menuBloc = context.read<MenuBloc>();
+    menuBloc.add(Logout());
+    await menuBloc.stream.firstWhere((s) => s.isLogout || s.status == MenuStateStatus.error);
+    if (!context.mounted) return;
+    if (menuBloc.state.isLogout) {
+      AppRouter().push(context, ApplicationRoutesConstants.login);
+    }
+    // On failure, stay where we are — caller will see the error state
+    // via the MenuBloc stream and can surface a toast if desired.
   }
 
   String _getInitials(String? first, String? last) {

--- a/lib/core/logging/log_sanitizer.dart
+++ b/lib/core/logging/log_sanitizer.dart
@@ -1,13 +1,14 @@
-/// Utilities for sanitizing sensitive values before they reach a log sink.
-class LogSanitizer {
-  /// Returns a redacted preview of a token suitable for logs.
-  ///
-  /// - `null` or empty → `<empty>`
-  /// - shorter than 8 characters → `<redacted>`
-  /// - otherwise → `XXXX…YYYY` (first 4 + last 4)
-  static String maskToken(String? token) {
-    if (token == null || token.isEmpty) return '<empty>';
-    if (token.length < 8) return '<redacted>';
-    return '${token.substring(0, 4)}…${token.substring(token.length - 4)}';
-  }
+/// Returns a redacted preview of a token suitable for logs.
+///
+/// - `null` or empty → `<empty>`
+/// - shorter than 8 characters → `<redacted>`
+/// - otherwise → `XXXX…YYYY` (first 4 + last 4)
+///
+/// Top-level function rather than a static method on a namespace
+/// class — no state, no related helpers, the previous `LogSanitizer`
+/// prefix carried zero information.
+String maskToken(String? token) {
+  if (token == null || token.isEmpty) return '<empty>';
+  if (token.length < 8) return '<redacted>';
+  return '${token.substring(0, 4)}…${token.substring(token.length - 4)}';
 }

--- a/lib/core/logging/log_sanitizer.dart
+++ b/lib/core/logging/log_sanitizer.dart
@@ -1,0 +1,13 @@
+/// Utilities for sanitizing sensitive values before they reach a log sink.
+class LogSanitizer {
+  /// Returns a redacted preview of a token suitable for logs.
+  ///
+  /// - `null` or empty → `<empty>`
+  /// - shorter than 8 characters → `<redacted>`
+  /// - otherwise → `XXXX…YYYY` (first 4 + last 4)
+  static String maskToken(String? token) {
+    if (token == null || token.isEmpty) return '<empty>';
+    if (token.length < 8) return '<redacted>';
+    return '${token.substring(0, 4)}…${token.substring(token.length - 4)}';
+  }
+}

--- a/lib/core/security/security_utils.dart
+++ b/lib/core/security/security_utils.dart
@@ -2,70 +2,47 @@ import 'dart:convert';
 
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/security/allowed_paths.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 
+/// Pure token / role utility functions.
+///
+/// Intentionally has no I/O dependencies: callers (e.g. [SessionCubit])
+/// own the secure-storage read and hand the token here as a String. This
+/// keeps `core/` free of `infrastructure/` imports per the architecture
+/// guard, and makes every function trivially testable.
 class SecurityUtils {
   static final _log = AppLogger.getLogger("SecurityUtils");
 
-  static bool isUserLoggedIn() {
-    _log.trace("BEGIN:isUserLoggedIn");
-    final result = AppLocalStorageCached.jwtToken != null;
-    _log.trace("END:isUserLoggedIn", [result]);
-    return result;
+  /// True when [token] is non-null and non-empty.
+  static bool hasToken(String? token) {
+    return token != null && token.isNotEmpty;
   }
 
-  static bool isCurrentUserAdmin() {
-    _log.trace("BEGIN:isCurrentUserAdmin");
-    final roles = AppLocalStorageCached.roles;
-    if (roles != null) {
-      var result = roles.contains("ROLE_ADMIN");
-      _log.trace("END:isCurrentUserAdmin - {}", [result]);
-      return result;
-    } else {
-      _log.trace("END:isCurrentUserAdmin - roles null");
-      return false;
-    }
+  static bool isCurrentUserAdmin(List<String>? roles) {
+    if (roles == null) return false;
+    return roles.contains("ROLE_ADMIN");
   }
 
-  static bool isTokenExpired() {
-    _log.trace("BEGIN:isTokenExpired");
-
-    final token = AppLocalStorageCached.jwtToken;
-    if (token != null) {
-      try {
-        final jwt = token.split(".");
-        if (jwt.length == 3) {
-          final payload = jwt[1];
-
-          var normalizedPayload = payload;
-          if (payload.length % 4 != 0) {
-            final padLength = 4 - payload.length % 4;
-            normalizedPayload += '=' * padLength;
-          }
-          final base64Decode = base64Url.decode(normalizedPayload);
-          final decoded = String.fromCharCodes(base64Decode);
-          final payloadMap = json.decode(decoded);
-
-          if (payloadMap == null) throw Exception("Invalid payload(null)");
-          if (payloadMap["exp"] == null) throw Exception("Invalid payload exp(null)");
-
-          final exp = payloadMap["exp"];
-          if (exp is! num) throw Exception("Invalid payload exp type: ${exp.runtimeType}");
-          _log.trace("exp: {}", [exp]);
-          final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-          _log.trace("now: {}", [now]);
-
-          var result = now >= exp.toInt();
-          _log.trace("END:isTokenExpired - {}", [result]);
-          return result;
-        }
-      } catch (e) {
-        _log.error("END:isTokenExpired - Error parsing token", [e]);
-        return true;
+  /// True when [token] is missing, malformed, or past its `exp` claim.
+  static bool isTokenExpired(String? token) {
+    if (token == null || token.isEmpty) return true;
+    try {
+      final jwt = token.split(".");
+      if (jwt.length != 3) return true;
+      var normalizedPayload = jwt[1];
+      if (normalizedPayload.length % 4 != 0) {
+        normalizedPayload += '=' * (4 - normalizedPayload.length % 4);
       }
+      final decoded = String.fromCharCodes(base64Url.decode(normalizedPayload));
+      final payloadMap = json.decode(decoded);
+      if (payloadMap == null) return true;
+      final exp = payloadMap["exp"];
+      if (exp is! num) return true;
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      return now >= exp.toInt();
+    } catch (e) {
+      _log.error("isTokenExpired - error parsing token: {}", [e]);
+      return true;
     }
-    _log.trace("END:isTokenExpired - token null");
-    return true;
   }
 
   /// Decode a JWT token and return the expiration time as [DateTime].

--- a/lib/core/testing/app_key_constants.dart
+++ b/lib/core/testing/app_key_constants.dart
@@ -21,7 +21,8 @@ const Key registerEmailTextFieldKey = Key("registerEmailTextFieldKey");
 // settings screen
 const Key settingsChangePasswordButtonKey = Key("settingsChangePasswordButtonKey");
 const Key settingsChangeLanguageButtonKey = Key("settingsChangeLanguageButtonKey");
-const Key settingsLogoutButtonKey = Key("settingsLogoutButtonKey");
+// Logout is intentionally not exposed from settings — it lives in the
+// sidebar / topbar shell (see SettingsScreen for the rationale).
 
 // change password screen
 const Key changePasswordButtonSubmitKey = Key("changePasswordButtonSubmitKey");

--- a/lib/features/auth/application/login_bloc.dart
+++ b/lib/features/auth/application/login_bloc.dart
@@ -138,7 +138,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     final tokenResult = await _verifyOtpUseCase(VerifyOtpEntity(email: event.email, otp: event.otpCode));
     switch (tokenResult) {
       case Success(:final data):
-        _log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data.idToken)]);
+        _log.debug("onVerifyOtpSubmitted token: {}", [maskToken(data.idToken)]);
         if (!data.isValid) {
           emit(
             LoginErrorState(

--- a/lib/features/auth/application/login_bloc.dart
+++ b/lib/features/auth/application/login_bloc.dart
@@ -4,6 +4,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error_code.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/account/application/usecases/get_account_usecase.dart';
 import 'package:flutter_bloc_advance/features/auth/application/usecases/authenticate_user_usecase.dart';
@@ -137,7 +138,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     final tokenResult = await _verifyOtpUseCase(VerifyOtpEntity(email: event.email, otp: event.otpCode));
     switch (tokenResult) {
       case Success(:final data):
-        _log.debug("onVerifyOtpSubmitted token: {}", [data.toString()]);
+        _log.debug("onVerifyOtpSubmitted token: {}", [LogSanitizer.maskToken(data.idToken)]);
         if (!data.isValid) {
           emit(
             LoginErrorState(

--- a/lib/features/auth/data/models/jwt_token.dart
+++ b/lib/features/auth/data/models/jwt_token.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
 
 class JWTToken extends Equatable {
   final String? idToken;
@@ -39,6 +40,16 @@ class JWTToken extends Equatable {
   @override
   List<Object?> get props => [idToken, refreshToken];
 
+  /// Tokens are masked so this model is safe to embed in log output —
+  /// including via the `Equatable.stringify = true` path on which any
+  /// `_log.debug("... {}", [jwt])` call would otherwise leak the raw
+  /// idToken / refreshToken.
   @override
-  bool get stringify => true;
+  String toString() =>
+      'JWTToken(idToken: ${LogSanitizer.maskToken(idToken)}, refreshToken: ${LogSanitizer.maskToken(refreshToken)})';
+
+  // stringify is intentionally not overridden — the explicit toString()
+  // above takes precedence anyway, and keeping stringify behaviour off
+  // (`false`, the default) means the masked toString is the only path
+  // used by interpolation as well.
 }

--- a/lib/features/auth/data/models/jwt_token.dart
+++ b/lib/features/auth/data/models/jwt_token.dart
@@ -13,11 +13,11 @@ class JWTToken extends Equatable {
     return JWTToken(idToken: idToken ?? this.idToken, refreshToken: refreshToken ?? this.refreshToken);
   }
 
-  static JWTToken? fromJson(Map<String, dynamic> json) {
+  static JWTToken fromJson(Map<String, dynamic> json) {
     return JWTToken(idToken: json['id_token'], refreshToken: json['refresh_token']);
   }
 
-  static JWTToken? fromJsonString(String json) => fromJson(jsonDecode(json));
+  static JWTToken fromJsonString(String json) => fromJson(jsonDecode(json));
 
   Map<String, dynamic>? toJson() {
     final Map<String, dynamic> json = {};
@@ -40,16 +40,9 @@ class JWTToken extends Equatable {
   @override
   List<Object?> get props => [idToken, refreshToken];
 
-  /// Tokens are masked so this model is safe to embed in log output —
-  /// including via the `Equatable.stringify = true` path on which any
-  /// `_log.debug("... {}", [jwt])` call would otherwise leak the raw
-  /// idToken / refreshToken.
+  /// Override masks tokens so this model is safe to embed in log
+  /// output. Any `_log.debug('... {}', [jwt])` call goes through
+  /// `toString()`, never through `props` — the override wins.
   @override
-  String toString() =>
-      'JWTToken(idToken: ${LogSanitizer.maskToken(idToken)}, refreshToken: ${LogSanitizer.maskToken(refreshToken)})';
-
-  // stringify is intentionally not overridden — the explicit toString()
-  // above takes precedence anyway, and keeping stringify behaviour off
-  // (`false`, the default) means the masked toString is the only path
-  // used by interpolation as well.
+  String toString() => 'JWTToken(idToken: ${maskToken(idToken)}, refreshToken: ${maskToken(refreshToken)})';
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -52,20 +52,36 @@ class LoginRepository implements IAuthRepository {
   @override
   Future<Result<void>> logout() async {
     _log.debug("BEGIN:logout repository start");
+    // Best-effort cleanup across BOTH backends. Each step is wrapped in
+    // its own try/catch so that a failure to delete one secure key does
+    // not skip the others — partial logout is the worst outcome since
+    // any leftover token would let AuthInterceptor re-attach it on the
+    // next request and silently defeat logout. Any individual failure
+    // surfaces as a Failure result so callers can decide whether to
+    // retry or notify the user.
+    final errors = <String>[];
     try {
-      // Wipe BOTH backends. AuthInterceptor reads JWT directly from
-      // secure storage on every request, so leaving the JWT/refreshToken
-      // there would re-attach the old token on the next request and
-      // silently defeat logout.
       await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
-      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-      await AppLocalStorage().clear();
-      _log.debug("END:logout successful");
-      return const Success(null);
-    } catch (e, st) {
-      _log.error("END:logout error: {}", [e.toString()]);
-      return Failure(UnknownError(e.toString()), stackTrace: st);
+    } catch (e) {
+      errors.add('jwt: $e');
     }
+    try {
+      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
+    } catch (e) {
+      errors.add('refresh: $e');
+    }
+    try {
+      await AppLocalStorage().clear();
+    } catch (e) {
+      errors.add('local: $e');
+    }
+    if (errors.isNotEmpty) {
+      final msg = errors.join('; ');
+      _log.error("END:logout partial failures: {}", [msg]);
+      return Failure(UnknownError(msg));
+    }
+    _log.debug("END:logout successful");
+    return const Success(null);
   }
 
   @override

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -57,28 +57,33 @@ class LoginRepository implements IAuthRepository {
     // not skip the others — partial logout is the worst outcome since
     // any leftover token would let AuthInterceptor re-attach it on the
     // next request and silently defeat logout. Any individual failure
-    // surfaces as a Failure result so callers can decide whether to
-    // retry or notify the user.
+    // surfaces as a Failure result (with the first stack trace attached
+    // for diagnostics) so callers can decide whether to retry or notify
+    // the user.
     final errors = <String>[];
+    StackTrace? firstStackTrace;
     try {
       await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
-    } catch (e) {
+    } catch (e, st) {
       errors.add('jwt: $e');
+      firstStackTrace ??= st;
     }
     try {
       await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-    } catch (e) {
+    } catch (e, st) {
       errors.add('refresh: $e');
+      firstStackTrace ??= st;
     }
     try {
       await AppLocalStorage().clear();
-    } catch (e) {
+    } catch (e, st) {
       errors.add('local: $e');
+      firstStackTrace ??= st;
     }
     if (errors.isNotEmpty) {
       final msg = errors.join('; ');
-      _log.error("END:logout partial failures: {}", [msg]);
-      return Failure(UnknownError(msg));
+      _log.error("END:logout partial failures: {}\n{}", [msg, firstStackTrace]);
+      return Failure(UnknownError(msg), stackTrace: firstStackTrace);
     }
     _log.debug("END:logout successful");
     return const Success(null);

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -53,9 +53,10 @@ class LoginRepository implements IAuthRepository {
   Future<Result<void>> logout() async {
     _log.debug("BEGIN:logout repository start");
     try {
-      // Wipe BOTH backends. Leaving JWT/refreshToken in secure storage
-      // makes AuthInterceptor (which falls back to secure on cache miss)
-      // re-attach the old token on the next request — defeating logout.
+      // Wipe BOTH backends. AuthInterceptor reads JWT directly from
+      // secure storage on every request, so leaving the JWT/refreshToken
+      // there would re-attach the old token on the next request and
+      // silently defeat logout.
       await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
       await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       await AppLocalStorage().clear();

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -8,11 +8,14 @@ import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_entity.d
 import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_repository.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class LoginRepository implements IAuthRepository {
   static final _log = AppLogger.getLogger("LoginRepository");
 
-  LoginRepository();
+  LoginRepository({ISecureStorage? secureStorage}) : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
+
+  final ISecureStorage _secureStorage;
 
   @override
   Future<Result<AuthTokenEntity>> authenticate(AuthCredentialsEntity userJWT) async {
@@ -50,6 +53,11 @@ class LoginRepository implements IAuthRepository {
   Future<Result<void>> logout() async {
     _log.debug("BEGIN:logout repository start");
     try {
+      // Wipe BOTH backends. Leaving JWT/refreshToken in secure storage
+      // makes AuthInterceptor (which falls back to secure on cache miss)
+      // re-attach the old token on the next request — defeating logout.
+      await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
+      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       await AppLocalStorage().clear();
       _log.debug("END:logout successful");
       return const Success(null);

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -4,18 +4,21 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/auth/data/mappers/auth_mapper.dart';
 import 'package:flutter_bloc_advance/features/auth/data/models/jwt_token.dart';
+import 'package:flutter_bloc_advance/features/auth/data/repositories/auth_session_repository_impl.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_entity.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_repository.dart';
+import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_session_repository.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class LoginRepository implements IAuthRepository {
   static final _log = AppLogger.getLogger("LoginRepository");
 
-  LoginRepository({ISecureStorage? secureStorage}) : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
+  LoginRepository({ISecureStorage? secureStorage, IAuthSessionRepository? sessionRepository})
+    : _sessionRepository =
+          sessionRepository ?? AuthSessionRepository(secureStorage: secureStorage ?? FlutterSecureStorageAdapter());
 
-  final ISecureStorage _secureStorage;
+  final IAuthSessionRepository _sessionRepository;
 
   @override
   Future<Result<AuthTokenEntity>> authenticate(AuthCredentialsEntity userJWT) async {
@@ -52,41 +55,19 @@ class LoginRepository implements IAuthRepository {
   @override
   Future<Result<void>> logout() async {
     _log.debug("BEGIN:logout repository start");
-    // Best-effort cleanup across BOTH backends. Each step is wrapped in
-    // its own try/catch so that a failure to delete one secure key does
-    // not skip the others — partial logout is the worst outcome since
-    // any leftover token would let AuthInterceptor re-attach it on the
-    // next request and silently defeat logout. Any individual failure
-    // surfaces as a Failure result (with the first stack trace attached
-    // for diagnostics) so callers can decide whether to retry or notify
-    // the user.
-    final errors = <String>[];
-    StackTrace? firstStackTrace;
-    try {
-      await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
-    } catch (e, st) {
-      errors.add('jwt: $e');
-      firstStackTrace ??= st;
+    // Delegate to IAuthSessionRepository.clear so there is exactly
+    // one cleanup implementation (best-effort across both backends,
+    // error aggregation, partial-logout failure semantics). Keeping
+    // two parallel cleanups guaranteed they would drift the next time
+    // either logout flow changed.
+    final result = await _sessionRepository.clear();
+    switch (result) {
+      case Failure(:final error):
+        _log.error("END:logout failed: {}", [error]);
+      case Success():
+        _log.debug("END:logout successful");
     }
-    try {
-      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-    } catch (e, st) {
-      errors.add('refresh: $e');
-      firstStackTrace ??= st;
-    }
-    try {
-      await AppLocalStorage().clear();
-    } catch (e, st) {
-      errors.add('local: $e');
-      firstStackTrace ??= st;
-    }
-    if (errors.isNotEmpty) {
-      final msg = errors.join('; ');
-      _log.error("END:logout partial failures: {}\n{}", [msg, firstStackTrace]);
-      return Failure(UnknownError(msg), stackTrace: firstStackTrace);
-    }
-    _log.debug("END:logout successful");
-    return const Success(null);
+    return result;
   }
 
   @override

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -29,8 +29,17 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
   @override
   Future<Result<void>> persist(AuthSession session) async {
+    // Snapshot pre-persist secure values so rollback can restore them on
+    // failure — including the "delete stale refreshToken when the new
+    // session has none" path, where the delete itself is the mutation we
+    // need to be able to undo.
+    final priorJwt = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    final priorRefresh = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
+    final priorCachedJwt = AppLocalStorageCached.jwtToken;
+
     final writtenSecure = <SecureStorageKeys>[];
     final writtenLocal = <StorageKeys>[];
+    var deletedStaleRefresh = false;
     try {
       await _writeSecure(SecureStorageKeys.jwtToken, session.idToken, writtenSecure);
       // Keep the sync cache consistent with the secure store so that
@@ -40,8 +49,10 @@ class AuthSessionRepository implements IAuthSessionRepository {
         await _writeSecure(SecureStorageKeys.refreshToken, session.refreshToken!, writtenSecure);
       } else {
         // Owner-of-keys contract: a session without a refresh token must
-        // not inherit one from a previous login. Best-effort removal.
+        // not inherit one from a previous login. Tracked separately so
+        // rollback can restore the prior value if a later write fails.
         await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
+        deletedStaleRefresh = true;
       }
       await _writeLocal(StorageKeys.username, session.username, writtenLocal);
       await _writeLocal(StorageKeys.roles, session.roles, writtenLocal);
@@ -52,7 +63,14 @@ class AuthSessionRepository implements IAuthSessionRepository {
         writtenLocal.length,
         e,
       ]);
-      await _rollback(writtenSecure, writtenLocal);
+      await _rollback(
+        writtenSecure: writtenSecure,
+        writtenLocal: writtenLocal,
+        deletedStaleRefresh: deletedStaleRefresh,
+        priorJwt: priorJwt,
+        priorRefresh: priorRefresh,
+        priorCachedJwt: priorCachedJwt,
+      );
       return Failure(UnknownError('Session persistence failed: $e'));
     }
   }
@@ -82,18 +100,41 @@ class AuthSessionRepository implements IAuthSessionRepository {
     written.add(key);
   }
 
-  Future<void> _rollback(List<SecureStorageKeys> writtenSecure, List<StorageKeys> writtenLocal) async {
+  Future<void> _rollback({
+    required List<SecureStorageKeys> writtenSecure,
+    required List<StorageKeys> writtenLocal,
+    required bool deletedStaleRefresh,
+    required String? priorJwt,
+    required String? priorRefresh,
+    required String? priorCachedJwt,
+  }) async {
     for (final key in writtenSecure) {
       try {
-        await _secureStorage.delete(key.key);
-        if (key == SecureStorageKeys.jwtToken) {
-          // Keep the sync cache consistent with the rolled-back secure store.
-          AppLocalStorageCached.jwtToken = null;
+        // Restore the pre-persist value (or delete if there was none) so
+        // that callers observing a Failure see the state as if persist
+        // had never been invoked.
+        final prior = switch (key) {
+          SecureStorageKeys.jwtToken => priorJwt,
+          SecureStorageKeys.refreshToken => priorRefresh,
+        };
+        if (prior == null) {
+          await _secureStorage.delete(key.key);
+        } else {
+          await _secureStorage.write(key.key, prior);
         }
       } catch (e) {
         _log.warn('secure rollback failed for {}: {}', [key.key, e]);
       }
     }
+    if (deletedStaleRefresh && priorRefresh != null) {
+      try {
+        await _secureStorage.write(SecureStorageKeys.refreshToken.key, priorRefresh);
+      } catch (e) {
+        _log.warn('refreshToken restore failed during rollback: {}', [e]);
+      }
+    }
+    // Restore the cached JWT (set unconditionally during persist).
+    AppLocalStorageCached.jwtToken = priorCachedJwt;
     for (final key in writtenLocal) {
       try {
         await _storage.remove(key.key);

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -51,15 +51,18 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
       await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
       mutatedSecure.add(SecureStorageKeys.jwtToken);
-      if (session.refreshToken != null) {
+      // Owner-of-keys contract: a session without a refresh token must
+      // not inherit one from a previous login. Treat null AND empty
+      // string equivalently — TokenRefreshInterceptor reads
+      // `refreshToken.isEmpty` as "absent", so persisting an empty
+      // string here would leave the key present but unusable.
+      final hasRefresh = session.refreshToken != null && session.refreshToken!.isNotEmpty;
+      if (hasRefresh) {
         await _secureStorage.write(SecureStorageKeys.refreshToken.key, session.refreshToken!);
-        mutatedSecure.add(SecureStorageKeys.refreshToken);
       } else {
-        // Owner-of-keys contract: a session without a refresh token
-        // must not inherit one from a previous login.
         await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-        mutatedSecure.add(SecureStorageKeys.refreshToken);
       }
+      mutatedSecure.add(SecureStorageKeys.refreshToken);
       await _writeLocal(StorageKeys.username, session.username, mutatedLocal);
       await _writeLocal(StorageKeys.roles, session.roles, mutatedLocal);
       _log.info('persist: session written ({} secure + {} local)', [mutatedSecure.length, mutatedLocal.length]);

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -57,6 +57,7 @@ class AuthSessionRepository implements IAuthSessionRepository {
       }
       await _writeLocal(StorageKeys.username, session.username, mutatedLocal);
       await _writeLocal(StorageKeys.roles, session.roles, mutatedLocal);
+      _log.info('persist: session written ({} secure + {} local)', [mutatedSecure.length, mutatedLocal.length]);
       return const Success(null);
     } catch (e) {
       _log.error('persist failed after {} secure + {} local mutations; rolling back: {}', [
@@ -82,6 +83,7 @@ class AuthSessionRepository implements IAuthSessionRepository {
       await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
       await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       await _storage.clear();
+      _log.info('clear: session wiped from both backends');
       return const Success(null);
     } catch (e) {
       return Failure(UnknownError('Session clear failed: $e'));

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -146,10 +146,13 @@ class AuthSessionRepository implements IAuthSessionRepository {
           StorageKeys.roles => priorRoles,
           _ => null,
         };
-        if (prior == null) {
-          await _storage.remove(key.key);
-        } else {
-          await _storage.save(key.key, prior);
+        // AppLocalStorage.save/remove can refuse a mutation by returning
+        // false without throwing. Honor that signal so a rollback that
+        // silently no-ops doesn't leave storage in a partially-mutated
+        // state — symmetric with how _writeLocal treats save == false.
+        final ok = prior == null ? await _storage.remove(key.key) : await _storage.save(key.key, prior);
+        if (!ok) {
+          _log.warn('local rollback refused for {} (storage returned false)', [key.key]);
         }
       } catch (e) {
         _log.warn('local rollback failed for {}: {}', [key.key, e]);

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -13,10 +13,11 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 /// (username, roles) to [AppLocalStorage] (SharedPreferences).
 ///
 /// Neither backend supports transactions, so atomicity is emulated
-/// across both: writes happen in order, and on any failure the keys
-/// that were successfully written during this call are removed —
-/// across both backends — before the failure is reported. The caller
-/// therefore never sees a half-written session.
+/// across both: writes happen in order, and on any failure every key
+/// that was successfully written during this call is restored to its
+/// pre-call value (or deleted if there was none) — across both
+/// backends — before the failure is reported. Callers therefore never
+/// observe a half-written session.
 class AuthSessionRepository implements IAuthSessionRepository {
   AuthSessionRepository({required ISecureStorage secureStorage, AppLocalStorage? storage})
     : _secureStorage = secureStorage,
@@ -29,47 +30,41 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
   @override
   Future<Result<void>> persist(AuthSession session) async {
-    // Snapshot pre-persist secure values so rollback can restore them on
-    // failure — including the "delete stale refreshToken when the new
-    // session has none" path, where the delete itself is the mutation we
-    // need to be able to undo.
+    // Snapshot pre-persist secure values so rollback can restore them
+    // on failure — including the "delete stale refreshToken when the
+    // new session has none" path, where the delete itself is the
+    // mutation we need to be able to undo.
     final priorJwt = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
     final priorRefresh = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
-    final priorCachedJwt = AppLocalStorageCached.jwtToken;
 
-    final writtenSecure = <SecureStorageKeys>[];
+    final mutatedSecure = <SecureStorageKeys>{};
     final writtenLocal = <StorageKeys>[];
-    var deletedStaleRefresh = false;
     try {
-      await _writeSecure(SecureStorageKeys.jwtToken, session.idToken, writtenSecure);
-      // Keep the sync cache consistent with the secure store so that
-      // SecurityUtils.isUserLoggedIn() returns true immediately after persist.
-      AppLocalStorageCached.jwtToken = session.idToken;
+      await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
+      mutatedSecure.add(SecureStorageKeys.jwtToken);
       if (session.refreshToken != null) {
-        await _writeSecure(SecureStorageKeys.refreshToken, session.refreshToken!, writtenSecure);
+        await _secureStorage.write(SecureStorageKeys.refreshToken.key, session.refreshToken!);
+        mutatedSecure.add(SecureStorageKeys.refreshToken);
       } else {
-        // Owner-of-keys contract: a session without a refresh token must
-        // not inherit one from a previous login. Tracked separately so
-        // rollback can restore the prior value if a later write fails.
+        // Owner-of-keys contract: a session without a refresh token
+        // must not inherit one from a previous login.
         await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-        deletedStaleRefresh = true;
+        mutatedSecure.add(SecureStorageKeys.refreshToken);
       }
       await _writeLocal(StorageKeys.username, session.username, writtenLocal);
       await _writeLocal(StorageKeys.roles, session.roles, writtenLocal);
       return const Success(null);
     } catch (e) {
-      _log.error('persist failed after {} secure + {} local writes; rolling back: {}', [
-        writtenSecure.length,
+      _log.error('persist failed after {} secure + {} local mutations; rolling back: {}', [
+        mutatedSecure.length,
         writtenLocal.length,
         e,
       ]);
       await _rollback(
-        writtenSecure: writtenSecure,
+        mutatedSecure: mutatedSecure,
         writtenLocal: writtenLocal,
-        deletedStaleRefresh: deletedStaleRefresh,
         priorJwt: priorJwt,
         priorRefresh: priorRefresh,
-        priorCachedJwt: priorCachedJwt,
       );
       return Failure(UnknownError('Session persistence failed: $e'));
     }
@@ -87,11 +82,6 @@ class AuthSessionRepository implements IAuthSessionRepository {
     }
   }
 
-  Future<void> _writeSecure(SecureStorageKeys key, String value, List<SecureStorageKeys> written) async {
-    await _secureStorage.write(key.key, value);
-    written.add(key);
-  }
-
   Future<void> _writeLocal(StorageKeys key, dynamic value, List<StorageKeys> written) async {
     final ok = await _storage.save(key.key, value);
     if (!ok) {
@@ -101,18 +91,13 @@ class AuthSessionRepository implements IAuthSessionRepository {
   }
 
   Future<void> _rollback({
-    required List<SecureStorageKeys> writtenSecure,
+    required Set<SecureStorageKeys> mutatedSecure,
     required List<StorageKeys> writtenLocal,
-    required bool deletedStaleRefresh,
     required String? priorJwt,
     required String? priorRefresh,
-    required String? priorCachedJwt,
   }) async {
-    for (final key in writtenSecure) {
+    for (final key in mutatedSecure) {
       try {
-        // Restore the pre-persist value (or delete if there was none) so
-        // that callers observing a Failure see the state as if persist
-        // had never been invoked.
         final prior = switch (key) {
           SecureStorageKeys.jwtToken => priorJwt,
           SecureStorageKeys.refreshToken => priorRefresh,
@@ -126,15 +111,6 @@ class AuthSessionRepository implements IAuthSessionRepository {
         _log.warn('secure rollback failed for {}: {}', [key.key, e]);
       }
     }
-    if (deletedStaleRefresh && priorRefresh != null) {
-      try {
-        await _secureStorage.write(SecureStorageKeys.refreshToken.key, priorRefresh);
-      } catch (e) {
-        _log.warn('refreshToken restore failed during rollback: {}', [e]);
-      }
-    }
-    // Restore the cached JWT (set unconditionally during persist).
-    AppLocalStorageCached.jwtToken = priorCachedJwt;
     for (final key in writtenLocal) {
       try {
         await _storage.remove(key.key);

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -30,15 +30,19 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
   @override
   Future<Result<void>> persist(AuthSession session) async {
-    // Snapshot pre-persist secure values so rollback can restore them
-    // on failure — including the "delete stale refreshToken when the
-    // new session has none" path, where the delete itself is the
-    // mutation we need to be able to undo.
+    // Snapshot pre-persist values on BOTH backends so rollback restores
+    // them — including the "delete stale refreshToken when the new
+    // session has none" path, where the delete itself is the mutation
+    // we need to be able to undo. Without a local snapshot a re-login
+    // could wipe a previously persisted username/roles when persist()
+    // fails mid-way, violating the "no half-written session" invariant.
     final priorJwt = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
     final priorRefresh = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
+    final priorUsername = await _storage.read(StorageKeys.username.key);
+    final priorRoles = await _storage.read(StorageKeys.roles.key);
 
     final mutatedSecure = <SecureStorageKeys>{};
-    final writtenLocal = <StorageKeys>[];
+    final mutatedLocal = <StorageKeys>{};
     try {
       await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
       mutatedSecure.add(SecureStorageKeys.jwtToken);
@@ -51,20 +55,22 @@ class AuthSessionRepository implements IAuthSessionRepository {
         await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
         mutatedSecure.add(SecureStorageKeys.refreshToken);
       }
-      await _writeLocal(StorageKeys.username, session.username, writtenLocal);
-      await _writeLocal(StorageKeys.roles, session.roles, writtenLocal);
+      await _writeLocal(StorageKeys.username, session.username, mutatedLocal);
+      await _writeLocal(StorageKeys.roles, session.roles, mutatedLocal);
       return const Success(null);
     } catch (e) {
       _log.error('persist failed after {} secure + {} local mutations; rolling back: {}', [
         mutatedSecure.length,
-        writtenLocal.length,
+        mutatedLocal.length,
         e,
       ]);
       await _rollback(
         mutatedSecure: mutatedSecure,
-        writtenLocal: writtenLocal,
+        mutatedLocal: mutatedLocal,
         priorJwt: priorJwt,
         priorRefresh: priorRefresh,
+        priorUsername: priorUsername,
+        priorRoles: priorRoles,
       );
       return Failure(UnknownError('Session persistence failed: $e'));
     }
@@ -82,19 +88,21 @@ class AuthSessionRepository implements IAuthSessionRepository {
     }
   }
 
-  Future<void> _writeLocal(StorageKeys key, dynamic value, List<StorageKeys> written) async {
+  Future<void> _writeLocal(StorageKeys key, dynamic value, Set<StorageKeys> mutated) async {
     final ok = await _storage.save(key.key, value);
     if (!ok) {
       throw StateError('save returned false for ${key.key}');
     }
-    written.add(key);
+    mutated.add(key);
   }
 
   Future<void> _rollback({
     required Set<SecureStorageKeys> mutatedSecure,
-    required List<StorageKeys> writtenLocal,
+    required Set<StorageKeys> mutatedLocal,
     required String? priorJwt,
     required String? priorRefresh,
+    required dynamic priorUsername,
+    required dynamic priorRoles,
   }) async {
     for (final key in mutatedSecure) {
       try {
@@ -111,9 +119,18 @@ class AuthSessionRepository implements IAuthSessionRepository {
         _log.warn('secure rollback failed for {}: {}', [key.key, e]);
       }
     }
-    for (final key in writtenLocal) {
+    for (final key in mutatedLocal) {
       try {
-        await _storage.remove(key.key);
+        final prior = switch (key) {
+          StorageKeys.username => priorUsername,
+          StorageKeys.roles => priorRoles,
+          _ => null,
+        };
+        if (prior == null) {
+          await _storage.remove(key.key);
+        } else {
+          await _storage.save(key.key, prior);
+        }
       } catch (e) {
         _log.warn('local rollback failed for {}: {}', [key.key, e]);
       }

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -20,6 +20,7 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 /// observe a half-written session.
 class AuthSessionRepository implements IAuthSessionRepository {
   AuthSessionRepository({required ISecureStorage secureStorage, AppLocalStorage? storage})
+    // ignore: prefer_initializing_formals
     : _secureStorage = secureStorage,
       _storage = storage ?? AppLocalStorage();
 
@@ -49,20 +50,25 @@ class AuthSessionRepository implements IAuthSessionRepository {
       priorUsername = await _storage.read(StorageKeys.username.key);
       priorRoles = await _storage.read(StorageKeys.roles.key);
 
-      await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
+      // Record the key as mutated BEFORE the await so that if the
+      // adapter throws after partially mutating platform state, the
+      // rollback path still knows to restore it. If the write throws
+      // cleanly (state unchanged), the rollback is a no-op against
+      // the snapshot (write same value back, or delete an absent key).
       mutatedSecure.add(SecureStorageKeys.jwtToken);
+      await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
       // Owner-of-keys contract: a session without a refresh token must
       // not inherit one from a previous login. Treat null AND empty
       // string equivalently — TokenRefreshInterceptor reads
       // `refreshToken.isEmpty` as "absent", so persisting an empty
       // string here would leave the key present but unusable.
+      mutatedSecure.add(SecureStorageKeys.refreshToken);
       final hasRefresh = session.refreshToken != null && session.refreshToken!.isNotEmpty;
       if (hasRefresh) {
         await _secureStorage.write(SecureStorageKeys.refreshToken.key, session.refreshToken!);
       } else {
         await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       }
-      mutatedSecure.add(SecureStorageKeys.refreshToken);
       await _writeLocal(StorageKeys.username, session.username, mutatedLocal);
       await _writeLocal(StorageKeys.roles, session.roles, mutatedLocal);
       _log.info('persist: session written ({} secure + {} local)', [mutatedSecure.length, mutatedLocal.length]);

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -4,42 +4,55 @@ import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_session_repository.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
-/// SharedPreferences-backed implementation of [IAuthSessionRepository].
+/// Persistence-layer implementation of [IAuthSessionRepository].
 ///
-/// SharedPreferences does not support transactions, so atomicity is
-/// emulated: writes happen in order, and on any failure the keys that
-/// were successfully written during this call are removed before the
-/// failure is reported. The caller therefore never sees a half-written
-/// session.
+/// Routes sensitive fields (idToken, refreshToken) to [ISecureStorage]
+/// (Keychain / EncryptedSharedPreferences) and non-secret fields
+/// (username, roles) to [AppLocalStorage] (SharedPreferences).
+///
+/// Neither backend supports transactions, so atomicity is emulated
+/// across both: writes happen in order, and on any failure the keys
+/// that were successfully written during this call are removed —
+/// across both backends — before the failure is reported. The caller
+/// therefore never sees a half-written session.
 class AuthSessionRepository implements IAuthSessionRepository {
-  AuthSessionRepository({AppLocalStorage? storage}) : _storage = storage ?? AppLocalStorage();
+  AuthSessionRepository({required ISecureStorage secureStorage, AppLocalStorage? storage})
+    : _secureStorage = secureStorage,
+      _storage = storage ?? AppLocalStorage();
 
   static final _log = AppLogger.getLogger('AuthSessionRepository');
 
+  final ISecureStorage _secureStorage;
   final AppLocalStorage _storage;
 
   @override
   Future<Result<void>> persist(AuthSession session) async {
-    final written = <StorageKeys>[];
+    final writtenSecure = <SecureStorageKeys>[];
+    final writtenLocal = <StorageKeys>[];
     try {
-      await _write(StorageKeys.jwtToken, session.idToken, written);
+      await _writeSecure(SecureStorageKeys.jwtToken, session.idToken, writtenSecure);
+      // Keep the sync cache consistent with the secure store so that
+      // SecurityUtils.isUserLoggedIn() returns true immediately after persist.
+      AppLocalStorageCached.jwtToken = session.idToken;
       if (session.refreshToken != null) {
-        await _write(StorageKeys.refreshToken, session.refreshToken, written);
+        await _writeSecure(SecureStorageKeys.refreshToken, session.refreshToken!, writtenSecure);
       } else {
         // Owner-of-keys contract: a session without a refresh token must
-        // not inherit one from a previous login. Best-effort removal —
-        // a remove failure here is not fatal because the field is just
-        // unused if it lingers, but we still try and surface the error
-        // via the rollback path on persist failure further down.
-        await _storage.remove(StorageKeys.refreshToken.key);
+        // not inherit one from a previous login. Best-effort removal.
+        await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       }
-      await _write(StorageKeys.username, session.username, written);
-      await _write(StorageKeys.roles, session.roles, written);
+      await _writeLocal(StorageKeys.username, session.username, writtenLocal);
+      await _writeLocal(StorageKeys.roles, session.roles, writtenLocal);
       return const Success(null);
     } catch (e) {
-      _log.error('persist failed after {} writes; rolling back: {}', [written.length, e]);
-      await _rollback(written);
+      _log.error('persist failed after {} secure + {} local writes; rolling back: {}', [
+        writtenSecure.length,
+        writtenLocal.length,
+        e,
+      ]);
+      await _rollback(writtenSecure, writtenLocal);
       return Failure(UnknownError('Session persistence failed: $e'));
     }
   }
@@ -47,6 +60,8 @@ class AuthSessionRepository implements IAuthSessionRepository {
   @override
   Future<Result<void>> clear() async {
     try {
+      await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
+      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
       await _storage.clear();
       return const Success(null);
     } catch (e) {
@@ -54,7 +69,12 @@ class AuthSessionRepository implements IAuthSessionRepository {
     }
   }
 
-  Future<void> _write(StorageKeys key, dynamic value, List<StorageKeys> written) async {
+  Future<void> _writeSecure(SecureStorageKeys key, String value, List<SecureStorageKeys> written) async {
+    await _secureStorage.write(key.key, value);
+    written.add(key);
+  }
+
+  Future<void> _writeLocal(StorageKeys key, dynamic value, List<StorageKeys> written) async {
     final ok = await _storage.save(key.key, value);
     if (!ok) {
       throw StateError('save returned false for ${key.key}');
@@ -62,12 +82,23 @@ class AuthSessionRepository implements IAuthSessionRepository {
     written.add(key);
   }
 
-  Future<void> _rollback(List<StorageKeys> written) async {
-    for (final key in written) {
+  Future<void> _rollback(List<SecureStorageKeys> writtenSecure, List<StorageKeys> writtenLocal) async {
+    for (final key in writtenSecure) {
+      try {
+        await _secureStorage.delete(key.key);
+        if (key == SecureStorageKeys.jwtToken) {
+          // Keep the sync cache consistent with the rolled-back secure store.
+          AppLocalStorageCached.jwtToken = null;
+        }
+      } catch (e) {
+        _log.warn('secure rollback failed for {}: {}', [key.key, e]);
+      }
+    }
+    for (final key in writtenLocal) {
       try {
         await _storage.remove(key.key);
       } catch (e) {
-        _log.warn('rollback failed for {}: {}', [key.key, e]);
+        _log.warn('local rollback failed for {}: {}', [key.key, e]);
       }
     }
   }

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -79,15 +79,33 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
   @override
   Future<Result<void>> clear() async {
+    // Best-effort across BOTH backends: a throw on the first secure
+    // delete must not skip the second key or the local clear. Any
+    // leftover token would let AuthInterceptor re-attach it on the
+    // next request and silently defeat a clear/logout.
+    final errors = <String>[];
     try {
       await _secureStorage.delete(SecureStorageKeys.jwtToken.key);
-      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
-      await _storage.clear();
-      _log.info('clear: session wiped from both backends');
-      return const Success(null);
     } catch (e) {
-      return Failure(UnknownError('Session clear failed: $e'));
+      errors.add('jwt: $e');
     }
+    try {
+      await _secureStorage.delete(SecureStorageKeys.refreshToken.key);
+    } catch (e) {
+      errors.add('refresh: $e');
+    }
+    try {
+      await _storage.clear();
+    } catch (e) {
+      errors.add('local: $e');
+    }
+    if (errors.isNotEmpty) {
+      final msg = errors.join('; ');
+      _log.error('clear: partial failures: {}', [msg]);
+      return Failure(UnknownError('Session clear failed: $msg'));
+    }
+    _log.info('clear: session wiped from both backends');
+    return const Success(null);
   }
 
   Future<void> _writeLocal(StorageKeys key, dynamic value, Set<StorageKeys> mutated) async {

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -30,20 +30,25 @@ class AuthSessionRepository implements IAuthSessionRepository {
 
   @override
   Future<Result<void>> persist(AuthSession session) async {
+    final mutatedSecure = <SecureStorageKeys>{};
+    final mutatedLocal = <StorageKeys>{};
     // Snapshot pre-persist values on BOTH backends so rollback restores
     // them — including the "delete stale refreshToken when the new
     // session has none" path, where the delete itself is the mutation
-    // we need to be able to undo. Without a local snapshot a re-login
-    // could wipe a previously persisted username/roles when persist()
-    // fails mid-way, violating the "no half-written session" invariant.
-    final priorJwt = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
-    final priorRefresh = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
-    final priorUsername = await _storage.read(StorageKeys.username.key);
-    final priorRoles = await _storage.read(StorageKeys.roles.key);
-
-    final mutatedSecure = <SecureStorageKeys>{};
-    final mutatedLocal = <StorageKeys>{};
+    // we need to be able to undo. The snapshot itself must live inside
+    // the try block: ISecureStorage.read can throw on platform /
+    // decryption failure, and the contract is that persist always
+    // returns a Result — never propagates a raw exception.
+    String? priorJwt;
+    String? priorRefresh;
+    dynamic priorUsername;
+    dynamic priorRoles;
     try {
+      priorJwt = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+      priorRefresh = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
+      priorUsername = await _storage.read(StorageKeys.username.key);
+      priorRoles = await _storage.read(StorageKeys.roles.key);
+
       await _secureStorage.write(SecureStorageKeys.jwtToken.key, session.idToken);
       mutatedSecure.add(SecureStorageKeys.jwtToken);
       if (session.refreshToken != null) {

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -155,12 +155,20 @@ class AuthSessionRepository implements IAuthSessionRepository {
     }
     for (final key in mutatedLocal) {
       try {
-        // Compile-time exhaustive — adding a new StorageKeys variant
-        // here without snapshotting its prior value will surface as
-        // a missing case at build time, not as a silent rollback-to-
-        // null (== delete). Persist mutates only the keys listed
-        // below; any new local field this repository persists must
-        // also extend the snapshot/restore signature.
+        // Compile-time exhaustive over the full StorageKeys enum so a
+        // new variant added here without snapshotting its prior value
+        // surfaces as a missing case at build time, not as a silent
+        // rollback-to-null (== delete).
+        //
+        // [persist] only ever adds [StorageKeys.username] and
+        // [StorageKeys.roles] to `mutatedLocal`, so the
+        // language/theme/brightness branches are unreachable in
+        // practice — but they MUST stay in the switch to enforce
+        // exhaustiveness. The `null` they return is safe because
+        // [persist] never inserts those keys into `mutatedLocal`,
+        // so they cannot iterate here. Any future field this
+        // repository persists must extend the snapshot/restore
+        // signature, not silently land in the unreachable branches.
         final prior = switch (key) {
           StorageKeys.username => priorUsername,
           StorageKeys.roles => priorRoles,

--- a/lib/features/auth/data/repositories/auth_session_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_session_repository_impl.dart
@@ -149,10 +149,18 @@ class AuthSessionRepository implements IAuthSessionRepository {
     }
     for (final key in mutatedLocal) {
       try {
+        // Compile-time exhaustive — adding a new StorageKeys variant
+        // here without snapshotting its prior value will surface as
+        // a missing case at build time, not as a silent rollback-to-
+        // null (== delete). Persist mutates only the keys listed
+        // below; any new local field this repository persists must
+        // also extend the snapshot/restore signature.
         final prior = switch (key) {
           StorageKeys.username => priorUsername,
           StorageKeys.roles => priorRoles,
-          _ => null,
+          StorageKeys.language => null,
+          StorageKeys.theme => null,
+          StorageKeys.brightness => null,
         };
         // AppLocalStorage.save/remove can refuse a mutation by returning
         // false without throwing. Honor that signal so a rollback that

--- a/lib/features/auth/domain/entities/auth_session.dart
+++ b/lib/features/auth/domain/entities/auth_session.dart
@@ -22,13 +22,12 @@ class AuthSession extends Equatable {
   @override
   List<Object?> get props => [idToken, refreshToken, username, roles];
 
-  /// Tokens are masked so this is safe to embed in log output, even if
-  /// `Equatable.stringify` is later flipped on for diagnostic reasons.
+  /// Tokens are masked so this is safe to embed in log output.
   @override
   String toString() =>
       'AuthSession('
-      'idToken: ${LogSanitizer.maskToken(idToken)}, '
-      'refreshToken: ${LogSanitizer.maskToken(refreshToken)}, '
+      'idToken: ${maskToken(idToken)}, '
+      'refreshToken: ${maskToken(refreshToken)}, '
       'username: $username, '
       'roles: $roles)';
 }

--- a/lib/features/auth/domain/entities/auth_session.dart
+++ b/lib/features/auth/domain/entities/auth_session.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
 
 /// Value object representing a fully-formed authenticated session.
 ///
@@ -20,4 +21,14 @@ class AuthSession extends Equatable {
 
   @override
   List<Object?> get props => [idToken, refreshToken, username, roles];
+
+  /// Tokens are masked so this is safe to embed in log output, even if
+  /// `Equatable.stringify` is later flipped on for diagnostic reasons.
+  @override
+  String toString() =>
+      'AuthSession('
+      'idToken: ${LogSanitizer.maskToken(idToken)}, '
+      'refreshToken: ${LogSanitizer.maskToken(refreshToken)}, '
+      'username: $username, '
+      'roles: $roles)';
 }

--- a/lib/features/settings/presentation/pages/settings_screen.dart
+++ b/lib/features/settings/presentation/pages/settings_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/core/testing/app_key_constants.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/shared/design_system/components/app_card.dart';
 import 'package:flutter_bloc_advance/shared/design_system/tokens/app_spacing.dart';
-import 'package:flutter_bloc_advance/shared/widgets/confirmation_dialog_widget.dart';
 import 'package:flutter_bloc_advance/shared/widgets/theme_selection_dialog.dart';
 import 'package:flutter_bloc_advance/app/router/app_routes_constants.dart';
 import 'package:go_router/go_router.dart';
@@ -92,23 +90,12 @@ class SettingsScreen extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: AppSpacing.lg),
-
-              // Danger zone
-              _SettingsSection(
-                title: S.of(context).logout,
-                isDanger: true,
-                children: [
-                  _SettingsTile(
-                    key: settingsLogoutButtonKey,
-                    icon: Icons.logout,
-                    title: S.of(context).logout,
-                    subtitle: 'Sign out from this device',
-                    isDanger: true,
-                    onTap: () => _handleLogout(context),
-                  ),
-                ],
-              ),
+              // Logout intentionally lives only in the sidebar / topbar
+              // shell, not here. Settings is feature-scoped and an
+              // auth-session lifecycle action would cross feature
+              // boundaries (architecture guard rejects features/settings
+              // → features/auth imports). Sidebar's MenuBloc.Logout
+              // flow handles it correctly.
             ],
           ),
         ),
@@ -122,23 +109,14 @@ class SettingsScreen extends StatelessWidget {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
-
-  Future<void> _handleLogout(BuildContext context) async {
-    final shouldLogout = await ConfirmationDialog.show(context: context, type: DialogType.logout) ?? false;
-    if (shouldLogout && context.mounted) {
-      AppLocalStorage().clear();
-      context.go(ApplicationRoutesConstants.login);
-    }
-  }
 }
 
 /// A grouped settings section with a title and list of tiles.
 class _SettingsSection extends StatelessWidget {
   final String title;
   final List<Widget> children;
-  final bool isDanger;
 
-  const _SettingsSection({required this.title, required this.children, this.isDanger = false});
+  const _SettingsSection({required this.title, required this.children});
 
   @override
   Widget build(BuildContext context) {
@@ -152,14 +130,11 @@ class _SettingsSection extends StatelessWidget {
           padding: const EdgeInsets.only(left: AppSpacing.xs, bottom: AppSpacing.sm),
           child: Text(
             title,
-            style: textTheme.labelLarge?.copyWith(
-              color: isDanger ? colorScheme.error : colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
+            style: textTheme.labelLarge?.copyWith(color: colorScheme.onSurfaceVariant, fontWeight: FontWeight.w600),
           ),
         ),
         AppCard(
-          variant: isDanger ? AppCardVariant.outlined : AppCardVariant.outlined,
+          variant: AppCardVariant.outlined,
           padding: EdgeInsets.zero,
           child: Column(
             children: [
@@ -187,16 +162,8 @@ class _SettingsTile extends StatelessWidget {
   final String title;
   final String subtitle;
   final VoidCallback? onTap;
-  final bool isDanger;
 
-  const _SettingsTile({
-    super.key,
-    required this.icon,
-    required this.title,
-    required this.subtitle,
-    this.onTap,
-    this.isDanger = false,
-  });
+  const _SettingsTile({super.key, required this.icon, required this.title, required this.subtitle, this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -204,13 +171,13 @@ class _SettingsTile extends StatelessWidget {
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg, vertical: AppSpacing.xs),
-      leading: Icon(icon, color: isDanger ? colorScheme.error : colorScheme.onSurfaceVariant),
-      title: Text(title, style: TextStyle(color: isDanger ? colorScheme.error : null)),
+      leading: Icon(icon, color: colorScheme.onSurfaceVariant),
+      title: Text(title),
       subtitle: Text(
         subtitle,
         style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
       ),
-      trailing: isDanger ? null : Icon(Icons.chevron_right_rounded, color: colorScheme.onSurfaceVariant),
+      trailing: Icon(Icons.chevron_right_rounded, color: colorScheme.onSurfaceVariant),
       onTap: onTap,
     );
   }

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc_advance/infrastructure/http/interceptors/dev_consol
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/mock_interceptor.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/resilience_interceptor.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/token_refresh_interceptor.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Metadata describing one entry in the [ApiClient] interceptor chain.
 ///
@@ -65,6 +66,15 @@ class ApiClient {
   /// that the [TokenRefreshInterceptor] can notify the app layer to log out.
   static OnSessionExpired? onSessionExpired;
 
+  /// Secure storage instance threaded into [AuthInterceptor] and
+  /// [TokenRefreshInterceptor] when Dio is built. Bootstrap sets this
+  /// to the same [ISecureStorage] adapter it uses for migration and
+  /// the widget tree, so the HTTP interceptors and the repository
+  /// layer share one source of truth. Falls back to a default
+  /// [FlutterSecureStorageAdapter] when unset (tests that don't go
+  /// through bootstrap).
+  static ISecureStorage? secureStorage;
+
   /// Inject a custom Dio instance for testing.
   static void setTestInstance(Dio dio) => _testDio = dio;
 
@@ -107,11 +117,15 @@ class ApiClient {
         meta: const InterceptorChainEntry(name: 'ConnectivityInterceptor', detail: 'Rejects requests when offline'),
       ),
       (
-        interceptor: AuthInterceptor(),
+        interceptor: AuthInterceptor(secureStorage: secureStorage),
         meta: const InterceptorChainEntry(name: 'AuthInterceptor', detail: 'Attaches JWT token to requests'),
       ),
       (
-        interceptor: TokenRefreshInterceptor(dio: dio, onSessionExpired: onSessionExpired),
+        interceptor: TokenRefreshInterceptor(
+          dio: dio,
+          onSessionExpired: onSessionExpired,
+          secureStorage: secureStorage,
+        ),
         meta: const InterceptorChainEntry(name: 'TokenRefreshInterceptor', detail: 'Refreshes expired access tokens'),
       ),
       (

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -82,10 +82,20 @@ class ApiClient {
   static void resetTestInstance() => _testDio = null;
 
   /// Reset the production singleton (useful in tests).
+  ///
+  /// Clears every static hook the class owns so a re-init path
+  /// (hot reload, test tearDown, multi-test runs in one process)
+  /// cannot leak a previous adapter/callback into the next Dio
+  /// construction. Without resetting [secureStorage] / [onSessionExpired]
+  /// here, a test that sets them and a later test that builds a fresh
+  /// Dio would inherit those — silently re-binding the new interceptors
+  /// to the previous run's instances.
   static void reset() {
     _dio?.close();
     _dio = null;
     _testDio = null;
+    secureStorage = null;
+    onSessionExpired = null;
   }
 
   /// The active Dio instance.

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -96,6 +96,20 @@ class ApiClient {
 
   static Dio _createDio() {
     _log.debug('Creating Dio instance (production: {})', [ProfileConstants.isProduction]);
+    if (secureStorage == null) {
+      // Loud warning when Dio is built without a shared secureStorage.
+      // Production code paths through AppBootstrap always set this
+      // before the first HTTP call; if you see this in test or app
+      // logs it means HTTP interceptors are about to construct their
+      // own FlutterSecureStorageAdapter instance, which will diverge
+      // from whatever the repository layer / SessionCubit are using.
+      // Set ApiClient.secureStorage before touching ApiClient.instance
+      // (test setup helpers do this — see test/test_utils.dart).
+      _log.warn(
+        'ApiClient.secureStorage is null at Dio creation — interceptors will fall back '
+        'to a private FlutterSecureStorageAdapter and diverge from the repository layer.',
+      );
+    }
 
     final dio = Dio(
       BaseOptions(

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -1,14 +1,14 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Injects JWT Bearer token into every outgoing request.
 ///
-/// Token is sourced from [AppLocalStorageCached.jwtToken] (populated on login
-/// by [AppLocalStorageCached.loadCache]) so that the interceptor stays
-/// synchronous in the fast path. Falls back to [ISecureStorage] for production
-/// reads when the cache is cold.
+/// Reads from [ISecureStorage] on every request. There is no in-memory
+/// cache: the only data source for the JWT is the secure store, which
+/// gives us a single, authoritative answer and removes the need for
+/// downstream consumers (repository persist, token refresh, logout) to
+/// keep a parallel cache field consistent.
 class AuthInterceptor extends Interceptor {
   static final _log = AppLogger.getLogger('AuthInterceptor');
 
@@ -18,11 +18,8 @@ class AuthInterceptor extends Interceptor {
 
   @override
   Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
-    // Use the in-memory cache first (populated after persist / loadCache).
-    // This avoids platform-channel calls on every request and works in tests
-    // where the plugin is unavailable.
-    final jwtToken = AppLocalStorageCached.jwtToken ?? await _secureStorage.read(SecureStorageKeys.jwtToken.key);
-    if (jwtToken != null) {
+    final jwtToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    if (jwtToken != null && jwtToken.isNotEmpty) {
       options.headers['Authorization'] = 'Bearer $jwtToken';
     }
     _log.debug('Request [{}] {} (auth: {})', [options.method, options.path, jwtToken != null]);

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Injects JWT Bearer token into every outgoing request.
@@ -23,7 +24,12 @@ class AuthInterceptor extends Interceptor {
     if (hasAuth) {
       options.headers['Authorization'] = 'Bearer $jwtToken';
     }
-    _log.debug('Request [{}] {} (auth: {})', [options.method, options.path, hasAuth]);
+    _log.debug('Request [{}] {} (auth: {}, token: {})', [
+      options.method,
+      options.path,
+      hasAuth,
+      LogSanitizer.maskToken(jwtToken),
+    ]);
     handler.next(options);
   }
 }

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -19,7 +19,17 @@ class AuthInterceptor extends Interceptor {
 
   @override
   Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
-    final jwtToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    // ISecureStorage.read can throw on platform / decryption failure.
+    // If that happens, send the request anonymously rather than failing
+    // the request itself — the downstream 401 path will trigger logout
+    // / re-auth, which is the right user-visible outcome. Crashing the
+    // interceptor would break every HTTP call until app restart.
+    String? jwtToken;
+    try {
+      jwtToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    } catch (e) {
+      _log.warn('secure read failed for {}; sending request without Authorization: {}', [options.path, e]);
+    }
     final hasAuth = jwtToken != null && jwtToken.isNotEmpty;
     if (hasAuth) {
       options.headers['Authorization'] = 'Bearer $jwtToken';

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -19,10 +19,11 @@ class AuthInterceptor extends Interceptor {
   @override
   Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
     final jwtToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
-    if (jwtToken != null && jwtToken.isNotEmpty) {
+    final hasAuth = jwtToken != null && jwtToken.isNotEmpty;
+    if (hasAuth) {
       options.headers['Authorization'] = 'Bearer $jwtToken';
     }
-    _log.debug('Request [{}] {} (auth: {})', [options.method, options.path, jwtToken != null]);
+    _log.debug('Request [{}] {} (auth: {})', [options.method, options.path, hasAuth]);
     handler.next(options);
   }
 }

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -1,14 +1,27 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Injects JWT Bearer token into every outgoing request.
+///
+/// Token is sourced from [AppLocalStorageCached.jwtToken] (populated on login
+/// by [AppLocalStorageCached.loadCache]) so that the interceptor stays
+/// synchronous in the fast path. Falls back to [ISecureStorage] for production
+/// reads when the cache is cold.
 class AuthInterceptor extends Interceptor {
   static final _log = AppLogger.getLogger('AuthInterceptor');
 
+  AuthInterceptor({ISecureStorage? secureStorage}) : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
+
+  final ISecureStorage _secureStorage;
+
   @override
   Future<void> onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
-    final jwtToken = await AppLocalStorage().read(StorageKeys.jwtToken.key);
+    // Use the in-memory cache first (populated after persist / loadCache).
+    // This avoids platform-channel calls on every request and works in tests
+    // where the plugin is unavailable.
+    final jwtToken = AppLocalStorageCached.jwtToken ?? await _secureStorage.read(SecureStorageKeys.jwtToken.key);
     if (jwtToken != null) {
       options.headers['Authorization'] = 'Bearer $jwtToken';
     }

--- a/lib/infrastructure/http/interceptors/auth_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/auth_interceptor.dart
@@ -34,12 +34,7 @@ class AuthInterceptor extends Interceptor {
     if (hasAuth) {
       options.headers['Authorization'] = 'Bearer $jwtToken';
     }
-    _log.debug('Request [{}] {} (auth: {}, token: {})', [
-      options.method,
-      options.path,
-      hasAuth,
-      LogSanitizer.maskToken(jwtToken),
-    ]);
+    _log.debug('Request [{}] {} (auth: {}, token: {})', [options.method, options.path, hasAuth, maskToken(jwtToken)]);
     handler.next(options);
   }
 }

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -41,6 +41,14 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       _onSessionExpired = onSessionExpired,
       _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
 
+  /// Marker placed on [RequestOptions.extra] for requests that have
+  /// already been retried after a refresh. A second 401 on the same
+  /// request short-circuits to logout instead of attempting another
+  /// refresh — prevents infinite refresh loops when the backend keeps
+  /// rejecting freshly-rotated tokens (revoked session, clock skew,
+  /// backend bug, etc.).
+  static const _retriedAfterRefresh = '_tokenRefresh_retried';
+
   @override
   Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
     // Only handle 401 Unauthorized responses
@@ -53,6 +61,17 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     final requestPath = err.requestOptions.path;
     if (requestPath.contains('/api/token/refresh')) {
       _log.warn('Refresh endpoint returned 401 — session expired');
+      _triggerLogout();
+      handler.next(err);
+      return;
+    }
+
+    // Second 401 on the same request after a refresh+retry round
+    // already happened — refusing to refresh again. The newly-rotated
+    // token is being rejected; another refresh would just produce
+    // another rejected token. Surface the failure and log out.
+    if (err.requestOptions.extra[_retriedAfterRefresh] == true) {
+      _log.warn('401 again after refresh+retry for {} — giving up to avoid loop', [requestPath]);
       _triggerLogout();
       handler.next(err);
       return;
@@ -99,10 +118,15 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
 
   /// Retry the original request with [token]. Forwards retry failures
   /// (not the original 401) to the handler so the real cause surfaces.
+  ///
+  /// Stamps [RequestOptions.extra] with [_retriedAfterRefresh] so a
+  /// second 401 on the same retried request short-circuits to logout
+  /// in [onError] — see the loop-prevention check there.
   Future<void> _retryWithToken(DioException err, String token, ErrorInterceptorHandler handler) async {
     try {
       final retryOptions = err.requestOptions;
       retryOptions.headers['Authorization'] = 'Bearer $token';
+      retryOptions.extra[_retriedAfterRefresh] = true;
       final retryResponse = await _dio.fetch(retryOptions);
       handler.resolve(retryResponse);
     } on DioException catch (retryErr) {

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Callback signature for notifying the app layer that the session has expired
 /// and the user must be logged out.
@@ -26,8 +26,12 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
 
   final Dio _dio;
   final OnSessionExpired? _onSessionExpired;
+  final ISecureStorage _secureStorage;
 
-  TokenRefreshInterceptor({required this._dio, this._onSessionExpired});
+  TokenRefreshInterceptor({required Dio dio, OnSessionExpired? onSessionExpired, ISecureStorage? secureStorage})
+    : _dio = dio,
+      _onSessionExpired = onSessionExpired,
+      _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
 
   @override
   Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
@@ -49,8 +53,8 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     _log.debug('401 received for {} — attempting token refresh', [requestPath]);
 
     try {
-      final refreshToken = await AppLocalStorage().read(StorageKeys.refreshToken.key);
-      if (refreshToken == null || (refreshToken is String && refreshToken.isEmpty)) {
+      final refreshToken = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
+      if (refreshToken == null || refreshToken.isEmpty) {
         _log.warn('No refresh token available — session expired');
         _triggerLogout();
         handler.next(err);
@@ -83,9 +87,9 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
         }
 
         // Persist the new tokens
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, newIdToken);
+        await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
         if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
-          await AppLocalStorage().save(StorageKeys.refreshToken.key, newRefreshToken);
+          await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
         }
 
         _log.info('Token refresh successful — retrying original request');

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -11,6 +11,13 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 /// infrastructure layer.
 typedef OnSessionExpired = void Function();
 
+/// Factory for the bare [Dio] instance used to POST the refresh
+/// request. A separate Dio is needed so the refresh call bypasses the
+/// production interceptor chain (otherwise a 401 on `/api/token/refresh`
+/// would re-enter this interceptor recursively). Pluggable so tests
+/// can short-circuit the POST without depending on `http_mock_adapter`.
+typedef RefreshDioFactory = Dio Function(Dio sourceDio);
+
 /// Intercepts 401 responses and attempts a silent token refresh.
 ///
 /// Extends [QueuedInterceptor] so dio queues concurrent 401s, but the
@@ -30,16 +37,31 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
   final Dio _dio;
   final OnSessionExpired? _onSessionExpired;
   final ISecureStorage _secureStorage;
+  final RefreshDioFactory _refreshDioFactory;
 
   /// Shared in-flight refresh. Non-null while a refresh is in progress;
   /// concurrent 401s await the same Future. Cleared on completion (success
   /// or failure) so the next refresh window can start a fresh attempt.
   Future<String?>? _inFlightRefresh;
 
-  TokenRefreshInterceptor({required Dio dio, OnSessionExpired? onSessionExpired, ISecureStorage? secureStorage})
-    : _dio = dio,
-      _onSessionExpired = onSessionExpired,
-      _secureStorage = secureStorage ?? FlutterSecureStorageAdapter();
+  TokenRefreshInterceptor({
+    required Dio dio,
+    OnSessionExpired? onSessionExpired,
+    ISecureStorage? secureStorage,
+    RefreshDioFactory? refreshDioFactory,
+  }) : _dio = dio,
+       _onSessionExpired = onSessionExpired,
+       _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
+       _refreshDioFactory = refreshDioFactory ?? _defaultRefreshDio;
+
+  static Dio _defaultRefreshDio(Dio source) => Dio(
+    BaseOptions(
+      baseUrl: source.options.baseUrl,
+      connectTimeout: source.options.connectTimeout,
+      receiveTimeout: source.options.receiveTimeout,
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/json'},
+    ),
+  );
 
   /// Marker placed on [RequestOptions.extra] for requests that have
   /// already been retried after a refresh. A second 401 on the same
@@ -166,14 +188,7 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       }
 
       // Use a fresh Dio instance to bypass the interceptor chain.
-      final refreshDio = Dio(
-        BaseOptions(
-          baseUrl: _dio.options.baseUrl,
-          connectTimeout: _dio.options.connectTimeout,
-          receiveTimeout: _dio.options.receiveTimeout,
-          headers: {'Accept': 'application/json', 'Content-Type': 'application/json'},
-        ),
-      );
+      final refreshDio = _refreshDioFactory(_dio);
 
       final response = await refreshDio.post('/api/token/refresh', data: jsonEncode({'refresh_token': refreshToken}));
 
@@ -194,9 +209,35 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       // Persist the rotated tokens. AuthInterceptor reads JWT from
       // secure storage on every request, so the next outgoing call
       // picks up the rotated value automatically.
-      await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
-      if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
-        await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
+      //
+      // Both writes are wrapped together with rollback-to-prior so a
+      // partial failure (id_token persisted, refresh_token throws)
+      // cannot leave a torn pair on disk. A torn pair would let the
+      // next request succeed briefly with the new id_token, then fail
+      // on the following 401 because the refresh_token is stale — a
+      // user-visible logout for a reason unrelated to the original
+      // failure. Snapshotting prior values mirrors the pattern in
+      // AuthSessionRepositoryImpl.persist.
+      String? priorIdToken;
+      try {
+        priorIdToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+      } catch (e) {
+        // Snapshot read failed; rollback for jwtToken will fall
+        // through to delete. The session-expired callback will then
+        // force a clean re-auth.
+        _log.warn('Failed to snapshot prior id_token before persist: {}', [e]);
+      }
+
+      try {
+        await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
+        if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
+          await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
+        }
+      } catch (e, st) {
+        _log.error('Persist of rotated tokens failed — rolling back to prior values: {}', [e, st]);
+        await _restoreOrDelete(SecureStorageKeys.jwtToken, priorIdToken);
+        await _restoreOrDelete(SecureStorageKeys.refreshToken, refreshToken);
+        return null;
       }
 
       _log.info('Token refresh successful');
@@ -207,6 +248,22 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     } catch (e) {
       _log.error('Unexpected error during token refresh: {}', [e]);
       return null;
+    }
+  }
+
+  /// Best-effort rollback helper for [_performRefresh]: writes [prior]
+  /// back if it was present, otherwise deletes the key. Swallows any
+  /// failure so a rollback never escalates beyond a clean
+  /// session-expired callback for the user.
+  Future<void> _restoreOrDelete(SecureStorageKeys key, String? prior) async {
+    try {
+      if (prior != null && prior.isNotEmpty) {
+        await _secureStorage.write(key.key, prior);
+      } else {
+        await _secureStorage.delete(key.key);
+      }
+    } catch (e) {
+      _log.warn('Rollback failed for {}: {}', [key.key, e]);
     }
   }
 

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -46,12 +46,12 @@ typedef RefreshDioFactory = Dio Function(Dio sourceDio);
 /// [Future]. When several requests fail with 401 around the same time
 /// the first one starts the refresh; the rest await the same Future
 /// and retry with the already-rotated token instead of triggering a
-/// refresh storm against `/api/token/refresh`.
+/// refresh storm against the refresh endpoint.
 ///
-/// Interceptor order (must come AFTER [AuthInterceptor]):
-/// ```
-/// AuthInterceptor -> TokenRefreshInterceptor -> MockInterceptor? -> ...
-/// ```
+/// Must be registered after [AuthInterceptor] in the chain — see
+/// `ApiClient._createDio` for the single source of truth on order
+/// (any inline ASCII diagram here would drift the next time the
+/// chain is edited).
 class TokenRefreshInterceptor extends QueuedInterceptor {
   static final _log = AppLogger.getLogger('TokenRefreshInterceptor');
 

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -58,7 +58,23 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       return;
     }
 
-    _log.debug('401 received for {} — attempting token refresh', [requestPath]);
+    _log.debug('401 received for {} — checking refresh state', [requestPath]);
+
+    // Stale-header short-circuit: if the JWT has already been rotated
+    // since this request was sent (e.g. a previous refresh completed
+    // while this request was in flight), just retry with the current
+    // token. Avoids back-to-back refresh calls when a serialised wave
+    // of 401s arrives after the first refresh completes.
+    final currentToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    final requestAuth = err.requestOptions.headers['Authorization'] as String?;
+    final requestToken = (requestAuth != null && requestAuth.startsWith('Bearer '))
+        ? requestAuth.substring('Bearer '.length)
+        : null;
+    if (currentToken != null && currentToken.isNotEmpty && requestToken != null && requestToken != currentToken) {
+      _log.debug('JWT already rotated since {} was sent — retrying with current token', [requestPath]);
+      await _retryWithToken(err, currentToken, handler);
+      return;
+    }
 
     final newIdToken = await _refreshOnce();
     if (newIdToken == null) {
@@ -67,23 +83,22 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       return;
     }
 
+    await _retryWithToken(err, newIdToken, handler);
+  }
+
+  /// Retry the original request with [token]. Forwards retry failures
+  /// (not the original 401) to the handler so the real cause surfaces.
+  Future<void> _retryWithToken(DioException err, String token, ErrorInterceptorHandler handler) async {
     try {
-      // Retry the original request with the rotated token.
       final retryOptions = err.requestOptions;
-      retryOptions.headers['Authorization'] = 'Bearer $newIdToken';
+      retryOptions.headers['Authorization'] = 'Bearer $token';
       final retryResponse = await _dio.fetch(retryOptions);
       handler.resolve(retryResponse);
     } on DioException catch (retryErr) {
-      // Forward the RETRY failure — not the original 401 — so callers
-      // see the real cause (network error, 5xx, etc.) instead of a
-      // stale auth error. The original 401 has already been resolved
-      // by a successful token refresh; the retry is its own attempt.
       _log.error('Retry after refresh failed (Dio): {}', [retryErr.message]);
       handler.next(retryErr);
     } catch (e, st) {
       _log.error('Retry after refresh failed (non-Dio): {}', [e]);
-      // Wrap non-Dio failures in a DioException so the interceptor
-      // contract holds (handler.next requires a DioException).
       handler.next(
         DioException(requestOptions: err.requestOptions, error: e, stackTrace: st, type: DioExceptionType.unknown),
       );

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -248,9 +248,20 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
         return null;
       }
 
-      final data = response.data is String ? jsonDecode(response.data as String) : response.data;
-      final newIdToken = data[_RefreshEndpoint.responseKeyIdToken] as String?;
-      final newRefreshToken = data[_RefreshEndpoint.responseKeyRefreshToken] as String?;
+      // Decode the body, then defensively narrow to Map<String, dynamic>
+      // before indexing. A misconfigured backend / proxy could return a
+      // JSON array, a bare string, or wrap the payload (e.g. `{"data":
+      // {...}}`); in any of those shapes `decoded[id_token]` would throw
+      // a NoSuchMethodError that the outer catch would swallow as
+      // "Unexpected error during token refresh" — surfacing the body
+      // shape explicitly makes the misconfiguration debuggable from logs.
+      final decoded = response.data is String ? jsonDecode(response.data as String) : response.data;
+      if (decoded is! Map<String, dynamic>) {
+        _log.error('Refresh response body is not a JSON object (was {}); session expired', [decoded.runtimeType]);
+        return null;
+      }
+      final newIdToken = decoded[_RefreshEndpoint.responseKeyIdToken] as String?;
+      final newRefreshToken = decoded[_RefreshEndpoint.responseKeyRefreshToken] as String?;
 
       if (newIdToken == null || newIdToken.isEmpty) {
         _log.error('Refresh response missing id_token — session expired');

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Callback signature for notifying the app layer that the session has expired
@@ -91,6 +92,10 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
         if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
           await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
         }
+        // Sync the in-memory cache so AuthInterceptor (which prefers the
+        // cache over a disk read) attaches the rotated JWT on subsequent
+        // requests rather than the stale pre-refresh value.
+        AppLocalStorageCached.jwtToken = newIdToken;
 
         _log.info('Token refresh successful — retrying original request');
 

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -1,8 +1,29 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+/// Backend contract for the refresh endpoint, isolated as named
+/// constants so a typo or rename surfaces at one site instead of
+/// scattering across the file. Not exported (private to this library)
+/// because they describe how *this* interceptor talks to the backend —
+/// not a project-wide HTTP policy.
+class _RefreshEndpoint {
+  static const path = '/api/token/refresh';
+  static const requestKeyRefreshToken = 'refresh_token';
+  static const responseKeyIdToken = 'id_token';
+  static const responseKeyRefreshToken = 'refresh_token';
+}
+
+/// HTTP auth header shape. Same locality reasoning as
+/// [_RefreshEndpoint] — these are how this layer writes the header,
+/// not a cross-feature contract.
+class _AuthHeader {
+  static const name = 'Authorization';
+  static const bearerPrefix = 'Bearer ';
+}
 
 /// Callback signature for notifying the app layer that the session has expired
 /// and the user must be logged out.
@@ -63,13 +84,38 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     ),
   );
 
-  /// Marker placed on [RequestOptions.extra] for requests that have
-  /// already been retried after a refresh. A second 401 on the same
+  /// Typed marker that flags a [RequestOptions] as "already retried
+  /// once after a successful refresh." A second 401 on the same
   /// request short-circuits to logout instead of attempting another
   /// refresh — prevents infinite refresh loops when the backend keeps
   /// rejecting freshly-rotated tokens (revoked session, clock skew,
   /// backend bug, etc.).
-  static const _retriedAfterRefresh = '_tokenRefresh_retried';
+  ///
+  /// Uses [Expando] keyed on the [RequestOptions] instance instead of
+  /// the prior stringly-typed `extra['_tokenRefresh_retried']`. The
+  /// previous shape was vulnerable to map-key collisions and `== true`
+  /// comparison drift (would silently fail for `'true'` or `1`).
+  /// The Expando is per-instance, so the marker cannot leak to
+  /// unrelated requests.
+  static final _retriedAfterRefresh = Expando<bool>('_tokenRefresh_retried');
+
+  /// Test-only helpers around the private retry marker. Production
+  /// code never calls these — the marker is stamped exclusively by
+  /// [_retryWithToken] after a successful refresh round, and read
+  /// exclusively by [onError]'s loop-prevention check. Exposed via
+  /// `@visibleForTesting` so tests can drive the loop-prevention
+  /// branch directly and assert that the retry path stamps the
+  /// marker, without leaking the [Expando] mechanism into production
+  /// callers.
+  @visibleForTesting
+  static void debugMarkAsRetried(RequestOptions options) {
+    _retriedAfterRefresh[options] = true;
+  }
+
+  @visibleForTesting
+  static bool debugIsMarkedAsRetried(RequestOptions options) {
+    return _retriedAfterRefresh[options] == true;
+  }
 
   @override
   Future<void> onError(DioException err, ErrorInterceptorHandler handler) async {
@@ -81,7 +127,7 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
 
     // Avoid refreshing on the refresh endpoint itself to prevent infinite loops
     final requestPath = err.requestOptions.path;
-    if (requestPath.contains('/api/token/refresh')) {
+    if (requestPath.contains(_RefreshEndpoint.path)) {
       _log.warn('Refresh endpoint returned 401 — session expired');
       _triggerLogout();
       handler.next(err);
@@ -92,7 +138,7 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     // already happened — refusing to refresh again. The newly-rotated
     // token is being rejected; another refresh would just produce
     // another rejected token. Surface the failure and log out.
-    if (err.requestOptions.extra[_retriedAfterRefresh] == true) {
+    if (_retriedAfterRefresh[err.requestOptions] == true) {
       _log.warn('401 again after refresh+retry for {} — giving up to avoid loop', [requestPath]);
       _triggerLogout();
       handler.next(err);
@@ -120,12 +166,12 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     }
     // Dio headers are Map<String, dynamic>; defensive narrowing to
     // avoid a runtime crash if a non-String value ever lands on
-    // 'Authorization' (interceptor would otherwise break the entire
+    // [_AuthHeader.name] (interceptor would otherwise break the entire
     // request pipeline for one malformed header).
-    final rawAuth = err.requestOptions.headers['Authorization'];
+    final rawAuth = err.requestOptions.headers[_AuthHeader.name];
     final requestAuth = rawAuth is String ? rawAuth : null;
-    final requestToken = (requestAuth != null && requestAuth.startsWith('Bearer '))
-        ? requestAuth.substring('Bearer '.length)
+    final requestToken = (requestAuth != null && requestAuth.startsWith(_AuthHeader.bearerPrefix))
+        ? requestAuth.substring(_AuthHeader.bearerPrefix.length)
         : null;
     if (currentToken != null && currentToken.isNotEmpty && requestToken != null && requestToken != currentToken) {
       _log.debug('JWT already rotated since {} was sent — retrying with current token', [requestPath]);
@@ -152,8 +198,8 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
   Future<void> _retryWithToken(DioException err, String token, ErrorInterceptorHandler handler) async {
     try {
       final retryOptions = err.requestOptions;
-      retryOptions.headers['Authorization'] = 'Bearer $token';
-      retryOptions.extra[_retriedAfterRefresh] = true;
+      retryOptions.headers[_AuthHeader.name] = '${_AuthHeader.bearerPrefix}$token';
+      _retriedAfterRefresh[retryOptions] = true;
       final retryResponse = await _dio.fetch(retryOptions);
       handler.resolve(retryResponse);
     } on DioException catch (retryErr) {
@@ -190,7 +236,10 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       // Use a fresh Dio instance to bypass the interceptor chain.
       final refreshDio = _refreshDioFactory(_dio);
 
-      final response = await refreshDio.post('/api/token/refresh', data: jsonEncode({'refresh_token': refreshToken}));
+      final response = await refreshDio.post(
+        _RefreshEndpoint.path,
+        data: jsonEncode({_RefreshEndpoint.requestKeyRefreshToken: refreshToken}),
+      );
 
       if (response.statusCode != 200 && response.statusCode != 201) {
         _log.warn('Token refresh failed with status {} — session expired', [response.statusCode]);
@@ -198,8 +247,8 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       }
 
       final data = response.data is String ? jsonDecode(response.data as String) : response.data;
-      final newIdToken = data['id_token'] as String?;
-      final newRefreshToken = data['refresh_token'] as String?;
+      final newIdToken = data[_RefreshEndpoint.responseKeyIdToken] as String?;
+      final newRefreshToken = data[_RefreshEndpoint.responseKeyRefreshToken] as String?;
 
       if (newIdToken == null || newIdToken.isEmpty) {
         _log.error('Refresh response missing id_token — session expired');

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -96,7 +96,12 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     } catch (e) {
       _log.warn('Stale-header check skipped — secure read failed: {}', [e]);
     }
-    final requestAuth = err.requestOptions.headers['Authorization'] as String?;
+    // Dio headers are Map<String, dynamic>; defensive narrowing to
+    // avoid a runtime crash if a non-String value ever lands on
+    // 'Authorization' (interceptor would otherwise break the entire
+    // request pipeline for one malformed header).
+    final rawAuth = err.requestOptions.headers['Authorization'];
+    final requestAuth = rawAuth is String ? rawAuth : null;
     final requestToken = (requestAuth != null && requestAuth.startsWith('Bearer '))
         ? requestAuth.substring('Bearer '.length)
         : null;

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -65,7 +65,18 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     // while this request was in flight), just retry with the current
     // token. Avoids back-to-back refresh calls when a serialised wave
     // of 401s arrives after the first refresh completes.
-    final currentToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    //
+    // ISecureStorage.read can throw on platform / decryption failure
+    // (contract from the secure-storage refactor). Treat that as
+    // "optimization unavailable" and fall through to the normal
+    // refresh path — letting the read escape would break the request
+    // pipeline.
+    String? currentToken;
+    try {
+      currentToken = await _secureStorage.read(SecureStorageKeys.jwtToken.key);
+    } catch (e) {
+      _log.warn('Stale-header check skipped — secure read failed: {}', [e]);
+    }
     final requestAuth = err.requestOptions.headers['Authorization'] as String?;
     final requestToken = (requestAuth != null && requestAuth.startsWith('Bearer '))
         ? requestAuth.substring('Bearer '.length)

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -285,7 +285,7 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
           await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
         }
       } catch (e, st) {
-        _log.error('Persist of rotated tokens failed — rolling back to prior values: {}', [e, st]);
+        _log.error('Persist of rotated tokens failed — rolling back to prior values: {} {}', [e, st]);
         await _restoreOrDelete(SecureStorageKeys.jwtToken, priorIdToken);
         await _restoreOrDelete(SecureStorageKeys.refreshToken, refreshToken);
         return null;

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 /// Callback signature for notifying the app layer that the session has expired
@@ -87,15 +86,13 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
           return;
         }
 
-        // Persist the new tokens
+        // Persist the new tokens. AuthInterceptor reads from secure
+        // storage on every request, so no cache sync is needed here —
+        // the next outgoing request picks up the rotated JWT directly.
         await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
         if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
           await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
         }
-        // Sync the in-memory cache so AuthInterceptor (which prefers the
-        // cache over a disk read) attaches the rotated JWT on subsequent
-        // requests rather than the stale pre-refresh value.
-        AppLocalStorageCached.jwtToken = newIdToken;
 
         _log.info('Token refresh successful — retrying original request');
 

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -70,7 +70,9 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
     OnSessionExpired? onSessionExpired,
     ISecureStorage? secureStorage,
     RefreshDioFactory? refreshDioFactory,
+    // ignore: prefer_initializing_formals
   }) : _dio = dio,
+       // ignore: prefer_initializing_formals
        _onSessionExpired = onSessionExpired,
        _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
        _refreshDioFactory = refreshDioFactory ?? _defaultRefreshDio;

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -13,9 +13,12 @@ typedef OnSessionExpired = void Function();
 
 /// Intercepts 401 responses and attempts a silent token refresh.
 ///
-/// Extends [QueuedInterceptor] so that concurrent requests hitting a 401 are
-/// serialised — only one refresh attempt is made and all queued requests are
-/// retried with the new token.
+/// Extends [QueuedInterceptor] so dio queues concurrent 401s, but the
+/// refresh request itself is also coalesced via a shared in-flight
+/// [Future]. When several requests fail with 401 around the same time
+/// the first one starts the refresh; the rest await the same Future
+/// and retry with the already-rotated token instead of triggering a
+/// refresh storm against `/api/token/refresh`.
 ///
 /// Interceptor order (must come AFTER [AuthInterceptor]):
 /// ```
@@ -27,6 +30,11 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
   final Dio _dio;
   final OnSessionExpired? _onSessionExpired;
   final ISecureStorage _secureStorage;
+
+  /// Shared in-flight refresh. Non-null while a refresh is in progress;
+  /// concurrent 401s await the same Future. Cleared on completion (success
+  /// or failure) so the next refresh window can start a fresh attempt.
+  Future<String?>? _inFlightRefresh;
 
   TokenRefreshInterceptor({required Dio dio, OnSessionExpired? onSessionExpired, ISecureStorage? secureStorage})
     : _dio = dio,
@@ -52,16 +60,46 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
 
     _log.debug('401 received for {} — attempting token refresh', [requestPath]);
 
+    final newIdToken = await _refreshOnce();
+    if (newIdToken == null) {
+      _triggerLogout();
+      handler.next(err);
+      return;
+    }
+
+    try {
+      // Retry the original request with the rotated token.
+      final retryOptions = err.requestOptions;
+      retryOptions.headers['Authorization'] = 'Bearer $newIdToken';
+      final retryResponse = await _dio.fetch(retryOptions);
+      handler.resolve(retryResponse);
+    } catch (e) {
+      _log.error('Retry after refresh failed: {}', [e]);
+      handler.next(err);
+    }
+  }
+
+  /// Returns a single in-flight refresh Future. The first caller starts
+  /// the refresh; concurrent callers await the same Future. Cleared on
+  /// completion so subsequent refresh windows start fresh.
+  Future<String?> _refreshOnce() {
+    return _inFlightRefresh ??= _performRefresh().whenComplete(() {
+      _inFlightRefresh = null;
+    });
+  }
+
+  /// Performs the actual refresh call + persistence. Returns the new
+  /// idToken on success, null on any failure (missing refresh token,
+  /// non-2xx response, malformed body, transport error).
+  Future<String?> _performRefresh() async {
     try {
       final refreshToken = await _secureStorage.read(SecureStorageKeys.refreshToken.key);
       if (refreshToken == null || refreshToken.isEmpty) {
         _log.warn('No refresh token available — session expired');
-        _triggerLogout();
-        handler.next(err);
-        return;
+        return null;
       }
 
-      // Attempt token refresh using a fresh Dio instance to bypass interceptors
+      // Use a fresh Dio instance to bypass the interceptor chain.
       final refreshDio = Dio(
         BaseOptions(
           baseUrl: _dio.options.baseUrl,
@@ -73,50 +111,36 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
 
       final response = await refreshDio.post('/api/token/refresh', data: jsonEncode({'refresh_token': refreshToken}));
 
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        final data = response.data is String ? jsonDecode(response.data as String) : response.data;
-
-        final newIdToken = data['id_token'] as String?;
-        final newRefreshToken = data['refresh_token'] as String?;
-
-        if (newIdToken == null || newIdToken.isEmpty) {
-          _log.error('Refresh response missing id_token — session expired');
-          _triggerLogout();
-          handler.next(err);
-          return;
-        }
-
-        // Persist the new tokens. AuthInterceptor reads from secure
-        // storage on every request, so no cache sync is needed here —
-        // the next outgoing request picks up the rotated JWT directly.
-        await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
-        if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
-          await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
-        }
-
-        _log.info('Token refresh successful — retrying original request');
-
-        // Retry the original request with the new token
-        final retryOptions = err.requestOptions;
-        retryOptions.headers['Authorization'] = 'Bearer $newIdToken';
-
-        final retryResponse = await _dio.fetch(retryOptions);
-        handler.resolve(retryResponse);
-        return;
-      } else {
+      if (response.statusCode != 200 && response.statusCode != 201) {
         _log.warn('Token refresh failed with status {} — session expired', [response.statusCode]);
-        _triggerLogout();
-        handler.next(err);
-        return;
+        return null;
       }
+
+      final data = response.data is String ? jsonDecode(response.data as String) : response.data;
+      final newIdToken = data['id_token'] as String?;
+      final newRefreshToken = data['refresh_token'] as String?;
+
+      if (newIdToken == null || newIdToken.isEmpty) {
+        _log.error('Refresh response missing id_token — session expired');
+        return null;
+      }
+
+      // Persist the rotated tokens. AuthInterceptor reads JWT from
+      // secure storage on every request, so the next outgoing call
+      // picks up the rotated value automatically.
+      await _secureStorage.write(SecureStorageKeys.jwtToken.key, newIdToken);
+      if (newRefreshToken != null && newRefreshToken.isNotEmpty) {
+        await _secureStorage.write(SecureStorageKeys.refreshToken.key, newRefreshToken);
+      }
+
+      _log.info('Token refresh successful');
+      return newIdToken;
     } on DioException catch (e) {
       _log.error('Token refresh request failed: {}', [e.message]);
-      _triggerLogout();
-      handler.next(err);
+      return null;
     } catch (e) {
       _log.error('Unexpected error during token refresh: {}', [e]);
-      _triggerLogout();
-      handler.next(err);
+      return null;
     }
   }
 

--- a/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/token_refresh_interceptor.dart
@@ -73,9 +73,20 @@ class TokenRefreshInterceptor extends QueuedInterceptor {
       retryOptions.headers['Authorization'] = 'Bearer $newIdToken';
       final retryResponse = await _dio.fetch(retryOptions);
       handler.resolve(retryResponse);
-    } catch (e) {
-      _log.error('Retry after refresh failed: {}', [e]);
-      handler.next(err);
+    } on DioException catch (retryErr) {
+      // Forward the RETRY failure — not the original 401 — so callers
+      // see the real cause (network error, 5xx, etc.) instead of a
+      // stale auth error. The original 401 has already been resolved
+      // by a successful token refresh; the retry is its own attempt.
+      _log.error('Retry after refresh failed (Dio): {}', [retryErr.message]);
+      handler.next(retryErr);
+    } catch (e, st) {
+      _log.error('Retry after refresh failed (non-Dio): {}', [e]);
+      // Wrap non-Dio failures in a DioException so the interceptor
+      // contract holds (handler.next requires a DioException).
+      handler.next(
+        DioException(requestOptions: err.requestOptions, error: e, stackTrace: st, type: DioExceptionType.unknown),
+      );
     }
   }
 

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -148,7 +148,13 @@ class AppLocalStorage {
     final prefs = await _prefs;
     final ok = await prefs.clear();
     if (!ok) {
+      // Symmetric with [save] / [remove]: a refused mutation surfaces
+      // to callers via exception so Result/rollback paths
+      // (LoginRepository.logout, AuthSessionRepository.clear) treat it
+      // as a failure rather than logging "Cleared all data" and moving
+      // on with stale state.
       _log.error("SharedPreferences clear returned false");
+      throw StateError('SharedPreferences clear returned false');
     }
     await AppLocalStorageCached.loadCache();
     _log.info("Cleared all data from local storage");

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -90,8 +90,8 @@ class AppLocalStorage {
   Future<bool> save(String key, dynamic value) async {
     _log.trace("Saving data to local storage {} {}", [key, value]);
     final prefs = await _prefs;
+    final bool ok;
     try {
-      final bool ok;
       if (value is String) {
         ok = await prefs.setString(key, value);
       } else if (value is int) {
@@ -105,18 +105,27 @@ class AppLocalStorage {
       } else {
         throw Exception("Unsupported value type");
       }
-      if (!ok) {
-        _log.error("SharedPreferences refused write for key {}", [key]);
-        return false;
-      }
-
-      await AppLocalStorageCached.loadCache();
-      _log.trace("Saved data to local storage {} {}", [key, value]);
-      return true;
     } catch (e) {
       _log.error("Error saving data to local storage: {}, {}", [key, e]);
       return false;
     }
+    if (!ok) {
+      _log.error("SharedPreferences refused write for key {}", [key]);
+      return false;
+    }
+    // Refresh the in-memory cache. A failure here means the cache
+    // is stale, NOT that the write failed — the write already landed
+    // above. Returning false from this path would falsely flag a
+    // successful save as a failure and trigger the cross-backend
+    // rollback in AuthSessionRepository._writeLocal, undoing a
+    // legitimate login over a transient SharedPreferences read error.
+    try {
+      await AppLocalStorageCached.loadCache();
+    } catch (e) {
+      _log.warn("Post-save cache refresh failed for {} — cache may be stale: {}", [key, e]);
+    }
+    _log.trace("Saved data to local storage {} {}", [key, value]);
+    return true;
   }
 
   Future<dynamic> read(String key) async {
@@ -127,20 +136,29 @@ class AppLocalStorage {
 
   Future<bool> remove(String key) async {
     _log.trace("Removing data from local storage");
+    final bool ok;
     try {
       final prefs = await _prefs;
-      final ok = await prefs.remove(key);
-      if (!ok) {
-        _log.error("SharedPreferences refused remove for key {}", [key]);
-        return false;
-      }
-      await AppLocalStorageCached.loadCache();
-      _log.trace("Removed data from local storage {}", [key]);
-      return true;
+      ok = await prefs.remove(key);
     } catch (e) {
       _log.error("Error removing data from local storage: {}, {}", [key, e]);
       return false;
     }
+    if (!ok) {
+      _log.error("SharedPreferences refused remove for key {}", [key]);
+      return false;
+    }
+    // Same cache-refresh-failure invariant as [save]: a failure here
+    // does not mean the remove failed (it landed above) — only that
+    // the cache is now stale. Treating it as a failure would block
+    // logout from an unrelated transient error.
+    try {
+      await AppLocalStorageCached.loadCache();
+    } catch (e) {
+      _log.warn("Post-remove cache refresh failed for {} — cache may be stale: {}", [key, e]);
+    }
+    _log.trace("Removed data from local storage {}", [key]);
+    return true;
   }
 
   Future<void> clear() async {

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -172,7 +172,16 @@ class AppLocalStorage {
       _log.error("SharedPreferences clear returned false");
       throw StateError('SharedPreferences clear returned false');
     }
-    await AppLocalStorageCached.loadCache();
+    // Same cache-refresh-failure invariant as [save] / [remove]: the
+    // clear() mutation already landed above. A loadCache failure
+    // means the in-memory cache is stale, NOT that the clear failed.
+    // Letting it throw would force callers (logout, AuthSessionRepository
+    // .clear) to surface Failure even though the on-disk wipe succeeded.
+    try {
+      await AppLocalStorageCached.loadCache();
+    } catch (e) {
+      _log.warn("Post-clear cache refresh failed — cache may be stale: {}", [e]);
+    }
     _log.info("Cleared all data from local storage");
   }
 }

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -1,37 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppLocalStorageCached {
   static final _log = AppLogger.getLogger("AppLocalStorageCached");
-  static late String? jwtToken;
-  static late List<String>? roles;
-  static late String? language;
-  static late String? username;
-  static late String? theme;
-  static late String? brightness;
+  static String? jwtToken;
+  static List<String>? roles;
+  static String? language;
+  static String? username;
+  static String? theme;
+  static String? brightness;
 
-  /// Reload the local-storage-backed fields from [AppLocalStorage].
+  /// Reload all cached fields from their respective backends.
   ///
-  /// [jwtToken] is intentionally NOT reloaded here because it lives in
-  /// secure storage (Keychain / EncryptedSharedPreferences). It is
-  /// updated directly by [AuthSessionRepository.persist] and cleared by
-  /// [AuthSessionRepository.clear] or [AppLocalStorage.clear]. Calling
-  /// the secure storage plugin synchronously on every [AppLocalStorage.save]
-  /// would be both slow and fragile in test environments where the plugin
-  /// is unavailable.
-  static Future<void> loadCache() async {
+  /// [jwtToken] is sourced from [ISecureStorage] only when [secureStorage]
+  /// is provided. Bootstrap passes its own adapter so the JWT is restored
+  /// on app launch. Intra-app callers triggered by [AppLocalStorage.save]
+  /// pass nothing — they have no reason to touch the secure store, and
+  /// the JWT field is kept current by [AuthSessionRepository.persist]
+  /// (which writes the cache directly) and `clear` (which nulls it).
+  /// This split keeps the cache layer free of a hard secure-storage
+  /// dependency in test environments where the plugin is unavailable.
+  static Future<void> loadCache({ISecureStorage? secureStorage}) async {
     _log.trace("Loading cache");
+    if (secureStorage != null) {
+      jwtToken = await secureStorage.read(SecureStorageKeys.jwtToken.key);
+    }
     roles = await AppLocalStorage().read(StorageKeys.roles.key);
     language = await AppLocalStorage().read(StorageKeys.language.key) ?? "en";
     username = await AppLocalStorage().read(StorageKeys.username.key);
     theme = await AppLocalStorage().read(StorageKeys.theme.key) ?? "classic";
     brightness = await AppLocalStorage().read(StorageKeys.brightness.key) ?? "light";
-    _log.trace("Loaded cache with username:{}, roles:{}, language:{}, jwtToken:{}, theme:{}, brightness:{}", [
+    _log.trace("Loaded cache with username:{}, roles:{}, language:{}, jwt-present:{}, theme:{}, brightness:{}", [
       username,
       roles,
       language,
-      jwtToken,
+      jwtToken != null,
       theme,
       brightness,
     ]);

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -11,9 +11,17 @@ class AppLocalStorageCached {
   static late String? theme;
   static late String? brightness;
 
+  /// Reload the local-storage-backed fields from [AppLocalStorage].
+  ///
+  /// [jwtToken] is intentionally NOT reloaded here because it lives in
+  /// secure storage (Keychain / EncryptedSharedPreferences). It is
+  /// updated directly by [AuthSessionRepository.persist] and cleared by
+  /// [AuthSessionRepository.clear] or [AppLocalStorage.clear]. Calling
+  /// the secure storage plugin synchronously on every [AppLocalStorage.save]
+  /// would be both slow and fragile in test environments where the plugin
+  /// is unavailable.
   static Future<void> loadCache() async {
     _log.trace("Loading cache");
-    jwtToken = await AppLocalStorage().read(StorageKeys.jwtToken.key);
     roles = await AppLocalStorage().read(StorageKeys.roles.key);
     language = await AppLocalStorage().read(StorageKeys.language.key) ?? "en";
     username = await AppLocalStorage().read(StorageKeys.username.key);
@@ -126,6 +134,9 @@ class AppLocalStorage {
     _log.info("Clearing all data from local storage");
     final prefs = await _prefs;
     prefs.clear();
+    // Also clear the secure-storage cache entry so that SecurityUtils
+    // reflects the cleared state synchronously.
+    AppLocalStorageCached.jwtToken = null;
     await AppLocalStorageCached.loadCache();
     _log.info("Cleared all data from local storage");
   }

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -1,42 +1,33 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+/// In-memory cache for fields that are read synchronously across the app.
+///
+/// The JWT is intentionally NOT cached here: it lives in [ISecureStorage]
+/// and is read on demand via [SecurityUtils] / [AuthInterceptor]. Keeping
+/// a sync mirror of an async secret created six write paths that all had
+/// to agree — see PR #137 history. The other fields legitimately live in
+/// SharedPreferences and a sync read is cheap and correct.
 class AppLocalStorageCached {
   static final _log = AppLogger.getLogger("AppLocalStorageCached");
-  static String? jwtToken;
   static List<String>? roles;
   static String? language;
   static String? username;
   static String? theme;
   static String? brightness;
 
-  /// Reload all cached fields from their respective backends.
-  ///
-  /// [jwtToken] is sourced from [ISecureStorage] only when [secureStorage]
-  /// is provided. Bootstrap passes its own adapter so the JWT is restored
-  /// on app launch. Intra-app callers triggered by [AppLocalStorage.save]
-  /// pass nothing — they have no reason to touch the secure store, and
-  /// the JWT field is kept current by [AuthSessionRepository.persist]
-  /// (which writes the cache directly) and `clear` (which nulls it).
-  /// This split keeps the cache layer free of a hard secure-storage
-  /// dependency in test environments where the plugin is unavailable.
-  static Future<void> loadCache({ISecureStorage? secureStorage}) async {
+  static Future<void> loadCache() async {
     _log.trace("Loading cache");
-    if (secureStorage != null) {
-      jwtToken = await secureStorage.read(SecureStorageKeys.jwtToken.key);
-    }
     roles = await AppLocalStorage().read(StorageKeys.roles.key);
     language = await AppLocalStorage().read(StorageKeys.language.key) ?? "en";
     username = await AppLocalStorage().read(StorageKeys.username.key);
     theme = await AppLocalStorage().read(StorageKeys.theme.key) ?? "classic";
     brightness = await AppLocalStorage().read(StorageKeys.brightness.key) ?? "light";
-    _log.trace("Loaded cache with username:{}, roles:{}, language:{}, jwt-present:{}, theme:{}, brightness:{}", [
+    _log.trace("Loaded cache with username:{}, roles:{}, language:{}, theme:{}, brightness:{}", [
       username,
       roles,
       language,
-      jwtToken != null,
       theme,
       brightness,
     ]);
@@ -155,9 +146,6 @@ class AppLocalStorage {
     if (!ok) {
       _log.error("SharedPreferences clear returned false");
     }
-    // Also clear the secure-storage cache entry so that SecurityUtils
-    // reflects the cleared state synchronously.
-    AppLocalStorageCached.jwtToken = null;
     await AppLocalStorageCached.loadCache();
     _log.info("Cleared all data from local storage");
   }

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -4,11 +4,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// In-memory cache for fields that are read synchronously across the app.
 ///
-/// The JWT is intentionally NOT cached here: it lives in [ISecureStorage]
-/// and is read on demand via [SecurityUtils] / [AuthInterceptor]. Keeping
-/// a sync mirror of an async secret created six write paths that all had
-/// to agree — see PR #137 history. The other fields legitimately live in
-/// SharedPreferences and a sync read is cheap and correct.
+/// The JWT is intentionally NOT cached here: it lives in `ISecureStorage`
+/// and is read on demand by `AuthInterceptor` (per-request) and by
+/// `SessionCubit.restore` (per app launch). `SecurityUtils` itself is
+/// pure — it takes the token as an argument and does no I/O. Keeping a
+/// sync mirror of an async secret created six coordinated write paths
+/// that all had to agree; removing it eliminated that class of bugs.
+///
+/// The other fields legitimately live in SharedPreferences and a sync
+/// read is cheap and correct.
 class AppLocalStorageCached {
   static final _log = AppLogger.getLogger("AppLocalStorageCached");
   static List<String>? roles;

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -38,8 +38,6 @@ class AppLocalStorageCached {
 /// by appending — do not change existing [key] strings without a
 /// migration.
 enum StorageKeys {
-  jwtToken('jwtToken'),
-  refreshToken('refreshToken'),
   roles('roles'),
   language('language'),
   username('username'),

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -87,23 +87,32 @@ class AppLocalStorage {
   /// Save data to local storage.
   ///
   /// Supported value types: String, int, double, bool, `List<String>`.
-  /// Returns false if value type is not supported or an error occurs.
+  /// Returns false if the value type is unsupported, the underlying
+  /// SharedPreferences write reports failure, or an error is thrown.
+  /// This boolean is the contract that [AuthSessionRepository._writeLocal]
+  /// relies on for cross-backend rollback — silent success here breaks
+  /// atomicity, so each platform call is awaited and its result honored.
   Future<bool> save(String key, dynamic value) async {
     _log.trace("Saving data to local storage {} {}", [key, value]);
     final prefs = await _prefs;
     try {
+      final bool ok;
       if (value is String) {
-        prefs.setString(key, value);
+        ok = await prefs.setString(key, value);
       } else if (value is int) {
-        prefs.setInt(key, value);
+        ok = await prefs.setInt(key, value);
       } else if (value is double) {
-        prefs.setDouble(key, value);
+        ok = await prefs.setDouble(key, value);
       } else if (value is bool) {
-        prefs.setBool(key, value);
+        ok = await prefs.setBool(key, value);
       } else if (value is List<String>) {
-        prefs.setStringList(key, value);
+        ok = await prefs.setStringList(key, value);
       } else {
         throw Exception("Unsupported value type");
+      }
+      if (!ok) {
+        _log.error("SharedPreferences refused write for key {}", [key]);
+        return false;
       }
 
       await AppLocalStorageCached.loadCache();
@@ -125,7 +134,11 @@ class AppLocalStorage {
     _log.trace("Removing data from local storage");
     try {
       final prefs = await _prefs;
-      prefs.remove(key);
+      final ok = await prefs.remove(key);
+      if (!ok) {
+        _log.error("SharedPreferences refused remove for key {}", [key]);
+        return false;
+      }
       await AppLocalStorageCached.loadCache();
       _log.trace("Removed data from local storage {}", [key]);
       return true;
@@ -138,7 +151,10 @@ class AppLocalStorage {
   Future<void> clear() async {
     _log.info("Clearing all data from local storage");
     final prefs = await _prefs;
-    prefs.clear();
+    final ok = await prefs.clear();
+    if (!ok) {
+      _log.error("SharedPreferences clear returned false");
+    }
     // Also clear the secure-storage cache entry so that SecurityUtils
     // reflects the cleared state synchronously.
     AppLocalStorageCached.jwtToken = null;

--- a/lib/infrastructure/storage/local_storage.dart
+++ b/lib/infrastructure/storage/local_storage.dart
@@ -7,9 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// The JWT is intentionally NOT cached here: it lives in `ISecureStorage`
 /// and is read on demand by `AuthInterceptor` (per-request) and by
 /// `SessionCubit.restore` (per app launch). `SecurityUtils` itself is
-/// pure — it takes the token as an argument and does no I/O. Keeping a
-/// sync mirror of an async secret created six coordinated write paths
-/// that all had to agree; removing it eliminated that class of bugs.
+/// pure — it takes the token as an argument and does no I/O.
 ///
 /// The other fields legitimately live in SharedPreferences and a sync
 /// read is cheap and correct.

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -68,3 +68,18 @@ class FlutterSecureStorageAdapter implements ISecureStorage {
     }
   }
 }
+
+/// Keys for values that must be stored in the platform-backed secure
+/// store (iOS Keychain, Android EncryptedSharedPreferences).
+///
+/// Renaming an enum value will NOT change the stored key, so user data
+/// survives refactors safely. Add new entries by appending — do not
+/// change existing [key] strings without a migration.
+enum SecureStorageKeys {
+  jwtToken('jwtToken'),
+  refreshToken('refreshToken');
+
+  const SecureStorageKeys(this.key);
+
+  final String key;
+}

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -7,13 +7,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// in plaintext SharedPreferences.
 ///
 /// Failure contract: every method MUST throw on platform failure so
-/// that callers using Result/rollback semantics
-/// (e.g. [AuthSessionRepository.persist], [SessionMigration]) can react
-/// correctly. Silently swallowing errors here makes Success reports
-/// meaningless. In particular, [read] does NOT collapse platform
-/// failures to null — a transient read failure during a rollback
-/// snapshot must not be misread as "no prior value" and lead to
-/// deleting an existing token.
+/// that callers using Result/rollback semantics — the session-persist
+/// repository and the session-migration runner — can react correctly.
+/// Silently swallowing errors here makes Success reports meaningless.
+/// In particular, [read] does NOT collapse platform failures to null
+/// — a transient read failure during a rollback snapshot must not be
+/// misread as "no prior value" and lead to deleting an existing token.
 ///
 /// [read] returns null only when the key is absent. Platform / decryption
 /// failures throw.
@@ -96,8 +95,9 @@ class FlutterSecureStorageAdapter implements ISecureStorage {
 ///
 /// The current strings (`'jwtToken'`, `'refreshToken'`) deliberately
 /// match the legacy plaintext SharedPreferences key names so the
-/// one-shot migration in [SessionMigration] can locate the source
-/// data. Once analytics confirm no installs older than the migration
+/// one-shot `runSessionMigration()` can locate the source data
+/// (see `session_migration.dart`). Once analytics confirm no installs
+/// older than the migration
 /// remain in the wild (target: 2 minor versions after #129 ships),
 /// these can be renamed to e.g. `'secure.jwt'` / `'secure.refresh'`
 /// with a one-shot migration step that copies the value forward —

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -88,11 +88,20 @@ class FlutterSecureStorageAdapter implements ISecureStorage {
 }
 
 /// Keys for values that must be stored in the platform-backed secure
-/// store (iOS Keychain, Android EncryptedSharedPreferences).
+/// store (iOS Keychain, Android Keystore-backed ciphers).
 ///
 /// Renaming an enum value will NOT change the stored key, so user data
 /// survives refactors safely. Add new entries by appending — do not
 /// change existing [key] strings without a migration.
+///
+/// The current strings (`'jwtToken'`, `'refreshToken'`) deliberately
+/// match the legacy plaintext SharedPreferences key names so the
+/// one-shot migration in [SessionMigration] can locate the source
+/// data. Once analytics confirm no installs older than the migration
+/// remain in the wild (target: 2 minor versions after #129 ships),
+/// these can be renamed to e.g. `'secure.jwt'` / `'secure.refresh'`
+/// with a one-shot migration step that copies the value forward —
+/// TODO(#129-follow-up): close the legacy-name reuse loop.
 enum SecureStorageKeys {
   jwtToken('jwtToken'),
   refreshToken('refreshToken');

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -6,15 +6,21 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// Used for sensitive data like JWT tokens that should not be stored
 /// in plaintext SharedPreferences.
 ///
-/// Failure contract: mutating methods ([write], [delete], [deleteAll])
-/// MUST throw on failure so that callers using Result/rollback semantics
+/// Failure contract: every method MUST throw on platform failure so
+/// that callers using Result/rollback semantics
 /// (e.g. [AuthSessionRepository.persist], [SessionMigration]) can react
 /// correctly. Silently swallowing errors here makes Success reports
-/// meaningless. [read] returns null on failure to keep the read path
-/// simple — a missing key and an unreadable key are equivalent from the
-/// app's perspective.
+/// meaningless. In particular, [read] does NOT collapse platform
+/// failures to null — a transient read failure during a rollback
+/// snapshot must not be misread as "no prior value" and lead to
+/// deleting an existing token.
+///
+/// [read] returns null only when the key is absent. Platform / decryption
+/// failures throw.
 abstract interface class ISecureStorage {
-  /// Read a value by [key]. Returns null if not found OR on read failure.
+  /// Read a value by [key]. Returns null only when the key is absent.
+  /// Throws on platform / decryption failure so transactional callers
+  /// can distinguish "missing" from "unknown".
   Future<String?> read(String key);
 
   /// Write a [value] for the given [key]. Throws on platform failure.
@@ -38,12 +44,7 @@ class FlutterSecureStorageAdapter implements ISecureStorage {
   @override
   Future<String?> read(String key) async {
     _log.trace('Reading secure storage key: {}', [key]);
-    try {
-      return await _storage.read(key: key);
-    } catch (e) {
-      _log.error('Error reading secure storage key {}: {}', [key, e]);
-      return null;
-    }
+    return await _storage.read(key: key);
   }
 
   @override

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -5,17 +5,25 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 ///
 /// Used for sensitive data like JWT tokens that should not be stored
 /// in plaintext SharedPreferences.
+///
+/// Failure contract: mutating methods ([write], [delete], [deleteAll])
+/// MUST throw on failure so that callers using Result/rollback semantics
+/// (e.g. [AuthSessionRepository.persist], [SessionMigration]) can react
+/// correctly. Silently swallowing errors here makes Success reports
+/// meaningless. [read] returns null on failure to keep the read path
+/// simple — a missing key and an unreadable key are equivalent from the
+/// app's perspective.
 abstract interface class ISecureStorage {
-  /// Read a value by [key]. Returns null if not found.
+  /// Read a value by [key]. Returns null if not found OR on read failure.
   Future<String?> read(String key);
 
-  /// Write a [value] for the given [key].
+  /// Write a [value] for the given [key]. Throws on platform failure.
   Future<void> write(String key, String value);
 
-  /// Delete the value for the given [key].
+  /// Delete the value for the given [key]. Throws on platform failure.
   Future<void> delete(String key);
 
-  /// Delete all stored values.
+  /// Delete all stored values. Throws on platform failure.
   Future<void> deleteAll();
 }
 
@@ -41,31 +49,19 @@ class FlutterSecureStorageAdapter implements ISecureStorage {
   @override
   Future<void> write(String key, String value) async {
     _log.trace('Writing secure storage key: {}', [key]);
-    try {
-      await _storage.write(key: key, value: value);
-    } catch (e) {
-      _log.error('Error writing secure storage key {}: {}', [key, e]);
-    }
+    await _storage.write(key: key, value: value);
   }
 
   @override
   Future<void> delete(String key) async {
     _log.trace('Deleting secure storage key: {}', [key]);
-    try {
-      await _storage.delete(key: key);
-    } catch (e) {
-      _log.error('Error deleting secure storage key {}: {}', [key, e]);
-    }
+    await _storage.delete(key: key);
   }
 
   @override
   Future<void> deleteAll() async {
     _log.info('Deleting all secure storage data');
-    try {
-      await _storage.deleteAll();
-    } catch (e) {
-      _log.error('Error deleting all secure storage data: {}', [e]);
-    }
+    await _storage.deleteAll();
   }
 }
 

--- a/lib/infrastructure/storage/secure_storage.dart
+++ b/lib/infrastructure/storage/secure_storage.dart
@@ -34,12 +34,33 @@ abstract interface class ISecureStorage {
 }
 
 /// Production implementation backed by [FlutterSecureStorage].
+///
+/// Platform configuration is pinned explicitly so future package
+/// upgrades or default flips cannot silently weaken the security
+/// posture of stored secrets:
+///
+/// - **Android:** `flutter_secure_storage` ≥ 10 uses custom AES-GCM
+///   ciphers by default (replacing the deprecated Jetpack Crypto
+///   library). Min SDK is 23, so all targets support hardware-backed
+///   key storage. No extra options are needed beyond accepting the
+///   library defaults — flagged here so an audit reader does not
+///   wonder whether plaintext fallback is possible.
+/// - **iOS / macOS:** Keychain accessibility is pinned to
+///   [KeychainAccessibility.first_unlock_this_device] so secrets are
+///   readable after first unlock (e.g. background refresh) but are
+///   NOT synced to iCloud Keychain across devices. This is stricter
+///   than the library default of [KeychainAccessibility.first_unlock]
+///   (which permits iCloud backup) — appropriate for session tokens.
 class FlutterSecureStorageAdapter implements ISecureStorage {
   static final _log = AppLogger.getLogger('FlutterSecureStorageAdapter');
 
+  static const _iosOptions = IOSOptions(accessibility: KeychainAccessibility.first_unlock_this_device);
+  static const _macosOptions = MacOsOptions(accessibility: KeychainAccessibility.first_unlock_this_device);
+
   final FlutterSecureStorage _storage;
 
-  FlutterSecureStorageAdapter({FlutterSecureStorage? storage}) : _storage = storage ?? const FlutterSecureStorage();
+  FlutterSecureStorageAdapter({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage(iOptions: _iosOptions, mOptions: _macosOptions);
 
   @override
   Future<String?> read(String key) async {

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -27,8 +27,13 @@ class SessionMigration {
   static Future<void> _migrateOne(String legacyKey, ISecureStorage secureStorage, AppLocalStorage localStorage) async {
     try {
       final existing = await secureStorage.read(legacyKey);
-      final legacy = await localStorage.read(legacyKey);
-      final hasLegacyPlaintext = legacy is String && legacy.isNotEmpty;
+      // AppLocalStorage.read returns Future<dynamic>; narrow to String
+      // up front so the rest of the function operates on a concrete
+      // type and a future regression can't quietly send a non-String
+      // down to secure-storage write / verify.
+      final legacyRaw = await localStorage.read(legacyKey);
+      final String? legacy = legacyRaw is String ? legacyRaw : null;
+      final hasLegacyPlaintext = legacy != null && legacy.isNotEmpty;
 
       if (existing != null && existing.isNotEmpty) {
         // Already migrated. But if a plaintext copy is still lingering

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -2,6 +2,14 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
+final _log = AppLogger.getLogger('SessionMigration');
+
+/// Legacy SharedPreferences keys to migrate into [ISecureStorage].
+/// Sourced from [SecureStorageKeys] so the canonical token-key
+/// strings stay in lockstep — if a key string ever changes, this
+/// list moves with it automatically.
+final _legacyKeys = <String>[SecureStorageKeys.jwtToken.key, SecureStorageKeys.refreshToken.key];
+
 /// One-shot migration from plaintext SharedPreferences to SecureStorage.
 ///
 /// Runs at bootstrap before [AppLocalStorageCached.loadCache] so the
@@ -9,83 +17,78 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 /// present in [ISecureStorage] is left alone. Best-effort: a failure
 /// logs a warning and returns; worst case the user re-authenticates
 /// on the next launch.
-class SessionMigration {
-  static final _log = AppLogger.getLogger('SessionMigration');
-
-  /// Legacy SharedPreferences keys to migrate into [ISecureStorage].
-  /// Sourced from [SecureStorageKeys] so the canonical token-key
-  /// strings stay in lockstep — if a key string ever changes, this
-  /// list moves with it automatically.
-  static final _legacyKeys = <String>[SecureStorageKeys.jwtToken.key, SecureStorageKeys.refreshToken.key];
-
-  static Future<void> run({required ISecureStorage secureStorage, required AppLocalStorage localStorage}) async {
-    for (final legacyKey in _legacyKeys) {
-      await _migrateOne(legacyKey, secureStorage, localStorage);
-    }
+///
+/// Top-level function — there is no state, no polymorphism, no
+/// related helpers worth namespacing. The previous `SessionMigration`
+/// class wrapper carried zero information beyond what the function
+/// name already conveys.
+Future<void> runSessionMigration({required ISecureStorage secureStorage, required AppLocalStorage localStorage}) async {
+  for (final legacyKey in _legacyKeys) {
+    await _migrateOne(legacyKey, secureStorage, localStorage);
   }
+}
 
-  static Future<void> _migrateOne(String legacyKey, ISecureStorage secureStorage, AppLocalStorage localStorage) async {
-    try {
-      final existing = await secureStorage.read(legacyKey);
-      // AppLocalStorage.read returns Future<dynamic>; narrow to String
-      // up front so the rest of the function operates on a concrete
-      // type and a future regression can't quietly send a non-String
-      // down to secure-storage write / verify.
-      final legacyRaw = await localStorage.read(legacyKey);
-      final String? legacy = legacyRaw is String ? legacyRaw : null;
-      final hasLegacyPlaintext = legacy != null && legacy.isNotEmpty;
+Future<void> _migrateOne(String legacyKey, ISecureStorage secureStorage, AppLocalStorage localStorage) async {
+  try {
+    final existing = await secureStorage.read(legacyKey);
+    // AppLocalStorage.read returns Future<dynamic>; narrow to String
+    // up front so the rest of the function operates on a concrete
+    // type and a future regression can't quietly send a non-String
+    // down to secure-storage write / verify.
+    final legacyRaw = await localStorage.read(legacyKey);
+    final String? legacy = legacyRaw is String ? legacyRaw : null;
+    final hasLegacyPlaintext = legacy != null && legacy.isNotEmpty;
 
-      if (existing != null && existing.isNotEmpty) {
-        // Already migrated. But if a plaintext copy is still lingering
-        // in SharedPreferences — a previous migration may have left it
-        // behind, or the migration was interrupted between write and
-        // remove — clean it up now. Best-effort: the token is safe in
-        // secure storage, so a remove failure just delays cleanup
-        // until the next launch.
-        if (hasLegacyPlaintext) {
-          try {
-            final removed = await localStorage.remove(legacyKey);
-            if (removed) {
-              _log.info('Cleaned up lingering plaintext {} after prior migration', [legacyKey]);
-            } else {
-              _log.warn('Lingering plaintext {} remove returned false; will retry next launch', [legacyKey]);
-            }
-          } catch (e) {
-            _log.warn('Lingering plaintext {} cleanup failed: {}', [legacyKey, e]);
+    if (existing != null && existing.isNotEmpty) {
+      // Already migrated. But if a plaintext copy is still lingering
+      // in SharedPreferences — a previous migration may have left it
+      // behind, or the migration was interrupted between write and
+      // remove — clean it up now. Best-effort: the token is safe in
+      // secure storage, so a remove failure just delays cleanup
+      // until the next launch.
+      if (hasLegacyPlaintext) {
+        try {
+          final removed = await localStorage.remove(legacyKey);
+          if (removed) {
+            _log.info('Cleaned up lingering plaintext {} after prior migration', [legacyKey]);
+          } else {
+            _log.warn('Lingering plaintext {} remove returned false; will retry next launch', [legacyKey]);
           }
+        } catch (e) {
+          _log.warn('Lingering plaintext {} cleanup failed: {}', [legacyKey, e]);
         }
-        return;
       }
-
-      if (!hasLegacyPlaintext) return;
-
-      await secureStorage.write(legacyKey, legacy);
-
-      // Verify the write actually landed before deleting the legacy copy.
-      // The adapter throws on platform errors, but defense-in-depth: if a
-      // future custom adapter quietly drops a write we must not orphan the
-      // token by removing the only remaining copy.
-      final verify = await secureStorage.read(legacyKey);
-      if (verify != legacy) {
-        _log.warn('Migration verify mismatch for {}; legacy key retained', [legacyKey]);
-        return;
-      }
-
-      final removed = await localStorage.remove(legacyKey);
-      if (!removed) {
-        // The token IS now in secure storage (write+verify above), so the
-        // user is not stranded — but a leftover plaintext copy in
-        // SharedPreferences is exactly what this migration is meant to
-        // eliminate. Surface it so operators can act.
-        _log.warn(
-          'Migrated {} to SecureStorage but legacy SharedPreferences remove returned false; plaintext value may persist',
-          [legacyKey],
-        );
-        return;
-      }
-      _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
-    } catch (e) {
-      _log.warn('Migration failed for {}: {}', [legacyKey, e]);
+      return;
     }
+
+    if (!hasLegacyPlaintext) return;
+
+    await secureStorage.write(legacyKey, legacy);
+
+    // Verify the write actually landed before deleting the legacy copy.
+    // The adapter throws on platform errors, but defense-in-depth: if a
+    // future custom adapter quietly drops a write we must not orphan the
+    // token by removing the only remaining copy.
+    final verify = await secureStorage.read(legacyKey);
+    if (verify != legacy) {
+      _log.warn('Migration verify mismatch for {}; legacy key retained', [legacyKey]);
+      return;
+    }
+
+    final removed = await localStorage.remove(legacyKey);
+    if (!removed) {
+      // The token IS now in secure storage (write+verify above), so the
+      // user is not stranded — but a leftover plaintext copy in
+      // SharedPreferences is exactly what this migration is meant to
+      // eliminate. Surface it so operators can act.
+      _log.warn(
+        'Migrated {} to SecureStorage but legacy SharedPreferences remove returned false; plaintext value may persist',
+        [legacyKey],
+      );
+      return;
+    }
+    _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
+  } catch (e) {
+    _log.warn('Migration failed for {}: {}', [legacyKey, e]);
   }
 }

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -40,7 +40,18 @@ class SessionMigration {
         return;
       }
 
-      await localStorage.remove(legacyKey);
+      final removed = await localStorage.remove(legacyKey);
+      if (!removed) {
+        // The token IS now in secure storage (write+verify above), so the
+        // user is not stranded — but a leftover plaintext copy in
+        // SharedPreferences is exactly what this migration is meant to
+        // eliminate. Surface it so operators can act.
+        _log.warn(
+          'Migrated {} to SecureStorage but legacy SharedPreferences remove returned false; plaintext value may persist',
+          [legacyKey],
+        );
+        return;
+      }
       _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
     } catch (e) {
       _log.warn('Migration failed for {}: {}', [legacyKey, e]);

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+
+/// One-shot migration from plaintext SharedPreferences to SecureStorage.
+///
+/// Runs at bootstrap before [AppLocalStorageCached.loadCache] so the
+/// cache sees the post-migration state. Idempotent: any value already
+/// present in [ISecureStorage] is left alone. Best-effort: a failure
+/// logs a warning and returns; worst case the user re-authenticates
+/// on the next launch.
+class SessionMigration {
+  static final _log = AppLogger.getLogger('SessionMigration');
+
+  static const _legacyKeys = <String>['jwtToken', 'refreshToken'];
+
+  static Future<void> run({required ISecureStorage secureStorage, required AppLocalStorage localStorage}) async {
+    for (final legacyKey in _legacyKeys) {
+      await _migrateOne(legacyKey, secureStorage, localStorage);
+    }
+  }
+
+  static Future<void> _migrateOne(String legacyKey, ISecureStorage secureStorage, AppLocalStorage localStorage) async {
+    try {
+      final existing = await secureStorage.read(legacyKey);
+      if (existing != null && existing.isNotEmpty) return;
+
+      final legacy = await localStorage.read(legacyKey);
+      if (legacy is! String || legacy.isEmpty) return;
+
+      await secureStorage.write(legacyKey, legacy);
+      await localStorage.remove(legacyKey);
+      _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
+    } catch (e) {
+      _log.warn('Migration failed for {}: {}', [legacyKey, e]);
+    }
+  }
+}

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -29,6 +29,17 @@ class SessionMigration {
       if (legacy is! String || legacy.isEmpty) return;
 
       await secureStorage.write(legacyKey, legacy);
+
+      // Verify the write actually landed before deleting the legacy copy.
+      // The adapter throws on platform errors, but defense-in-depth: if a
+      // future custom adapter quietly drops a write we must not orphan the
+      // token by removing the only remaining copy.
+      final verify = await secureStorage.read(legacyKey);
+      if (verify != legacy) {
+        _log.warn('Migration verify mismatch for {}; legacy key retained', [legacyKey]);
+        return;
+      }
+
       await localStorage.remove(legacyKey);
       _log.info('Migrated {} from SharedPreferences to SecureStorage', [legacyKey]);
     } catch (e) {

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -27,10 +27,32 @@ class SessionMigration {
   static Future<void> _migrateOne(String legacyKey, ISecureStorage secureStorage, AppLocalStorage localStorage) async {
     try {
       final existing = await secureStorage.read(legacyKey);
-      if (existing != null && existing.isNotEmpty) return;
-
       final legacy = await localStorage.read(legacyKey);
-      if (legacy is! String || legacy.isEmpty) return;
+      final hasLegacyPlaintext = legacy is String && legacy.isNotEmpty;
+
+      if (existing != null && existing.isNotEmpty) {
+        // Already migrated. But if a plaintext copy is still lingering
+        // in SharedPreferences — a previous migration may have left it
+        // behind, or the migration was interrupted between write and
+        // remove — clean it up now. Best-effort: the token is safe in
+        // secure storage, so a remove failure just delays cleanup
+        // until the next launch.
+        if (hasLegacyPlaintext) {
+          try {
+            final removed = await localStorage.remove(legacyKey);
+            if (removed) {
+              _log.info('Cleaned up lingering plaintext {} after prior migration', [legacyKey]);
+            } else {
+              _log.warn('Lingering plaintext {} remove returned false; will retry next launch', [legacyKey]);
+            }
+          } catch (e) {
+            _log.warn('Lingering plaintext {} cleanup failed: {}', [legacyKey, e]);
+          }
+        }
+        return;
+      }
+
+      if (!hasLegacyPlaintext) return;
 
       await secureStorage.write(legacyKey, legacy);
 

--- a/lib/infrastructure/storage/session_migration.dart
+++ b/lib/infrastructure/storage/session_migration.dart
@@ -12,7 +12,11 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 class SessionMigration {
   static final _log = AppLogger.getLogger('SessionMigration');
 
-  static const _legacyKeys = <String>['jwtToken', 'refreshToken'];
+  /// Legacy SharedPreferences keys to migrate into [ISecureStorage].
+  /// Sourced from [SecureStorageKeys] so the canonical token-key
+  /// strings stay in lockstep — if a key string ever changes, this
+  /// list moves with it automatically.
+  static final _legacyKeys = <String>[SecureStorageKeys.jwtToken.key, SecureStorageKeys.refreshToken.key];
 
   static Future<void> run({required ISecureStorage secureStorage, required AppLocalStorage localStorage}) async {
     for (final legacyKey in _legacyKeys) {

--- a/test/app/di/repository_contracts_test.dart
+++ b/test/app/di/repository_contracts_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc_advance/app/di/app_dependencies.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_repository.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
@@ -17,6 +18,10 @@ class _StubSecureStorage implements ISecureStorage {
 }
 
 void main() {
+  setUpAll(() {
+    AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
+  });
+
   const dependencies = AppDependencies();
 
   test('app dependencies expose account repository contract', () {

--- a/test/app/di/repository_contracts_test.dart
+++ b/test/app/di/repository_contracts_test.dart
@@ -2,7 +2,19 @@ import 'package:flutter_bloc_advance/app/di/app_dependencies.dart';
 import 'package:flutter_bloc_advance/features/account/domain/repositories/account_repository.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/repositories/auth_repository.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+class _StubSecureStorage implements ISecureStorage {
+  @override
+  Future<String?> read(String key) async => null;
+  @override
+  Future<void> write(String key, String value) async {}
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll() async {}
+}
 
 void main() {
   const dependencies = AppDependencies();
@@ -12,7 +24,7 @@ void main() {
   });
 
   test('app dependencies expose auth repository contract', () {
-    expect(dependencies.createAuthRepository(), isA<IAuthRepository>());
+    expect(dependencies.createAuthRepository(_StubSecureStorage()), isA<IAuthRepository>());
   });
 
   test('app dependencies expose user repository contract', () {

--- a/test/app/router/app_router_factory_test.dart
+++ b/test/app/router/app_router_factory_test.dart
@@ -45,7 +45,7 @@ void main() {
 
     testWidgets('allows authenticated users to open settings', (tester) async {
       setDesktopViewport(tester);
-      await testUtils.setupAuthentication();
+      testUtils.setupAuthentication();
       await tester.pumpWidget(const App(language: 'en'));
       await tester.pumpAndSettle();
 

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -1,9 +1,21 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../test_utils.dart';
+
+class _MemorySecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
 
 void main() {
   final testUtils = TestUtils();
@@ -83,39 +95,37 @@ void main() {
     );
 
     blocTest<SessionCubit, SessionState>(
-      'restore emits unauthenticated when no token cached',
-      build: () => SessionCubit(),
+      'restore emits unauthenticated when secure storage has no token',
+      build: () => SessionCubit(secureStorage: _MemorySecureStorage()),
       act: (cubit) => cubit.restore(),
       expect: () => [const SessionState(isAuthenticated: false)],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'restore emits authenticated when token is cached',
-      setUp: () async {
-        // Seed the sync cache directly — FlutterSecureStorageAdapter is not
-        // available in unit tests.
-        AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
+      'restore emits authenticated when secure storage has a token',
+      build: () {
+        final secure = _MemorySecureStorage();
+        secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        return SessionCubit(secureStorage: secure);
       },
-      build: () => SessionCubit(),
       act: (cubit) => cubit.restore(),
       expect: () => [const SessionState(isAuthenticated: true)],
     );
 
     blocTest<SessionCubit, SessionState>(
       'refresh delegates to restore and emits correct state',
-      build: () => SessionCubit(),
+      build: () => SessionCubit(secureStorage: _MemorySecureStorage()),
       act: (cubit) => cubit.refresh(),
       expect: () => [const SessionState(isAuthenticated: false)],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'refresh emits authenticated when token is cached',
-      setUp: () async {
-        // Seed the sync cache directly — FlutterSecureStorageAdapter is not
-        // available in unit tests.
-        AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
+      'refresh emits authenticated when secure storage has a token',
+      build: () {
+        final secure = _MemorySecureStorage();
+        secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        return SessionCubit(secureStorage: secure);
       },
-      build: () => SessionCubit(),
       act: (cubit) => cubit.refresh(),
       expect: () => [const SessionState(isAuthenticated: true)],
     );

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -92,7 +92,9 @@ void main() {
     blocTest<SessionCubit, SessionState>(
       'restore emits authenticated when token is cached',
       setUp: () async {
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        // Seed the sync cache directly — FlutterSecureStorageAdapter is not
+        // available in unit tests.
+        AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
       },
       build: () => SessionCubit(),
       act: (cubit) => cubit.restore(),
@@ -109,7 +111,9 @@ void main() {
     blocTest<SessionCubit, SessionState>(
       'refresh emits authenticated when token is cached',
       setUp: () async {
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        // Seed the sync cache directly — FlutterSecureStorageAdapter is not
+        // available in unit tests.
+        AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
       },
       build: () => SessionCubit(),
       act: (cubit) => cubit.refresh(),

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -116,7 +116,11 @@ void main() {
       'restore emits authenticated when secure storage has a token',
       build: () {
         final secure = _MemorySecureStorage();
-        secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        // Map write is synchronous; the async `write` wrapper just
+        // exists to satisfy the ISecureStorage interface. Seeding
+        // directly avoids the unawaited-write race the linter would
+        // otherwise (correctly) flag.
+        secure._store[SecureStorageKeys.jwtToken.key] = 'MOCK_TOKEN';
         return SessionCubit(secureStorage: secure);
       },
       act: (cubit) => cubit.restore(),
@@ -134,7 +138,7 @@ void main() {
       'refresh emits authenticated when secure storage has a token',
       build: () {
         final secure = _MemorySecureStorage();
-        secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
+        secure._store[SecureStorageKeys.jwtToken.key] = 'MOCK_TOKEN';
         return SessionCubit(secureStorage: secure);
       },
       act: (cubit) => cubit.refresh(),

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -17,6 +17,17 @@ class _MemorySecureStorage implements ISecureStorage {
   Future<void> deleteAll() async => _store.clear();
 }
 
+class _ReadThrowsSecureStorage implements ISecureStorage {
+  @override
+  Future<String?> read(String key) async => throw StateError('boom on read $key');
+  @override
+  Future<void> write(String key, String value) async {}
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll() async {}
+}
+
 void main() {
   final testUtils = TestUtils();
 
@@ -128,6 +139,13 @@ void main() {
       },
       act: (cubit) => cubit.refresh(),
       expect: () => [const SessionState(isAuthenticated: true)],
+    );
+
+    blocTest<SessionCubit, SessionState>(
+      'restore emits unauthenticated (safe default) when secure read throws',
+      build: () => SessionCubit(secureStorage: _ReadThrowsSecureStorage()),
+      act: (cubit) => cubit.restore(),
+      expect: () => [const SessionState(isAuthenticated: false)],
     );
 
     blocTest<SessionCubit, SessionState>(

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
+import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -28,6 +29,10 @@ class _ReadThrowsSecureStorage implements ISecureStorage {
   Future<void> deleteAll() async {}
 }
 
+/// JWT with `exp` claim already in the past. Built statically so tests
+/// can be const-friendly. Payload: `{"sub":"u","exp":1}` (1970-01-01).
+const _expiredJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1IiwiZXhwIjoxfQ.signature';
+
 void main() {
   final testUtils = TestUtils();
 
@@ -39,117 +44,107 @@ void main() {
     await testUtils.tearDownUnitTest();
   });
 
-  group('SessionState', () {
-    test('unknown() factory creates unauthenticated state', () {
-      const state = SessionState.unknown();
-      expect(state.isAuthenticated, isFalse);
+  group('SessionState — sealed hierarchy', () {
+    test('SessionUnknown is the initial state, distinct from unauthenticated', () {
+      const unknown = SessionUnknown();
+      const unauthenticated = SessionUnauthenticated(reason: SessionExpiredReason.noToken);
+      expect(unknown, isNot(equals(unauthenticated)), reason: 'unknown ≠ unauthenticated by type');
     });
 
-    test('constructor creates state with given authentication status', () {
-      const authenticated = SessionState(isAuthenticated: true);
-      expect(authenticated.isAuthenticated, isTrue);
-
-      const unauthenticated = SessionState(isAuthenticated: false);
-      expect(unauthenticated.isAuthenticated, isFalse);
-    });
-
-    test('copyWith returns new state with updated isAuthenticated', () {
-      const state = SessionState(isAuthenticated: false);
-      final updated = state.copyWith(isAuthenticated: true);
-      expect(updated.isAuthenticated, isTrue);
-    });
-
-    test('copyWith preserves isAuthenticated when not provided', () {
-      const state = SessionState(isAuthenticated: true);
-      final updated = state.copyWith();
-      expect(updated.isAuthenticated, isTrue);
-    });
-
-    test('props contains isAuthenticated', () {
-      const state = SessionState(isAuthenticated: true);
-      expect(state.props, [true]);
-    });
-
-    test('two states with same isAuthenticated are equal', () {
-      const a = SessionState(isAuthenticated: true);
-      const b = SessionState(isAuthenticated: true);
+    test('SessionAuthenticated is a singleton-equivalent value type', () {
+      const a = SessionAuthenticated();
+      const b = SessionAuthenticated();
       expect(a, equals(b));
     });
 
-    test('two states with different isAuthenticated are not equal', () {
-      const a = SessionState(isAuthenticated: true);
-      const b = SessionState(isAuthenticated: false);
-      expect(a, isNot(equals(b)));
+    test('SessionUnauthenticated equality includes the reason', () {
+      const noToken = SessionUnauthenticated(reason: SessionExpiredReason.noToken);
+      const expired = SessionUnauthenticated(reason: SessionExpiredReason.expired);
+      expect(noToken, isNot(equals(expired)));
+    });
+
+    test('exhaustive switch covers all variants without a default', () {
+      // Compiler-enforced exhaustiveness — if a new variant is added
+      // without updating callers, the analyzer fails this build.
+      String label(SessionState s) => switch (s) {
+        SessionUnknown() => 'unknown',
+        SessionAuthenticated() => 'authenticated',
+        SessionUnauthenticated() => 'unauthenticated',
+      };
+      expect(label(const SessionUnknown()), 'unknown');
+      expect(label(const SessionAuthenticated()), 'authenticated');
+      expect(label(const SessionUnauthenticated()), 'unauthenticated');
     });
   });
 
   group('SessionCubit', () {
-    test('initial state is unauthenticated', () {
+    test('initial state is SessionUnknown — distinguishable from unauthenticated', () {
       final cubit = SessionCubit();
-      expect(cubit.state.isAuthenticated, isFalse);
+      expect(cubit.state, isA<SessionUnknown>());
       cubit.close();
     });
 
     blocTest<SessionCubit, SessionState>(
-      'markAuthenticated emits authenticated state',
+      'markAuthenticated emits SessionAuthenticated',
       build: () => SessionCubit(),
       act: (cubit) => cubit.markAuthenticated(),
-      expect: () => [const SessionState(isAuthenticated: true)],
+      expect: () => [const SessionAuthenticated()],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'markLoggedOut emits unauthenticated state',
+      'markLoggedOut emits SessionUnauthenticated with noToken reason by default',
       build: () => SessionCubit(),
-      seed: () => const SessionState(isAuthenticated: true),
+      seed: () => const SessionAuthenticated(),
       act: (cubit) => cubit.markLoggedOut(),
-      expect: () => [const SessionState(isAuthenticated: false)],
+      expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.noToken)],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'restore emits unauthenticated when secure storage has no token',
+      'restore emits SessionUnauthenticated(noToken) when secure storage is empty',
       build: () => SessionCubit(secureStorage: _MemorySecureStorage()),
       act: (cubit) => cubit.restore(),
-      expect: () => [const SessionState(isAuthenticated: false)],
+      expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.noToken)],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'restore emits authenticated when secure storage has a token',
+      'restore emits SessionAuthenticated when secure storage has a token',
       build: () {
         final secure = _MemorySecureStorage();
-        // Map write is synchronous; the async `write` wrapper just
-        // exists to satisfy the ISecureStorage interface. Seeding
-        // directly avoids the unawaited-write race the linter would
-        // otherwise (correctly) flag.
+        // Direct map write; the async `write` wrapper only exists to
+        // satisfy ISecureStorage. Seeding synchronously avoids the
+        // unawaited-write race the linter would otherwise flag.
         secure._store[SecureStorageKeys.jwtToken.key] = 'MOCK_TOKEN';
         return SessionCubit(secureStorage: secure);
       },
       act: (cubit) => cubit.restore(),
-      expect: () => [const SessionState(isAuthenticated: true)],
+      expect: () => [const SessionAuthenticated()],
     );
 
     blocTest<SessionCubit, SessionState>(
-      'refresh delegates to restore and emits correct state',
-      build: () => SessionCubit(secureStorage: _MemorySecureStorage()),
-      act: (cubit) => cubit.refresh(),
-      expect: () => [const SessionState(isAuthenticated: false)],
-    );
-
-    blocTest<SessionCubit, SessionState>(
-      'refresh emits authenticated when secure storage has a token',
+      'restore emits SessionUnauthenticated(expired) for an expired token in prod',
+      setUp: () => ProfileConstants.setEnvironment(Environment.prod),
       build: () {
         final secure = _MemorySecureStorage();
-        secure._store[SecureStorageKeys.jwtToken.key] = 'MOCK_TOKEN';
+        secure._store[SecureStorageKeys.jwtToken.key] = _expiredJwt;
         return SessionCubit(secureStorage: secure);
       },
-      act: (cubit) => cubit.refresh(),
-      expect: () => [const SessionState(isAuthenticated: true)],
+      act: (cubit) => cubit.restore(),
+      expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.expired)],
+      tearDown: () => ProfileConstants.setEnvironment(Environment.test),
     );
 
     blocTest<SessionCubit, SessionState>(
-      'restore emits unauthenticated (safe default) when secure read throws',
+      'restore emits SessionUnauthenticated(storageError) when secure read throws',
       build: () => SessionCubit(secureStorage: _ReadThrowsSecureStorage()),
       act: (cubit) => cubit.restore(),
-      expect: () => [const SessionState(isAuthenticated: false)],
+      expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.storageError)],
+    );
+
+    blocTest<SessionCubit, SessionState>(
+      'refresh delegates to restore',
+      build: () => SessionCubit(secureStorage: _MemorySecureStorage()),
+      act: (cubit) => cubit.refresh(),
+      expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.noToken)],
     );
 
     blocTest<SessionCubit, SessionState>(
@@ -159,14 +154,7 @@ void main() {
         cubit.markAuthenticated();
         cubit.markLoggedOut();
       },
-      expect: () => [const SessionState(isAuthenticated: true), const SessionState(isAuthenticated: false)],
-    );
-
-    blocTest<SessionCubit, SessionState>(
-      'markLoggedOut re-emits unauthenticated even when already unauthenticated',
-      build: () => SessionCubit(),
-      act: (cubit) => cubit.markLoggedOut(),
-      expect: () => [const SessionState(isAuthenticated: false)],
+      expect: () => [const SessionAuthenticated(), const SessionUnauthenticated(reason: SessionExpiredReason.noToken)],
     );
   });
 }

--- a/test/core/logging/log_sanitizer_test.dart
+++ b/test/core/logging/log_sanitizer_test.dart
@@ -2,27 +2,27 @@ import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('LogSanitizer.maskToken', () {
+  group('maskToken', () {
     test('returns <empty> for null', () {
-      expect(LogSanitizer.maskToken(null), '<empty>');
+      expect(maskToken(null), '<empty>');
     });
 
     test('returns <empty> for empty string', () {
-      expect(LogSanitizer.maskToken(''), '<empty>');
+      expect(maskToken(''), '<empty>');
     });
 
     test('returns <redacted> for tokens shorter than 8 chars', () {
-      expect(LogSanitizer.maskToken('a'), '<redacted>');
-      expect(LogSanitizer.maskToken('1234567'), '<redacted>');
+      expect(maskToken('a'), '<redacted>');
+      expect(maskToken('1234567'), '<redacted>');
     });
 
     test('masks the middle of an 8-char token', () {
-      expect(LogSanitizer.maskToken('12345678'), '1234…5678');
+      expect(maskToken('12345678'), '1234…5678');
     });
 
     test('masks a realistic JWT', () {
       const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature';
-      final masked = LogSanitizer.maskToken(jwt);
+      final masked = maskToken(jwt);
       expect(masked, startsWith('eyJh'));
       expect(masked, endsWith('ture'));
       expect(masked.contains('payload'), isFalse);

--- a/test/core/logging/log_sanitizer_test.dart
+++ b/test/core/logging/log_sanitizer_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_bloc_advance/core/logging/log_sanitizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LogSanitizer.maskToken', () {
+    test('returns <empty> for null', () {
+      expect(LogSanitizer.maskToken(null), '<empty>');
+    });
+
+    test('returns <empty> for empty string', () {
+      expect(LogSanitizer.maskToken(''), '<empty>');
+    });
+
+    test('returns <redacted> for tokens shorter than 8 chars', () {
+      expect(LogSanitizer.maskToken('a'), '<redacted>');
+      expect(LogSanitizer.maskToken('1234567'), '<redacted>');
+    });
+
+    test('masks the middle of an 8-char token', () {
+      expect(LogSanitizer.maskToken('12345678'), '1234…5678');
+    });
+
+    test('masks a realistic JWT', () {
+      const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature';
+      final masked = LogSanitizer.maskToken(jwt);
+      expect(masked, startsWith('eyJh'));
+      expect(masked, endsWith('ture'));
+      expect(masked.contains('payload'), isFalse);
+      expect(masked.contains('signature'), isFalse);
+    });
+  });
+}

--- a/test/core/security/security_utils_test.dart
+++ b/test/core/security/security_utils_test.dart
@@ -11,7 +11,13 @@ void main() {
     await TestUtils().setupUnitTest();
   });
 
+  setUp(() {
+    // Reset the sync cache before each test so no token lingers.
+    AppLocalStorageCached.jwtToken = null;
+  });
+
   tearDown(() async {
+    AppLocalStorageCached.jwtToken = null;
     await TestUtils().tearDownUnitTest();
   });
 
@@ -45,32 +51,32 @@ void main() {
       });
 
       test('should return true when token is invalid format', () async {
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, "invalid.token");
+        AppLocalStorageCached.jwtToken = 'invalid.token';
         expect(SecurityUtils.isTokenExpired(), true);
       });
 
       test('should return true when token payload is invalid', () async {
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, "header.invalid_payload.signature");
+        AppLocalStorageCached.jwtToken = 'header.invalid_payload.signature';
         expect(SecurityUtils.isTokenExpired(), true);
       });
 
       test('should return true when exp is missing in payload', () async {
         final payload = base64Url.encode('{"sub":"test"}'.codeUnits);
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, "header.$payload.signature");
+        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
         expect(SecurityUtils.isTokenExpired(), true);
       });
 
       test('should return true when token is expired', () async {
         final expiredTime = DateTime.now().subtract(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
         final payload = base64Url.encode('{"exp":$expiredTime}'.codeUnits);
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, "header.$payload.signature");
+        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
         expect(SecurityUtils.isTokenExpired(), true);
       });
 
       test('should return false when token is valid and not expired', () async {
         final futureTime = DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
         final payload = base64Url.encode('{"exp":$futureTime}'.codeUnits);
-        await AppLocalStorage().save(StorageKeys.jwtToken.key, "header.$payload.signature");
+        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
         expect(SecurityUtils.isTokenExpired(), false);
       });
     });

--- a/test/core/security/security_utils_test.dart
+++ b/test/core/security/security_utils_test.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc_advance/core/security/security_utils.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import '../../test_utils.dart';
 
@@ -11,92 +10,90 @@ void main() {
     await TestUtils().setupUnitTest();
   });
 
-  setUp(() {
-    // Reset the sync cache before each test so no token lingers.
-    AppLocalStorageCached.jwtToken = null;
-  });
-
   tearDown(() async {
-    AppLocalStorageCached.jwtToken = null;
     await TestUtils().tearDownUnitTest();
   });
 
-  group('SecurityUtils Tests', () {
-    test('isUserLoggedIn should return false when token is null', () {
-      expect(SecurityUtils.isUserLoggedIn(), false);
-    });
-
-    test('isUserLoggedIn should return true when token exists', () async {
-      await TestUtils().setupAuthentication();
-      expect(SecurityUtils.isUserLoggedIn(), true);
-    });
-
-    test('isCurrentUserAdmin should return false when roles is null', () {
-      expect(SecurityUtils.isCurrentUserAdmin(), false);
-    });
-
-    test('isCurrentUserAdmin should return true when user has admin role', () async {
-      await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_ADMIN"]);
-      expect(SecurityUtils.isCurrentUserAdmin(), true);
-    });
-
-    test('isCurrentUserAdmin should return false when user does not have admin role', () async {
-      await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
-      expect(SecurityUtils.isCurrentUserAdmin(), false);
-    });
-
-    group('isTokenExpired Tests', () {
-      test('should return true when token is null', () {
-        expect(SecurityUtils.isTokenExpired(), true);
+  group('SecurityUtils', () {
+    group('hasToken', () {
+      test('returns false for null', () {
+        expect(SecurityUtils.hasToken(null), isFalse);
       });
 
-      test('should return true when token is invalid format', () async {
-        AppLocalStorageCached.jwtToken = 'invalid.token';
-        expect(SecurityUtils.isTokenExpired(), true);
+      test('returns false for empty', () {
+        expect(SecurityUtils.hasToken(''), isFalse);
       });
 
-      test('should return true when token payload is invalid', () async {
-        AppLocalStorageCached.jwtToken = 'header.invalid_payload.signature';
-        expect(SecurityUtils.isTokenExpired(), true);
+      test('returns true for non-empty', () {
+        expect(SecurityUtils.hasToken('MOCK_TOKEN'), isTrue);
+      });
+    });
+
+    group('isCurrentUserAdmin', () {
+      test('returns false when roles is null', () {
+        expect(SecurityUtils.isCurrentUserAdmin(null), isFalse);
       });
 
-      test('should return true when exp is missing in payload', () async {
+      test('returns true when roles contains ROLE_ADMIN', () {
+        expect(SecurityUtils.isCurrentUserAdmin(['ROLE_ADMIN']), isTrue);
+      });
+
+      test('returns false when roles lacks ROLE_ADMIN', () {
+        expect(SecurityUtils.isCurrentUserAdmin(['ROLE_USER']), isFalse);
+      });
+    });
+
+    group('isTokenExpired', () {
+      test('returns true for null', () {
+        expect(SecurityUtils.isTokenExpired(null), isTrue);
+      });
+
+      test('returns true for empty', () {
+        expect(SecurityUtils.isTokenExpired(''), isTrue);
+      });
+
+      test('returns true for malformed token (wrong segment count)', () {
+        expect(SecurityUtils.isTokenExpired('invalid.token'), isTrue);
+      });
+
+      test('returns true for invalid base64 payload', () {
+        expect(SecurityUtils.isTokenExpired('header.invalid_payload.signature'), isTrue);
+      });
+
+      test('returns true when exp claim is missing', () {
         final payload = base64Url.encode('{"sub":"test"}'.codeUnits);
-        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
-        expect(SecurityUtils.isTokenExpired(), true);
+        expect(SecurityUtils.isTokenExpired('header.$payload.signature'), isTrue);
       });
 
-      test('should return true when token is expired', () async {
-        final expiredTime = DateTime.now().subtract(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
-        final payload = base64Url.encode('{"exp":$expiredTime}'.codeUnits);
-        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
-        expect(SecurityUtils.isTokenExpired(), true);
+      test('returns true when exp is in the past', () {
+        final past = DateTime.now().subtract(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+        final payload = base64Url.encode('{"exp":$past}'.codeUnits);
+        expect(SecurityUtils.isTokenExpired('header.$payload.signature'), isTrue);
       });
 
-      test('should return false when token is valid and not expired', () async {
-        final futureTime = DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
-        final payload = base64Url.encode('{"exp":$futureTime}'.codeUnits);
-        AppLocalStorageCached.jwtToken = 'header.$payload.signature';
-        expect(SecurityUtils.isTokenExpired(), false);
+      test('returns false when exp is in the future', () {
+        final future = DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+        final payload = base64Url.encode('{"exp":$future}'.codeUnits);
+        expect(SecurityUtils.isTokenExpired('header.$payload.signature'), isFalse);
       });
     });
 
-    group('getTokenExpiration Tests', () {
-      test('should return null for invalid token', () {
+    group('getTokenExpiration', () {
+      test('returns null for invalid token', () {
         expect(SecurityUtils.getTokenExpiration('invalid'), isNull);
       });
 
-      test('should return null for token without exp claim', () {
+      test('returns null for token without exp claim', () {
         final payload = base64Url.encode('{"sub":"test"}'.codeUnits);
         expect(SecurityUtils.getTokenExpiration('header.$payload.signature'), isNull);
       });
 
-      test('should return correct DateTime for valid token', () {
-        final futureTime = DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
-        final payload = base64Url.encode('{"exp":$futureTime}'.codeUnits);
+      test('returns DateTime for valid token', () {
+        final future = DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+        final payload = base64Url.encode('{"exp":$future}'.codeUnits);
         final result = SecurityUtils.getTokenExpiration('header.$payload.signature');
         expect(result, isNotNull);
-        expect(result!.millisecondsSinceEpoch ~/ 1000, futureTime);
+        expect(result!.millisecondsSinceEpoch ~/ 1000, future);
       });
     });
   });

--- a/test/features/account/data/repositories/account_repository_test.dart
+++ b/test/features/account/data/repositories/account_repository_test.dart
@@ -86,7 +86,7 @@ void main() {
   //test changePassword
   group("AccountRepository Change Password", () {
     test("Given valid passwordChangeDTO when changePassword then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       const passwordChangeDTO = mockPasswordChangePayload;
       final result = await AccountRepository().changePassword(passwordChangeDTO);
       expect(result, isA<Success<void>>());
@@ -110,7 +110,7 @@ void main() {
   //test resetPassword
   group("AccountRepository Reset Password", () {
     test("Given valid mailAddress when resetPassword then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       const mailAddress = "admin@sample.tech";
       final result = await AccountRepository().resetPassword(mailAddress);
       expect(result, isA<Success<void>>());
@@ -133,7 +133,7 @@ void main() {
   group("AccountRepository Get Account", () {
     //success
     test("Given valid user when getAccount then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final result = await AccountRepository().getAccount();
       expect(result, isA<Success<UserEntity>>());
     });
@@ -150,7 +150,7 @@ void main() {
   group("AccountRepository Save Account", () {
     //success
     test("Given valid user when saveAccount then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
       final result = await AccountRepository().update(entity);
       expect(result, isA<Success<UserEntity>>());
@@ -165,7 +165,7 @@ void main() {
     });
 
     test("Given user with empty id when saveAccount then return Failure with ValidationError", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       const entity = User();
       final result = await AccountRepository().update(entity);
       expect(result, isA<Failure<UserEntity>>());
@@ -173,7 +173,7 @@ void main() {
     });
 
     test("Given user with blank id when saveAccount then return Failure with ValidationError", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
       final result = await AccountRepository().update(entity);
       expect(result, isA<Failure<UserEntity>>());
@@ -185,7 +185,7 @@ void main() {
   group("AccountRepository Update Account", () {
     //success
     test("Given valid user when updateAccount then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
       final result = await AccountRepository().update(entity);
       expect(result, isA<Success<UserEntity>>());
@@ -200,7 +200,7 @@ void main() {
     });
 
     test("Given user with null id when updateAccount then return Failure with ValidationError", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       const entity = User();
       final result = await AccountRepository().update(entity);
       expect(result, isA<Failure<UserEntity>>());
@@ -208,7 +208,7 @@ void main() {
     });
 
     test("Given user with blank id when updateAccount then return Failure with ValidationError", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
       final result = await AccountRepository().update(entity);
       expect(result, isA<Failure<UserEntity>>());
@@ -220,7 +220,7 @@ void main() {
   group("AccountRepository Delete Account", () {
     //success
     test("Given valid id when deleteAccount then return Success", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final result = await AccountRepository().delete("id");
       expect(result, isA<Success<void>>());
     });
@@ -233,7 +233,7 @@ void main() {
     });
 
     test("Given empty id when deleteAccount then return Failure with ValidationError", () async {
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       final result = await AccountRepository().delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -305,7 +305,7 @@ void main() {
       blocTest<LoginBloc, LoginState>(
         'given valid credentials when submitted then emits [loading, success]',
         setUp: () async {
-          await TestUtils().setupAuthentication();
+          TestUtils().setupAuthentication();
           await AppLocalStorage().save(StorageKeys.username.key, "username");
           await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
           repository.authenticateResult = const Success(AuthTokenEntity(idToken: 'MOCK_TOKEN'));

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -305,7 +305,7 @@ void main() {
       blocTest<LoginBloc, LoginState>(
         'given valid credentials when submitted then emits [loading, success]',
         setUp: () async {
-          await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
+          AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
           await AppLocalStorage().save(StorageKeys.username.key, "username");
           await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
           repository.authenticateResult = const Success(AuthTokenEntity(idToken: 'MOCK_TOKEN'));

--- a/test/features/auth/application/login_bloc_test.dart
+++ b/test/features/auth/application/login_bloc_test.dart
@@ -305,7 +305,7 @@ void main() {
       blocTest<LoginBloc, LoginState>(
         'given valid credentials when submitted then emits [loading, success]',
         setUp: () async {
-          AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
+          await TestUtils().setupAuthentication();
           await AppLocalStorage().save(StorageKeys.username.key, "username");
           await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
           repository.authenticateResult = const Success(AuthTokenEntity(idToken: 'MOCK_TOKEN'));

--- a/test/features/auth/data/models/jwt_token_test.dart
+++ b/test/features/auth/data/models/jwt_token_test.dart
@@ -62,10 +62,18 @@ void main() {
 
   // toString, equals, hashcode
   group("toString, equals and hashcode", () {
-    test('should return string', () {
-      const entity = mockJWTTokenPayload;
+    test('toString masks tokens — raw idToken/refreshToken must not appear', () {
+      const entity = JWTToken(
+        idToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+        refreshToken: 'refresh-token-secret-value-12345',
+      );
 
-      expect(entity.toString(), contains('MOCK_TOKEN'));
+      final rendered = entity.toString();
+
+      expect(rendered, isNot(contains('payload')));
+      expect(rendered, isNot(contains('signature')));
+      expect(rendered, isNot(contains('refresh-token-secret-value-12345')));
+      expect(rendered, startsWith('JWTToken('));
     });
 
     test('should return true when comparing two JWTToken instances', () {

--- a/test/features/auth/data/models/jwt_token_test.dart
+++ b/test/features/auth/data/models/jwt_token_test.dart
@@ -49,14 +49,14 @@ void main() {
       final json = mockJWTTokenPayload.toJson();
       final entity = JWTToken.fromJson(json!);
 
-      expect(entity?.idToken, 'MOCK_TOKEN');
+      expect(entity.idToken, 'MOCK_TOKEN');
     });
 
     test('should deserialize from JSON string', () {
       final json = mockJWTTokenPayload.toJson();
       final entity = JWTToken.fromJsonString(jsonEncode(json!));
 
-      expect(entity?.idToken, 'MOCK_TOKEN');
+      expect(entity.idToken, 'MOCK_TOKEN');
     });
   });
 

--- a/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
@@ -21,6 +21,19 @@ class _MemorySecureStorage implements ISecureStorage {
   Future<void> deleteAll() async => _store.clear();
 }
 
+/// ISecureStorage whose read() always throws. Exercises the
+/// Result-on-snapshot-failure contract in persist().
+class _ReadThrowsSecureStorage implements ISecureStorage {
+  @override
+  Future<String?> read(String key) async => throw StateError('boom on read $key');
+  @override
+  Future<void> write(String key, String value) async {}
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll() async {}
+}
+
 /// ISecureStorage that throws on the configured delete key. Exercises
 /// the best-effort sequential cleanup path in clear().
 class _SelectiveFailSecureStorage implements ISecureStorage {
@@ -174,6 +187,20 @@ void main() {
 
       expect(result, isA<Failure<void>>());
       expect(await secure.read(SecureStorageKeys.refreshToken.key), 'STALE_REFRESH');
+    });
+
+    test('persist returns Failure (does not throw) when snapshot read fails', () async {
+      // ISecureStorage.read is allowed to throw on platform failure.
+      // Repository contract: persist always returns a Result — never
+      // propagates a raw exception, including from the pre-write
+      // snapshot.
+      final flaky = _ReadThrowsSecureStorage();
+      final repo = AuthSessionRepository(secureStorage: flaky, storage: storage);
+      const session = AuthSession(idToken: 'TOKEN', username: 'alice');
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Failure<void>>());
     });
 
     test('clear keeps wiping even if one secure delete throws', () async {

--- a/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
@@ -2,20 +2,31 @@ import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/auth/data/repositories/auth_session_repository_impl.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../../test_utils.dart';
 
-/// Storage fake that lets a test choose which key's `save` should fail,
-/// so we can simulate a partial-write failure and observe the rollback.
+/// In-memory ISecureStorage for tests.
+class _MemorySecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
+/// Storage fake that lets a test choose which key's `save` should fail.
 class _FlakyStorage implements AppLocalStorage {
   _FlakyStorage(this._inner, this.failOnKey);
-
   final AppLocalStorage _inner;
   final String failOnKey;
   final removedKeys = <String>[];
-
   @override
   Future<bool> save(String key, dynamic value) async {
     if (key == failOnKey) return false;
@@ -30,16 +41,15 @@ class _FlakyStorage implements AppLocalStorage {
 
   @override
   Future<dynamic> read(String key) => _inner.read(key);
-
   @override
   Future<void> clear() => _inner.clear();
-
   @override
   void setPreferencesInstance(SharedPreferences prefs) => _inner.setPreferencesInstance(prefs);
 }
 
 void main() {
   late AppLocalStorage storage;
+  late _MemorySecureStorage secure;
 
   setUpAll(() async {
     await TestUtils().setupUnitTest();
@@ -49,6 +59,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     storage = AppLocalStorage();
     storage.setPreferencesInstance(await SharedPreferences.getInstance());
+    secure = _MemorySecureStorage();
   });
 
   tearDown(() async {
@@ -56,67 +67,51 @@ void main() {
   });
 
   group('AuthSessionRepository', () {
-    test('persist writes jwtToken, username, and roles', () async {
-      final repo = AuthSessionRepository(storage: storage);
+    test('persist routes tokens to secure storage, username/roles to local', () async {
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
       const session = AuthSession(idToken: 'TOKEN', refreshToken: 'REFRESH', username: 'alice', roles: ['ROLE_USER']);
 
       final result = await repo.persist(session);
 
       expect(result, isA<Success<void>>());
-      expect(await storage.read(StorageKeys.jwtToken.key), 'TOKEN');
-      expect(await storage.read(StorageKeys.refreshToken.key), 'REFRESH');
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), 'TOKEN');
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), 'REFRESH');
       expect(await storage.read(StorageKeys.username.key), 'alice');
       expect(await storage.read(StorageKeys.roles.key), ['ROLE_USER']);
     });
 
-    test('persist skips refreshToken when null', () async {
-      final repo = AuthSessionRepository(storage: storage);
+    test('persist deletes refreshToken from secure storage when null', () async {
+      await secure.write(SecureStorageKeys.refreshToken.key, 'STALE');
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
       const session = AuthSession(idToken: 'TOKEN', username: 'alice');
 
       await repo.persist(session);
 
-      expect(await storage.read(StorageKeys.jwtToken.key), 'TOKEN');
-      expect(await storage.read(StorageKeys.refreshToken.key), isNull);
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), isNull);
     });
 
-    test('persist rolls back previously-written keys when a later write fails', () async {
+    test('persist rolls back secure writes when a local write fails', () async {
       final flaky = _FlakyStorage(storage, StorageKeys.username.key);
-      final repo = AuthSessionRepository(storage: flaky);
-      const session = AuthSession(idToken: 'TOKEN', refreshToken: 'REFRESH', username: 'alice', roles: ['ROLE_USER']);
+      final repo = AuthSessionRepository(secureStorage: secure, storage: flaky);
+      const session = AuthSession(idToken: 'TOKEN', refreshToken: 'REFRESH', username: 'alice');
 
       final result = await repo.persist(session);
 
       expect(result, isA<Failure<void>>());
-      // After rollback, the partial writes that succeeded (jwtToken,
-      // refreshToken) must have been removed; never a half-persisted
-      // session.
-      expect(await storage.read(StorageKeys.jwtToken.key), isNull);
-      expect(await storage.read(StorageKeys.refreshToken.key), isNull);
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull, reason: 'secure token rolled back');
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), isNull, reason: 'secure refresh rolled back');
       expect(await storage.read(StorageKeys.username.key), isNull);
-      expect(await storage.read(StorageKeys.roles.key), isNull);
-      expect(flaky.removedKeys, containsAll([StorageKeys.jwtToken.key, StorageKeys.refreshToken.key]));
     });
 
-    test('persist removes a stale refreshToken when the new session has none', () async {
-      final repo = AuthSessionRepository(storage: storage);
-      await storage.save(StorageKeys.refreshToken.key, 'STALE_REFRESH');
-      const session = AuthSession(idToken: 'TOKEN', username: 'alice');
-
-      final result = await repo.persist(session);
-
-      expect(result, isA<Success<void>>());
-      expect(await storage.read(StorageKeys.refreshToken.key), isNull);
-    });
-
-    test('clear empties the storage', () async {
-      final repo = AuthSessionRepository(storage: storage);
-      await storage.save(StorageKeys.jwtToken.key, 'TOKEN');
+    test('clear empties both backends', () async {
+      await secure.write(SecureStorageKeys.jwtToken.key, 'TOKEN');
       await storage.save(StorageKeys.username.key, 'alice');
+      final repo = AuthSessionRepository(secureStorage: secure, storage: storage);
 
       final result = await repo.clear();
 
       expect(result, isA<Success<void>>());
-      expect(await storage.read(StorageKeys.jwtToken.key), isNull);
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull);
       expect(await storage.read(StorageKeys.username.key), isNull);
     });
   });

--- a/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
@@ -121,6 +121,26 @@ void main() {
       expect(await secure.read(SecureStorageKeys.refreshToken.key), 'OLD_REFRESH');
     });
 
+    test('rollback restores prior username and roles on local-write failure', () async {
+      // Pre-existing local session: simulates a re-login where the user
+      // was already authenticated and persist() is invoked again with
+      // new tokens but fails partway through the local writes.
+      await storage.save(StorageKeys.username.key, 'OLD_USER');
+      await storage.save(StorageKeys.roles.key, ['ROLE_OLD']);
+
+      final flaky = _FlakyStorage(storage, StorageKeys.roles.key);
+      final repo = AuthSessionRepository(secureStorage: secure, storage: flaky);
+      const session = AuthSession(idToken: 'NEW_JWT', username: 'NEW_USER', roles: ['ROLE_NEW']);
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Failure<void>>());
+      // username was written but rollback restored the prior value
+      // rather than deleting (which would have wiped the old session).
+      expect(await storage.read(StorageKeys.username.key), 'OLD_USER');
+      expect(await storage.read(StorageKeys.roles.key), ['ROLE_OLD']);
+    });
+
     test('rollback restores stale refreshToken that persist had deleted', () async {
       // Pre-existing refresh token; new session has none, so persist would
       // delete it. If a later write fails, rollback must restore it.

--- a/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
@@ -103,6 +103,39 @@ void main() {
       expect(await storage.read(StorageKeys.username.key), isNull);
     });
 
+    test('rollback restores prior secure values, not just deletes', () async {
+      // Pre-existing session in secure storage.
+      await secure.write(SecureStorageKeys.jwtToken.key, 'OLD_JWT');
+      await secure.write(SecureStorageKeys.refreshToken.key, 'OLD_REFRESH');
+
+      // New persist that will fail on the local username write.
+      final flaky = _FlakyStorage(storage, StorageKeys.username.key);
+      final repo = AuthSessionRepository(secureStorage: secure, storage: flaky);
+      const session = AuthSession(idToken: 'NEW_JWT', refreshToken: 'NEW_REFRESH', username: 'bob');
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Failure<void>>());
+      // Rollback restored prior values rather than deleting them.
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), 'OLD_JWT');
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), 'OLD_REFRESH');
+    });
+
+    test('rollback restores stale refreshToken that persist had deleted', () async {
+      // Pre-existing refresh token; new session has none, so persist would
+      // delete it. If a later write fails, rollback must restore it.
+      await secure.write(SecureStorageKeys.refreshToken.key, 'STALE_REFRESH');
+
+      final flaky = _FlakyStorage(storage, StorageKeys.username.key);
+      final repo = AuthSessionRepository(secureStorage: secure, storage: flaky);
+      const session = AuthSession(idToken: 'NEW_JWT', username: 'bob');
+
+      final result = await repo.persist(session);
+
+      expect(result, isA<Failure<void>>());
+      expect(await secure.read(SecureStorageKeys.refreshToken.key), 'STALE_REFRESH');
+    });
+
     test('clear empties both backends', () async {
       await secure.write(SecureStorageKeys.jwtToken.key, 'TOKEN');
       await storage.save(StorageKeys.username.key, 'alice');

--- a/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_session_repository_impl_test.dart
@@ -21,6 +21,26 @@ class _MemorySecureStorage implements ISecureStorage {
   Future<void> deleteAll() async => _store.clear();
 }
 
+/// ISecureStorage that throws on the configured delete key. Exercises
+/// the best-effort sequential cleanup path in clear().
+class _SelectiveFailSecureStorage implements ISecureStorage {
+  _SelectiveFailSecureStorage({required this.failOn});
+  final String failOn;
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async {
+    if (key == failOn) throw StateError('boom on $key');
+    _store.remove(key);
+  }
+
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
 /// Storage fake that lets a test choose which key's `save` should fail.
 class _FlakyStorage implements AppLocalStorage {
   _FlakyStorage(this._inner, this.failOnKey);
@@ -154,6 +174,22 @@ void main() {
 
       expect(result, isA<Failure<void>>());
       expect(await secure.read(SecureStorageKeys.refreshToken.key), 'STALE_REFRESH');
+    });
+
+    test('clear keeps wiping even if one secure delete throws', () async {
+      // _MemorySecureStorage that selectively throws on one key — proves
+      // clear() doesn't bail on the first failure and leave the other
+      // secure key behind.
+      final flaky = _SelectiveFailSecureStorage(failOn: SecureStorageKeys.jwtToken.key);
+      await flaky.write(SecureStorageKeys.refreshToken.key, 'REFRESH');
+      await storage.save(StorageKeys.username.key, 'alice');
+      final repo = AuthSessionRepository(secureStorage: flaky, storage: storage);
+
+      final result = await repo.clear();
+
+      expect(result, isA<Failure<void>>(), reason: 'partial failure surfaces as Failure');
+      expect(await flaky.read(SecureStorageKeys.refreshToken.key), isNull);
+      expect(await storage.read(StorageKeys.username.key), isNull, reason: 'local clear still ran');
     });
 
     test('clear empties both backends', () async {

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_entity.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -42,15 +41,15 @@ void main() {
     });
 
     test("Given stored entity when logout then clear storage successfully", () async {
-      // Seed cache directly — FlutterSecureStorageAdapter plugin unavailable in unit tests.
-      AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
-      expect(AppLocalStorageCached.jwtToken, isNotNull);
+      final secure = FlutterSecureStorageAdapter();
+      await secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), 'MOCK_TOKEN');
 
       final result = await LoginRepository().logout();
       expect(result, isA<Success<void>>());
-      // AppLocalStorage.clear() reloads the cache; secure storage plugin is absent
-      // so the cache read returns null — confirming local storage was cleared.
-      expect(AppLocalStorageCached.jwtToken, isNull);
+      // Both backends are wiped after logout — secure store no longer
+      // holds the JWT, so AuthInterceptor cannot re-attach it.
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull);
     });
 
     test("logout wipes JWT and refresh token from secure storage", () async {

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
 
-
 void main() {
   setUpAll(() async {
     await TestUtils().setupUnitTest();

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
 
+
 void main() {
   setUpAll(() async {
     await TestUtils().setupUnitTest();
@@ -41,14 +42,15 @@ void main() {
     });
 
     test("Given stored entity when logout then clear storage successfully", () async {
-      TestUtils().setupAuthentication();
-
-      expect(await AppLocalStorage().read(StorageKeys.jwtToken.key), isNotNull);
-      expect(await AppLocalStorage().read(StorageKeys.jwtToken.key), isA<String>());
+      // Seed cache directly — FlutterSecureStorageAdapter plugin unavailable in unit tests.
+      AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
+      expect(AppLocalStorageCached.jwtToken, isNotNull);
 
       final result = await LoginRepository().logout();
       expect(result, isA<Success<void>>());
-      expect(await AppLocalStorage().read(StorageKeys.jwtToken.key), null);
+      // AppLocalStorage.clear() reloads the cache; secure storage plugin is absent
+      // so the cache read returns null — confirming local storage was cleared.
+      expect(AppLocalStorageCached.jwtToken, isNull);
     });
   });
 

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -6,6 +6,26 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
 
+/// ISecureStorage that throws on the configured delete key. Used to
+/// exercise the best-effort sequential cleanup path in logout.
+class _FlakyDeleteSecureStorage implements ISecureStorage {
+  _FlakyDeleteSecureStorage({required this.failOn});
+  final String failOn;
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async {
+    if (key == failOn) throw StateError('boom on $key');
+    _store.remove(key);
+  }
+
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
 void main() {
   setUpAll(() async {
     await TestUtils().setupUnitTest();
@@ -50,6 +70,25 @@ void main() {
       // Both backends are wiped after logout — secure store no longer
       // holds the JWT, so AuthInterceptor cannot re-attach it.
       expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull);
+    });
+
+    test("logout keeps wiping even if one secure delete throws", () async {
+      // ISecureStorage that throws on jwtToken delete but succeeds on
+      // refreshToken delete — proves best-effort sequential cleanup:
+      // a partial failure must not skip subsequent cleanup steps,
+      // because any leftover token would let AuthInterceptor re-attach
+      // it on the next request.
+      final secure = _FlakyDeleteSecureStorage(failOn: SecureStorageKeys.jwtToken.key);
+      await secure.write(SecureStorageKeys.refreshToken.key, 'REFRESH');
+
+      final result = await LoginRepository(secureStorage: secure).logout();
+
+      expect(result, isA<Failure<void>>(), reason: 'partial failure surfaced as Failure');
+      expect(
+        await secure.read(SecureStorageKeys.refreshToken.key),
+        isNull,
+        reason: 'refresh delete ran even though jwt delete threw',
+      );
     });
 
     test("logout wipes JWT and refresh token from secure storage", () async {

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_entity.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
@@ -50,6 +51,24 @@ void main() {
       // AppLocalStorage.clear() reloads the cache; secure storage plugin is absent
       // so the cache read returns null — confirming local storage was cleared.
       expect(AppLocalStorageCached.jwtToken, isNull);
+    });
+
+    test("logout wipes JWT and refresh token from secure storage", () async {
+      // Seed both backends to simulate a fully-logged-in session.
+      final secure = FlutterSecureStorageAdapter();
+      await secure.write(SecureStorageKeys.jwtToken.key, 'JWT_VALUE');
+      await secure.write(SecureStorageKeys.refreshToken.key, 'REFRESH_VALUE');
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), 'JWT_VALUE');
+
+      final result = await LoginRepository().logout();
+
+      expect(result, isA<Success<void>>());
+      expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull, reason: 'secure JWT must not survive logout');
+      expect(
+        await secure.read(SecureStorageKeys.refreshToken.key),
+        isNull,
+        reason: 'secure refresh must not survive logout',
+      );
     });
   });
 

--- a/test/features/auth/domain/entities/auth_session_test.dart
+++ b/test/features/auth/domain/entities/auth_session_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_bloc_advance/features/auth/domain/entities/auth_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthSession.toString', () {
+    test('masks idToken and refreshToken', () {
+      const session = AuthSession(
+        idToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature',
+        refreshToken: 'refresh-token-value-12345',
+        username: 'alice',
+        roles: ['ROLE_USER'],
+      );
+
+      final rendered = session.toString();
+
+      expect(rendered.contains('payload'), isFalse);
+      expect(rendered.contains('refresh-token-value-12345'), isFalse);
+      expect(rendered, contains('alice'));
+      expect(rendered, contains('ROLE_USER'));
+    });
+
+    test('renders empty marker when refreshToken is null', () {
+      const session = AuthSession(idToken: 'eyJhbGc.payload.signature', username: 'alice');
+      expect(session.toString(), contains('refreshToken: <empty>'));
+    });
+  });
+}

--- a/test/features/auth/presentation/pages/change_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/change_password_screen_test.dart
@@ -127,7 +127,7 @@ void main() {
   group("ChangePasswordScreen FormFieldsTest", () {
     testWidgets("Render Screen Validate Field Type Successful", (tester) async {
       _log.debug("begin Validate Field Type");
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       // Given:
       await tester.pumpWidget(getWidget());
       //When:

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -194,7 +194,7 @@ void main() {
       loginStateController.add(const LoginLoadingState(username: "test@example.com", loginMethod: LoginMethod.otp));
       await tester.pump();
 
-      await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
+      AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
       await AppLocalStorage().save(StorageKeys.username.key, "mock");
       await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
       loginStateController.add(const LoginLoadedState(username: "test@example.com"));

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -194,7 +194,7 @@ void main() {
       loginStateController.add(const LoginLoadingState(username: "test@example.com", loginMethod: LoginMethod.otp));
       await tester.pump();
 
-      AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
+      await TestUtils().setupAuthentication();
       await AppLocalStorage().save(StorageKeys.username.key, "mock");
       await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
       loginStateController.add(const LoginLoadedState(username: "test@example.com"));

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -194,7 +194,7 @@ void main() {
       loginStateController.add(const LoginLoadingState(username: "test@example.com", loginMethod: LoginMethod.otp));
       await tester.pump();
 
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
       await AppLocalStorage().save(StorageKeys.username.key, "mock");
       await AppLocalStorage().save(StorageKeys.roles.key, ["ROLE_USER"]);
       loginStateController.add(const LoginLoadedState(username: "test@example.com"));

--- a/test/features/dashboard/presentation/pages/home_screen_test.dart
+++ b/test/features/dashboard/presentation/pages/home_screen_test.dart
@@ -29,7 +29,7 @@ void main() {
       await tester.binding.setSurfaceSize(const Size(1280, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
-      TestUtils().setupAuthentication();
+      await TestUtils().setupAuthentication();
 
       // Given:
       await tester.pumpWidget(const App(language: language).buildHomeApp());

--- a/test/features/dashboard/presentation/pages/home_screen_test.dart
+++ b/test/features/dashboard/presentation/pages/home_screen_test.dart
@@ -29,7 +29,7 @@ void main() {
       await tester.binding.setSurfaceSize(const Size(1280, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
 
-      await TestUtils().setupAuthentication();
+      TestUtils().setupAuthentication();
 
       // Given:
       await tester.pumpWidget(const App(language: language).buildHomeApp());

--- a/test/features/settings/presentation/pages/settings_screen_test.dart
+++ b/test/features/settings/presentation/pages/settings_screen_test.dart
@@ -50,7 +50,7 @@ void main() {
 
   group('SettingsScreen Tests', () {
     testWidgets('renders all buttons correctly', (WidgetTester tester) async {
-      await testUtils.setupAuthentication();
+      testUtils.setupAuthentication();
       await tester.pumpWidget(buildTestableWidget());
       await tester.pumpAndSettle();
 
@@ -59,7 +59,7 @@ void main() {
     });
 
     testWidgets('navigates to change password screen when button is pressed', (WidgetTester tester) async {
-      await testUtils.setupAuthentication();
+      testUtils.setupAuthentication();
       await tester.pumpWidget(buildTestableWidget());
       await tester.pumpAndSettle();
 

--- a/test/features/settings/presentation/pages/settings_screen_test.dart
+++ b/test/features/settings/presentation/pages/settings_screen_test.dart
@@ -49,12 +49,18 @@ void main() {
   }
 
   group('SettingsScreen Tests', () {
-    testWidgets('renders all buttons correctly', (WidgetTester tester) async {
+    testWidgets('renders all settings tiles', (WidgetTester tester) async {
       testUtils.setupAuthentication();
       await tester.pumpWidget(buildTestableWidget());
       await tester.pumpAndSettle();
 
+      // Each visible tile on the settings screen — keyed actions get
+      // exact assertions, label-only tiles get text matches so the
+      // screen layout is guarded against accidental removal.
       expect(find.byKey(settingsChangePasswordButtonKey), findsOneWidget);
+      expect(find.byKey(settingsWebsiteButtonKey), findsOneWidget);
+      expect(find.text('Theme'), findsOneWidget);
+      expect(find.text('Appearance'), findsOneWidget);
       // Logout intentionally lives only in the sidebar / topbar shell —
       // settings does not own auth-session lifecycle (cross-feature).
     });

--- a/test/features/settings/presentation/pages/settings_screen_test.dart
+++ b/test/features/settings/presentation/pages/settings_screen_test.dart
@@ -54,13 +54,13 @@ void main() {
       await tester.pumpWidget(buildTestableWidget());
       await tester.pumpAndSettle();
 
-      // Each visible tile on the settings screen — keyed actions get
-      // exact assertions, label-only tiles get text matches so the
-      // screen layout is guarded against accidental removal.
+      // Assert via Keys only — text-based asserts would couple the
+      // test to the active locale (some titles use S.of(context) /
+      // generated strings, others are still literals pending i18n).
+      // Key presence is enough to guard the screen layout against
+      // accidental tile removal.
       expect(find.byKey(settingsChangePasswordButtonKey), findsOneWidget);
       expect(find.byKey(settingsWebsiteButtonKey), findsOneWidget);
-      expect(find.text('Theme'), findsOneWidget);
-      expect(find.text('Appearance'), findsOneWidget);
       // Logout intentionally lives only in the sidebar / topbar shell —
       // settings does not own auth-session lifecycle (cross-feature).
     });

--- a/test/features/settings/presentation/pages/settings_screen_test.dart
+++ b/test/features/settings/presentation/pages/settings_screen_test.dart
@@ -55,7 +55,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(settingsChangePasswordButtonKey), findsOneWidget);
-      expect(find.byKey(settingsLogoutButtonKey), findsOneWidget);
+      // Logout intentionally lives only in the sidebar / topbar shell —
+      // settings does not own auth-session lifecycle (cross-feature).
     });
 
     testWidgets('navigates to change password screen when button is pressed', (WidgetTester tester) async {

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -343,5 +343,21 @@ void main() {
         throwsUnsupportedError,
       );
     });
+
+    // Guard for the test-ordering hazard called out in the independent
+    // review (I3): when ApiClient.secureStorage is null at Dio creation
+    // time, the interceptors fall back to a private adapter instance
+    // that diverges from the repository layer's adapter. test_utils
+    // wires the shared adapter in setupUnitTest, so by the time any
+    // test reaches this point, secureStorage MUST be non-null.
+    test('ApiClient.secureStorage is wired by setupUnitTest — no silent divergence', () {
+      expect(
+        ApiClient.secureStorage,
+        isNotNull,
+        reason:
+            'If this fires, setupUnitTest is being bypassed or someone reset the static. '
+            'See ApiClient._createDio warn log and lib/infrastructure/http/api_client.dart:76.',
+      );
+    });
   });
 }

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -348,9 +348,12 @@ void main() {
     // review (I3): when ApiClient.secureStorage is null at Dio creation
     // time, the interceptors fall back to a private adapter instance
     // that diverges from the repository layer's adapter. test_utils
-    // wires the shared adapter in setupUnitTest, so by the time any
-    // test reaches this point, secureStorage MUST be non-null.
-    test('ApiClient.secureStorage is wired by setupUnitTest — no silent divergence', () {
+    // wires the shared adapter in setupUnitTest. Drives a fresh
+    // setupUnitTest inside the test so this assertion survives the
+    // group's pre-test ApiClient.reset() (which deliberately clears
+    // the static — see C-C / [ApiClient.reset]).
+    test('ApiClient.secureStorage is wired by setupUnitTest — no silent divergence', () async {
+      await TestUtils().setupUnitTest();
       expect(
         ApiClient.secureStorage,
         isNotNull,

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -244,7 +244,7 @@ void main() {
       });
 
       test('given test environment when GET request is made then should return mock data', () async {
-        await TestUtils().setupAuthentication();
+        TestUtils().setupAuthentication();
         final response = await ApiClient.get('/test');
         expect(response.statusCode, lessThan(300));
       });
@@ -254,7 +254,7 @@ void main() {
       });
 
       test('given test environment when POST request is made then should return mock data', () async {
-        await TestUtils().setupAuthentication();
+        TestUtils().setupAuthentication();
         final response = await ApiClient.post('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
@@ -264,7 +264,7 @@ void main() {
       });
 
       test('given test environment when PUT request is made then should return mock data', () async {
-        await TestUtils().setupAuthentication();
+        TestUtils().setupAuthentication();
         final response = await ApiClient.put('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
@@ -274,7 +274,7 @@ void main() {
       });
 
       test('given test environment when DELETE request is made then should return 204', () async {
-        await TestUtils().setupAuthentication();
+        TestUtils().setupAuthentication();
         final response = await ApiClient.delete('/test');
         expect(response.statusCode, lessThan(300));
       });

--- a/test/infrastructure/http/interceptors/auth_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/auth_interceptor_test.dart
@@ -1,0 +1,103 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/interceptors/auth_interceptor.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Covers the three behaviors of [AuthInterceptor] that every outgoing
+/// HTTP request depends on:
+/// 1. JWT present → `Authorization: Bearer <token>` is attached.
+/// 2. JWT absent or empty → no `Authorization` header is written.
+/// 3. Secure read throws → request proceeds anonymously (does NOT
+///    crash the interceptor chain).
+///
+/// The interceptor is the single most-called piece of code in the
+/// project; running the chain through `Interceptor.onRequest` directly
+/// with a synthetic handler keeps the assertions tight to behavior
+/// and free of Dio/HTTP plumbing.
+void main() {
+  setUpAll(() {
+    AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
+  });
+
+  group('AuthInterceptor.onRequest', () {
+    test('attaches Bearer header when secure storage returns a token', () async {
+      final interceptor = AuthInterceptor(secureStorage: _FixedSecureStorage('jwt-value'));
+
+      final options = RequestOptions(path: '/api/account');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(handler.passedOptions, isNotNull, reason: 'handler.next should be called');
+      expect(handler.passedOptions!.headers['Authorization'], 'Bearer jwt-value');
+    });
+
+    test('omits Authorization header when secure storage returns null', () async {
+      final interceptor = AuthInterceptor(secureStorage: _FixedSecureStorage(null));
+
+      final options = RequestOptions(path: '/api/public/health');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(handler.passedOptions!.headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('omits Authorization header when secure storage returns empty string', () async {
+      final interceptor = AuthInterceptor(secureStorage: _FixedSecureStorage(''));
+
+      final options = RequestOptions(path: '/api/account');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(handler.passedOptions!.headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('does not crash when secure storage read throws — request proceeds anonymously', () async {
+      final interceptor = AuthInterceptor(secureStorage: _ThrowingSecureStorage());
+
+      final options = RequestOptions(path: '/api/account');
+      final handler = _CapturingRequestHandler();
+
+      await interceptor.onRequest(options, handler);
+
+      expect(handler.passedOptions, isNotNull, reason: 'handler.next must still be called');
+      expect(handler.passedOptions!.headers.containsKey('Authorization'), isFalse);
+    });
+  });
+}
+
+class _FixedSecureStorage implements ISecureStorage {
+  _FixedSecureStorage(this._token);
+  final String? _token;
+  @override
+  Future<String?> read(String key) async => _token;
+  @override
+  Future<void> write(String key, String value) async {}
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll() async {}
+}
+
+class _ThrowingSecureStorage implements ISecureStorage {
+  @override
+  Future<String?> read(String key) async => throw StateError('secure read failed');
+  @override
+  Future<void> write(String key, String value) async {}
+  @override
+  Future<void> delete(String key) async {}
+  @override
+  Future<void> deleteAll() async {}
+}
+
+class _CapturingRequestHandler extends RequestInterceptorHandler {
+  RequestOptions? passedOptions;
+  @override
+  void next(RequestOptions requestOptions) {
+    passedOptions = requestOptions;
+    super.next(requestOptions);
+  }
+}

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -309,6 +309,31 @@ void main() {
       );
     });
 
+    test('skips refresh when JWT was already rotated since the failing request was sent', () async {
+      // Secure store already has the rotated token; the failing
+      // request carries the previous one. Interceptor should detect
+      // that and NOT call refresh again.
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'NEW_JWT');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+      final baselineRefreshReads = secureStorage.refreshTokenReadCount;
+
+      final interceptor = TokenRefreshInterceptor(dio: dio, secureStorage: secureStorage);
+      final requestOptions = RequestOptions(path: '/api/users', headers: {'Authorization': 'Bearer OLD_JWT'});
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      expect(
+        secureStorage.refreshTokenReadCount - baselineRefreshReads,
+        0,
+        reason: 'stale header path must NOT call refresh; refresh-token read is the proxy for that',
+      );
+    });
+
     test('clears in-flight Future so a later 401 starts a fresh refresh', () async {
       await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
       final interceptor = TokenRefreshInterceptor(dio: dio, secureStorage: secureStorage);

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -342,11 +342,12 @@ void main() {
         secureStorage: secureStorage,
         onSessionExpired: () => sessionExpiredCalls++,
       );
-      final ro = RequestOptions(
-        path: '/api/users',
-        headers: {'Authorization': 'Bearer SOME_JWT'},
-        extra: {'_tokenRefresh_retried': true},
-      );
+      final ro = RequestOptions(path: '/api/users', headers: {'Authorization': 'Bearer SOME_JWT'});
+      // Marker is an Expando keyed on RequestOptions (typed, per-
+      // instance, no map collisions). debugMarkAsRetried is the
+      // sanctioned test-only path to set it without driving a full
+      // refresh+retry round.
+      TokenRefreshInterceptor.debugMarkAsRetried(ro);
       final error = DioException(
         requestOptions: ro,
         response: Response(requestOptions: ro, statusCode: 401),
@@ -731,12 +732,14 @@ class _RefreshWriteFailsSecureStorage implements ISecureStorage {
 /// what bearer the retry used and whether the marker was stamped.
 class _CapturingSuccessStub extends Interceptor {
   String? lastAuthorization;
-  bool? lastRetryMarker;
+  bool lastRetryMarker = false;
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     lastAuthorization = options.headers['Authorization'] as String?;
-    lastRetryMarker = options.extra['_tokenRefresh_retried'] as bool?;
+    // Marker is stored in a private Expando on RequestOptions; the
+    // interceptor exposes a test-only reader so we can pin the stamp.
+    lastRetryMarker = TokenRefreshInterceptor.debugIsMarkedAsRetried(options);
     handler.resolve(Response(requestOptions: options, statusCode: 200, data: '{"ok":true}'));
   }
 }

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -1,22 +1,33 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/token_refresh_interceptor.dart';
-import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../test_utils.dart';
 
+/// In-memory ISecureStorage for tests.
+class _MemorySecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
 void main() {
   late Dio dio;
-  late AppLocalStorage localStorage;
+  late _MemorySecureStorage secureStorage;
 
   setUpAll(() async {
     await TestUtils().setupUnitTest();
   });
 
   setUp(() async {
-    SharedPreferences.setMockInitialValues({});
-    localStorage = AppLocalStorage();
+    secureStorage = _MemorySecureStorage();
     dio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
   });
 
@@ -202,10 +213,14 @@ void main() {
     });
 
     test('should call onSessionExpired when refresh token is empty string', () async {
-      await localStorage.save(StorageKeys.refreshToken.key, '');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, '');
 
       var sessionExpiredCalled = false;
-      final interceptor = TokenRefreshInterceptor(dio: dio, onSessionExpired: () => sessionExpiredCalled = true);
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        onSessionExpired: () => sessionExpiredCalled = true,
+        secureStorage: secureStorage,
+      );
       final handler = _TestErrorHandler();
       final requestOptions = RequestOptions(path: '/api/users');
 
@@ -223,11 +238,15 @@ void main() {
 
   group('TokenRefreshInterceptor - 401 with refresh token', () {
     test('should attempt refresh and call onSessionExpired when refresh fails', () async {
-      await localStorage.save(StorageKeys.refreshToken.key, 'valid-refresh-token');
-      await localStorage.save(StorageKeys.jwtToken.key, 'old-jwt-token');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt-token');
 
       var sessionExpiredCalled = false;
-      final interceptor = TokenRefreshInterceptor(dio: dio, onSessionExpired: () => sessionExpiredCalled = true);
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        onSessionExpired: () => sessionExpiredCalled = true,
+        secureStorage: secureStorage,
+      );
       final handler = _TestErrorHandler();
       final requestOptions = RequestOptions(path: '/api/users');
 

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -648,6 +648,40 @@ void main() {
       expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'old-jwt');
     });
 
+    test('logs out (no crash) when refresh response is a JSON array instead of an object', () async {
+      // Defense against backend/proxy misconfiguration: if the body is
+      // a JSON array (or any non-Map shape), parsing must not crash
+      // the interceptor — surface as session-expired with a
+      // diagnosable log.
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh');
+
+      var logoutCount = 0;
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        onSessionExpired: () => logoutCount++,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(_StubInterceptor()..stubSuccess(data: '["not", "a", "map"]'));
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      expect(logoutCount, 1, reason: 'non-object body must trigger session-expired');
+      expect(handler.nextCalled, isTrue);
+      expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'old-jwt', reason: 'no garbage persisted');
+    });
+
     test('rolls back rotated tokens to prior values when refresh_token write throws', () async {
       // Setup: prior tokens exist. Refresh returns new pair. Secure
       // storage succeeds writing the new id_token but throws on the

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -509,6 +509,236 @@ void main() {
       expect(response.data, '{"result":"ok"}');
     });
   });
+
+  group('TokenRefreshInterceptor - 401 followed by successful refresh', () {
+    // Drives [TokenRefreshInterceptor.onError] directly (mirroring the
+    // existing 401-with-refresh-token test) and short-circuits the
+    // retry's _dio.fetch by adding a [_CapturingSuccessStub] to the
+    // production Dio. This isolates the assertions to the interceptor's
+    // own contract — no full Dio pipeline, no real HTTP.
+
+    test('persists rotated tokens, retries original request with new Bearer, marker stamped', () async {
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh');
+
+      final retryStub = _CapturingSuccessStub();
+      dio.interceptors.add(retryStub);
+
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(
+            _StubInterceptor()..stubSuccess(data: '{"id_token":"new-jwt","refresh_token":"new-refresh"}'),
+          );
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users', headers: {'Authorization': 'Bearer old-jwt'});
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      // Retry succeeded → resolve.
+      expect(handler.resolveCalled, isTrue, reason: 'retried request must resolve, not surface 401');
+      expect(handler.nextCalled, isFalse);
+
+      // Retry used the rotated token and was marked.
+      expect(retryStub.lastAuthorization, 'Bearer new-jwt');
+      expect(retryStub.lastRetryMarker, isTrue);
+
+      // Rotated tokens persisted, ready for next outgoing call.
+      expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'new-jwt');
+      expect(await secureStorage.read(SecureStorageKeys.refreshToken.key), 'new-refresh');
+    });
+
+    test('persists only id_token when refresh response omits new refresh_token', () async {
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'still-valid-refresh');
+
+      dio.interceptors.add(_CapturingSuccessStub());
+
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(_StubInterceptor()..stubSuccess(data: '{"id_token":"new-jwt"}'));
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      await interceptor.onError(error, _TestErrorHandler());
+
+      expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'new-jwt');
+      expect(
+        await secureStorage.read(SecureStorageKeys.refreshToken.key),
+        'still-valid-refresh',
+        reason: 'omitted refresh_token in response must leave the existing one intact',
+      );
+    });
+
+    test('logs out when refresh response is missing id_token', () async {
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh');
+
+      var logoutCount = 0;
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        onSessionExpired: () => logoutCount++,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(_StubInterceptor()..stubSuccess(data: '{}'));
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      expect(logoutCount, 1, reason: 'malformed refresh response must trigger session-expired');
+      expect(handler.nextCalled, isTrue, reason: 'original 401 must surface');
+      // Original token unchanged; no garbage persisted.
+      expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'old-jwt');
+    });
+
+    test('logs out when refresh response returns id_token=""', () async {
+      await secureStorage.write(SecureStorageKeys.jwtToken.key, 'old-jwt');
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh');
+
+      var logoutCount = 0;
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        onSessionExpired: () => logoutCount++,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(_StubInterceptor()..stubSuccess(data: '{"id_token":""}'));
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      await interceptor.onError(error, _TestErrorHandler());
+
+      expect(logoutCount, 1);
+      expect(await secureStorage.read(SecureStorageKeys.jwtToken.key), 'old-jwt');
+    });
+
+    test('rolls back rotated tokens to prior values when refresh_token write throws', () async {
+      // Setup: prior tokens exist. Refresh returns new pair. Secure
+      // storage succeeds writing the new id_token but throws on the
+      // refresh_token write. The interceptor must restore both keys
+      // to their prior values so the user re-authenticates cleanly
+      // instead of running with a torn id/refresh pair.
+      final torn = _RefreshWriteFailsSecureStorage();
+      await torn.seed(jwt: 'prior-jwt', refresh: 'prior-refresh');
+
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: torn,
+        refreshDioFactory: (source) {
+          final refreshDio = Dio(BaseOptions(baseUrl: source.options.baseUrl));
+          refreshDio.interceptors.add(
+            _StubInterceptor()..stubSuccess(data: '{"id_token":"new-jwt","refresh_token":"new-refresh"}'),
+          );
+          return refreshDio;
+        },
+      );
+
+      final requestOptions = RequestOptions(path: '/api/users');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(requestOptions: requestOptions, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      // The failed persist must surface as session-expired, not as a
+      // half-applied rotation.
+      expect(handler.nextCalled, isTrue, reason: 'original 401 must surface after rollback');
+      expect(handler.resolveCalled, isFalse);
+
+      // Both keys restored to prior values — no torn pair.
+      expect(await torn.read(SecureStorageKeys.jwtToken.key), 'prior-jwt');
+      expect(await torn.read(SecureStorageKeys.refreshToken.key), 'prior-refresh');
+    });
+  });
+}
+
+/// ISecureStorage that lets the jwtToken write succeed but throws on
+/// the refresh_token write — used to exercise the rollback path in
+/// `_performRefresh`. Read/delete behave normally so the rollback can
+/// actually restore values.
+class _RefreshWriteFailsSecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  bool _jwtWriteSeen = false;
+
+  Future<void> seed({required String jwt, required String refresh}) async {
+    _store[SecureStorageKeys.jwtToken.key] = jwt;
+    _store[SecureStorageKeys.refreshToken.key] = refresh;
+  }
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    if (key == SecureStorageKeys.jwtToken.key) {
+      _jwtWriteSeen = true;
+      _store[key] = value;
+      return;
+    }
+    if (key == SecureStorageKeys.refreshToken.key && _jwtWriteSeen) {
+      throw StateError('refresh_token write torn after id_token landed');
+    }
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
+/// Captures the Authorization header and the loop-prevention marker on
+/// any incoming request, then resolves it with 200. Used to short-circuit
+/// the retry's `_dio.fetch(retryOptions)` so the assertions can verify
+/// what bearer the retry used and whether the marker was stamped.
+class _CapturingSuccessStub extends Interceptor {
+  String? lastAuthorization;
+  bool? lastRetryMarker;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    lastAuthorization = options.headers['Authorization'] as String?;
+    lastRetryMarker = options.extra['_tokenRefresh_retried'] as bool?;
+    handler.resolve(Response(requestOptions: options, statusCode: 200, data: '{"ok":true}'));
+  }
 }
 
 /// Interceptor that stubs responses or errors before any real HTTP call.

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -5,11 +5,17 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../test_utils.dart';
 
-/// In-memory ISecureStorage for tests.
+/// In-memory ISecureStorage for tests. Counts reads of the refresh-token
+/// key so concurrent-refresh coalescing can be asserted.
 class _MemorySecureStorage implements ISecureStorage {
   final Map<String, String> _store = {};
+  int refreshTokenReadCount = 0;
   @override
-  Future<String?> read(String key) async => _store[key];
+  Future<String?> read(String key) async {
+    if (key == SecureStorageKeys.refreshToken.key) refreshTokenReadCount++;
+    return _store[key];
+  }
+
   @override
   Future<void> write(String key, String value) async => _store[key] = value;
   @override
@@ -262,6 +268,68 @@ void main() {
 
       expect(sessionExpiredCalled, isTrue);
       expect(handler.nextCalled, isTrue);
+    });
+  });
+
+  group('TokenRefreshInterceptor - concurrent refresh coalescing', () {
+    test('coalesces concurrent 401s into a single refresh request', () async {
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+      // Baseline the counter — earlier setup or other code paths may
+      // have read the key — so we assert the DELTA introduced by the
+      // three concurrent onError calls below, not the absolute count.
+      final baseline = secureStorage.refreshTokenReadCount;
+
+      final interceptor = TokenRefreshInterceptor(dio: dio, secureStorage: secureStorage);
+      DioException makeErr() {
+        final ro = RequestOptions(path: '/api/users');
+        return DioException(
+          requestOptions: ro,
+          response: Response(requestOptions: ro, statusCode: 401),
+        );
+      }
+
+      final h1 = _TestErrorHandler();
+      final h2 = _TestErrorHandler();
+      final h3 = _TestErrorHandler();
+
+      await Future.wait([
+        interceptor.onError(makeErr(), h1),
+        interceptor.onError(makeErr(), h2),
+        interceptor.onError(makeErr(), h3),
+      ]);
+
+      // Without coalescing this would be 3 — one refreshToken read per
+      // concurrent 401. With the in-flight Future shared, all three
+      // queued callers await the same refresh and the secure store is
+      // read exactly once.
+      expect(
+        secureStorage.refreshTokenReadCount - baseline,
+        1,
+        reason: 'concurrent 401s should share a single refresh attempt',
+      );
+    });
+
+    test('clears in-flight Future so a later 401 starts a fresh refresh', () async {
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+      final interceptor = TokenRefreshInterceptor(dio: dio, secureStorage: secureStorage);
+      DioException makeErr() {
+        final ro = RequestOptions(path: '/api/users');
+        return DioException(
+          requestOptions: ro,
+          response: Response(requestOptions: ro, statusCode: 401),
+        );
+      }
+
+      // First wave completes…
+      await interceptor.onError(makeErr(), _TestErrorHandler());
+      final after1 = secureStorage.refreshTokenReadCount;
+
+      // …then a later 401 (after the in-flight Future cleared) starts
+      // its own refresh sequence.
+      await interceptor.onError(makeErr(), _TestErrorHandler());
+      final after2 = secureStorage.refreshTokenReadCount;
+
+      expect(after2, greaterThan(after1), reason: 'next 401 must trigger a new refresh');
     });
   });
 

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -5,6 +5,24 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../../../test_utils.dart';
 
+/// ISecureStorage whose jwtToken read throws (refresh token is normal).
+/// Exercises the stale-header check's graceful-fallback path.
+class _ReadThrowsOnJwtSecureStorage implements ISecureStorage {
+  final Map<String, String> _store = {};
+  @override
+  Future<String?> read(String key) async {
+    if (key == SecureStorageKeys.jwtToken.key) throw StateError('boom on jwt read');
+    return _store[key];
+  }
+
+  @override
+  Future<void> write(String key, String value) async => _store[key] = value;
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
 /// In-memory ISecureStorage for tests. Counts reads of the refresh-token
 /// key so concurrent-refresh coalescing can be asserted.
 class _MemorySecureStorage implements ISecureStorage {
@@ -307,6 +325,28 @@ void main() {
         1,
         reason: 'concurrent 401s should share a single refresh attempt',
       );
+    });
+
+    test('stale-header check survives a throwing secure read (graceful fallback)', () async {
+      // Failing-but-readable secure store: jwtToken throws, refreshToken
+      // exists. The stale-header optimization read should be swallowed
+      // and we should fall through to the normal refresh path — letting
+      // the throw escape would break the request pipeline.
+      final flaky = _ReadThrowsOnJwtSecureStorage();
+      await flaky.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+
+      final interceptor = TokenRefreshInterceptor(dio: dio, secureStorage: flaky);
+      final ro = RequestOptions(path: '/api/users', headers: {'Authorization': 'Bearer OLD_JWT'});
+      final error = DioException(
+        requestOptions: ro,
+        response: Response(requestOptions: ro, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      // Must NOT throw; falls through to refresh attempt which will
+      // also fail (no real server), so onSessionExpired is reached.
+      await interceptor.onError(error, handler);
+      expect(handler.nextCalled, isTrue);
     });
 
     test('skips refresh when JWT was already rotated since the failing request was sent', () async {

--- a/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
+++ b/test/infrastructure/http/interceptors/token_refresh_interceptor_test.dart
@@ -327,6 +327,43 @@ void main() {
       );
     });
 
+    test('does not attempt a second refresh when the retried request 401s again', () async {
+      // Simulates a request that has already been retried after a
+      // refresh — RequestOptions.extra carries the _retriedAfterRefresh
+      // marker. A second 401 must short-circuit to logout instead of
+      // entering another refresh round (which would just rotate
+      // tokens forever against a backend that keeps rejecting them).
+      var sessionExpiredCalls = 0;
+      await secureStorage.write(SecureStorageKeys.refreshToken.key, 'valid-refresh-token');
+      final baselineRefreshReads = secureStorage.refreshTokenReadCount;
+
+      final interceptor = TokenRefreshInterceptor(
+        dio: dio,
+        secureStorage: secureStorage,
+        onSessionExpired: () => sessionExpiredCalls++,
+      );
+      final ro = RequestOptions(
+        path: '/api/users',
+        headers: {'Authorization': 'Bearer SOME_JWT'},
+        extra: {'_tokenRefresh_retried': true},
+      );
+      final error = DioException(
+        requestOptions: ro,
+        response: Response(requestOptions: ro, statusCode: 401),
+      );
+      final handler = _TestErrorHandler();
+
+      await interceptor.onError(error, handler);
+
+      expect(sessionExpiredCalls, 1, reason: 'must surface logout on second 401');
+      expect(handler.nextCalled, isTrue);
+      expect(
+        secureStorage.refreshTokenReadCount - baselineRefreshReads,
+        0,
+        reason: 'must NOT enter the refresh path — refresh-token read is the proxy',
+      );
+    });
+
     test('stale-header check survives a throwing secure read (graceful fallback)', () async {
       // Failing-but-readable secure store: jwtToken throws, refreshToken
       // exists. The stale-header optimization read should be swallowed

--- a/test/infrastructure/storage/local_storage_test.dart
+++ b/test/infrastructure/storage/local_storage_test.dart
@@ -141,4 +141,39 @@ void main() {
       reset(mockPrefs);
     });
   });
+
+  group('clear method throw-on-refuse contract', () {
+    // Pins the contract that AuthSessionRepository.clear and
+    // LoginRepository.logout rely on: SharedPreferences.clear() returning
+    // false MUST surface as a thrown StateError so the aggregated logout
+    // result captures the failure instead of reporting Success(null) with
+    // a stale session lingering on disk.
+    late AppLocalStorage localStorage;
+    late SharedPreferences mockPrefs;
+
+    setUp(() {
+      AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
+      localStorage = AppLocalStorage();
+      mockPrefs = MockSharedPreferences();
+      SharedPreferences.setMockInitialValues({});
+      localStorage.setPreferencesInstance(mockPrefs);
+    });
+
+    test('throws StateError when SharedPreferences.clear() returns false', () async {
+      when(() => mockPrefs.clear()).thenAnswer((_) async => false);
+
+      await expectLater(localStorage.clear(), throwsA(isA<StateError>()));
+      verify(() => mockPrefs.clear()).called(1);
+    });
+
+    test('propagates exceptions thrown by SharedPreferences.clear()', () async {
+      when(() => mockPrefs.clear()).thenThrow(Exception('platform died'));
+
+      await expectLater(localStorage.clear(), throwsA(isA<Exception>()));
+    });
+
+    tearDown(() {
+      reset(mockPrefs);
+    });
+  });
 }

--- a/test/infrastructure/storage/secure_storage_test.dart
+++ b/test/infrastructure/storage/secure_storage_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the `throw-on-failure` contract documented on [ISecureStorage]
+/// against the production [FlutterSecureStorageAdapter]. The other
+/// storage tests use an in-memory fake that cannot fail, so a future
+/// "helpful" refactor that catches and returns null inside the adapter
+/// would silently break rollback semantics in
+/// [AuthSessionRepositoryImpl.persist] and [SessionMigration] without
+/// any test surface noticing.
+///
+/// We drive the underlying `plugins.it_nomads.com/flutter_secure_storage`
+/// MethodChannel directly to simulate a platform error.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
+  const channel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  void mockChannel(Future<Object?> Function(MethodCall) handler) {
+    messenger.setMockMethodCallHandler(channel, handler);
+  }
+
+  tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+  group('FlutterSecureStorageAdapter throw-on-failure contract', () {
+    test('read propagates PlatformException from the platform side', () async {
+      mockChannel((call) async {
+        if (call.method == 'read') {
+          throw PlatformException(code: 'platform_error', message: 'decryption failed');
+        }
+        return null;
+      });
+
+      final adapter = FlutterSecureStorageAdapter();
+
+      await expectLater(
+        adapter.read('jwtToken'),
+        throwsA(isA<PlatformException>().having((e) => e.code, 'code', 'platform_error')),
+      );
+    });
+
+    test('write propagates PlatformException from the platform side', () async {
+      mockChannel((call) async {
+        if (call.method == 'write') {
+          throw PlatformException(code: 'platform_error', message: 'keystore unavailable');
+        }
+        return null;
+      });
+
+      final adapter = FlutterSecureStorageAdapter();
+
+      await expectLater(adapter.write('jwtToken', 'some-token'), throwsA(isA<PlatformException>()));
+    });
+
+    test('delete propagates PlatformException from the platform side', () async {
+      mockChannel((call) async {
+        if (call.method == 'delete') {
+          throw PlatformException(code: 'platform_error', message: 'access denied');
+        }
+        return null;
+      });
+
+      final adapter = FlutterSecureStorageAdapter();
+
+      await expectLater(adapter.delete('jwtToken'), throwsA(isA<PlatformException>()));
+    });
+
+    test('deleteAll propagates PlatformException from the platform side', () async {
+      mockChannel((call) async {
+        if (call.method == 'deleteAll') {
+          throw PlatformException(code: 'platform_error', message: 'cleanup failed');
+        }
+        return null;
+      });
+
+      final adapter = FlutterSecureStorageAdapter();
+
+      await expectLater(adapter.deleteAll(), throwsA(isA<PlatformException>()));
+    });
+
+    test('read returns null only when the key is absent (not on error)', () async {
+      mockChannel((call) async {
+        expect(call.method, 'read');
+        return null; // absent
+      });
+
+      final adapter = FlutterSecureStorageAdapter();
+
+      expect(await adapter.read('jwtToken'), isNull);
+    });
+  });
+}

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -139,6 +139,7 @@ void main() {
 /// (returns false without throwing). Mirrors a SharedPreferences
 /// platform refusal.
 class _RefuseRemoveLocalStorage implements AppLocalStorage {
+  // ignore: prefer_initializing_formals
   _RefuseRemoveLocalStorage({required AppLocalStorage real, required this.refuseKey}) : _real = real;
   final AppLocalStorage _real;
   final String refuseKey;

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -59,14 +59,17 @@ void main() {
       expect(await local.read('refreshToken'), isNull);
     });
 
-    test('is a no-op when secure storage already has the value (idempotent)', () async {
+    test('preserves the secure value across runs (idempotent for secure side)', () async {
+      // Secure-storage value is never overwritten once migrated. The
+      // "cleans up lingering plaintext" test below covers what happens
+      // to a stale SharedPreferences copy in this same scenario —
+      // they're two halves of the same idempotency guarantee.
       await secure.write('jwtToken', 'ALREADY_MIGRATED');
-      await local.save('jwtToken', 'STALE');
 
       await SessionMigration.run(secureStorage: secure, localStorage: local);
 
       expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED');
-      expect(await local.read('jwtToken'), 'STALE');
+      expect(await local.read('jwtToken'), isNull);
     });
 
     test('is a no-op when there is nothing to migrate', () async {
@@ -97,6 +100,20 @@ void main() {
 
       expect(await silent.read('jwtToken'), isNull);
       expect(await local.read('jwtToken'), 'JWT_VALUE');
+    });
+
+    test('cleans up lingering plaintext when secure already has the value', () async {
+      // Simulates an interrupted prior migration: token is in secure
+      // storage, but a plaintext copy still lingers in SharedPreferences.
+      // The migration must clean up the leftover even though early-return
+      // would otherwise skip it — defeating the migration's whole point.
+      await secure.write('jwtToken', 'ALREADY_MIGRATED');
+      await local.save('jwtToken', 'STALE_PLAINTEXT');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED', reason: 'secure value untouched');
+      expect(await local.read('jwtToken'), isNull, reason: 'lingering plaintext cleaned up');
     });
 
     test('warns when SharedPreferences refuses to remove the legacy key', () async {

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../test_utils.dart';
+
+class _MemorySecureStorage implements ISecureStorage {
+  _MemorySecureStorage({this.failOnWrite = false});
+  final Map<String, String> _store = {};
+  final bool failOnWrite;
+  @override
+  Future<String?> read(String key) async => _store[key];
+  @override
+  Future<void> write(String key, String value) async {
+    if (failOnWrite) throw StateError('boom');
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+  @override
+  Future<void> deleteAll() async => _store.clear();
+}
+
+void main() {
+  late AppLocalStorage local;
+  late _MemorySecureStorage secure;
+
+  setUpAll(() async {
+    await TestUtils().setupUnitTest();
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    local = AppLocalStorage();
+    local.setPreferencesInstance(await SharedPreferences.getInstance());
+    secure = _MemorySecureStorage();
+  });
+
+  tearDown(() async => TestUtils().tearDownUnitTest());
+
+  group('SessionMigration.run', () {
+    test('migrates jwtToken and refreshToken from local to secure', () async {
+      await local.save('jwtToken', 'JWT_VALUE');
+      await local.save('refreshToken', 'REFRESH_VALUE');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), 'JWT_VALUE');
+      expect(await secure.read('refreshToken'), 'REFRESH_VALUE');
+      expect(await local.read('jwtToken'), isNull);
+      expect(await local.read('refreshToken'), isNull);
+    });
+
+    test('is a no-op when secure storage already has the value (idempotent)', () async {
+      await secure.write('jwtToken', 'ALREADY_MIGRATED');
+      await local.save('jwtToken', 'STALE');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED');
+      expect(await local.read('jwtToken'), 'STALE');
+    });
+
+    test('is a no-op when there is nothing to migrate', () async {
+      await SessionMigration.run(secureStorage: secure, localStorage: local);
+
+      expect(await secure.read('jwtToken'), isNull);
+      expect(await secure.read('refreshToken'), isNull);
+    });
+
+    test('does not throw when secure write fails', () async {
+      final flaky = _MemorySecureStorage(failOnWrite: true);
+      await local.save('jwtToken', 'JWT_VALUE');
+
+      await SessionMigration.run(secureStorage: flaky, localStorage: local);
+
+      expect(await local.read('jwtToken'), 'JWT_VALUE');
+    });
+  });
+}

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -46,12 +46,12 @@ void main() {
 
   tearDown(() async => TestUtils().tearDownUnitTest());
 
-  group('SessionMigration.run', () {
+  group('runSessionMigration', () {
     test('migrates jwtToken and refreshToken from local to secure', () async {
       await local.save('jwtToken', 'JWT_VALUE');
       await local.save('refreshToken', 'REFRESH_VALUE');
 
-      await SessionMigration.run(secureStorage: secure, localStorage: local);
+      await runSessionMigration(secureStorage: secure, localStorage: local);
 
       expect(await secure.read('jwtToken'), 'JWT_VALUE');
       expect(await secure.read('refreshToken'), 'REFRESH_VALUE');
@@ -66,14 +66,14 @@ void main() {
       // they're two halves of the same idempotency guarantee.
       await secure.write('jwtToken', 'ALREADY_MIGRATED');
 
-      await SessionMigration.run(secureStorage: secure, localStorage: local);
+      await runSessionMigration(secureStorage: secure, localStorage: local);
 
       expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED');
       expect(await local.read('jwtToken'), isNull);
     });
 
     test('is a no-op when there is nothing to migrate', () async {
-      await SessionMigration.run(secureStorage: secure, localStorage: local);
+      await runSessionMigration(secureStorage: secure, localStorage: local);
 
       expect(await secure.read('jwtToken'), isNull);
       expect(await secure.read('refreshToken'), isNull);
@@ -83,7 +83,7 @@ void main() {
       final flaky = _MemorySecureStorage(failOnWrite: true);
       await local.save('jwtToken', 'JWT_VALUE');
 
-      await SessionMigration.run(secureStorage: flaky, localStorage: local);
+      await runSessionMigration(secureStorage: flaky, localStorage: local);
 
       expect(await local.read('jwtToken'), 'JWT_VALUE');
     });
@@ -96,7 +96,7 @@ void main() {
       final silent = _MemorySecureStorage(silentlyDropWrites: true);
       await local.save('jwtToken', 'JWT_VALUE');
 
-      await SessionMigration.run(secureStorage: silent, localStorage: local);
+      await runSessionMigration(secureStorage: silent, localStorage: local);
 
       expect(await silent.read('jwtToken'), isNull);
       expect(await local.read('jwtToken'), 'JWT_VALUE');
@@ -110,7 +110,7 @@ void main() {
       await secure.write('jwtToken', 'ALREADY_MIGRATED');
       await local.save('jwtToken', 'STALE_PLAINTEXT');
 
-      await SessionMigration.run(secureStorage: secure, localStorage: local);
+      await runSessionMigration(secureStorage: secure, localStorage: local);
 
       expect(await secure.read('jwtToken'), 'ALREADY_MIGRATED', reason: 'secure value untouched');
       expect(await local.read('jwtToken'), isNull, reason: 'lingering plaintext cleaned up');
@@ -125,7 +125,7 @@ void main() {
       final secure = _MemorySecureStorage();
       await local.save('jwtToken', 'JWT_VALUE');
 
-      await SessionMigration.run(secureStorage: secure, localStorage: flakyLocal);
+      await runSessionMigration(secureStorage: secure, localStorage: flakyLocal);
 
       expect(await secure.read('jwtToken'), 'JWT_VALUE', reason: 'secure write succeeded');
       // The legacy key is still there because remove returned false;

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -98,5 +98,41 @@ void main() {
       expect(await silent.read('jwtToken'), isNull);
       expect(await local.read('jwtToken'), 'JWT_VALUE');
     });
+
+    test('warns when SharedPreferences refuses to remove the legacy key', () async {
+      // localStorage.remove returns false → secure side already has the
+      // migrated value, but the plaintext leftover in SharedPreferences
+      // is exactly what the migration is meant to eliminate. We must
+      // surface this rather than log a misleading success.
+      final flakyLocal = _RefuseRemoveLocalStorage(real: local, refuseKey: 'jwtToken');
+      final secure = _MemorySecureStorage();
+      await local.save('jwtToken', 'JWT_VALUE');
+
+      await SessionMigration.run(secureStorage: secure, localStorage: flakyLocal);
+
+      expect(await secure.read('jwtToken'), 'JWT_VALUE', reason: 'secure write succeeded');
+      // The legacy key is still there because remove returned false;
+      // operators see a warn-level log so the leftover can be cleaned up.
+      expect(await local.read('jwtToken'), 'JWT_VALUE');
+    });
   });
+}
+
+/// AppLocalStorage decorator that refuses to remove a specific key
+/// (returns false without throwing). Mirrors a SharedPreferences
+/// platform refusal.
+class _RefuseRemoveLocalStorage implements AppLocalStorage {
+  _RefuseRemoveLocalStorage({required AppLocalStorage real, required this.refuseKey}) : _real = real;
+  final AppLocalStorage _real;
+  final String refuseKey;
+  @override
+  Future<bool> save(String key, dynamic value) => _real.save(key, value);
+  @override
+  Future<dynamic> read(String key) => _real.read(key);
+  @override
+  Future<bool> remove(String key) async => key == refuseKey ? false : _real.remove(key);
+  @override
+  Future<void> clear() => _real.clear();
+  @override
+  void setPreferencesInstance(SharedPreferences prefs) => _real.setPreferencesInstance(prefs);
 }

--- a/test/infrastructure/storage/session_migration_test.dart
+++ b/test/infrastructure/storage/session_migration_test.dart
@@ -7,14 +7,19 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../test_utils.dart';
 
 class _MemorySecureStorage implements ISecureStorage {
-  _MemorySecureStorage({this.failOnWrite = false});
+  _MemorySecureStorage({this.failOnWrite = false, this.silentlyDropWrites = false});
   final Map<String, String> _store = {};
   final bool failOnWrite;
+
+  /// Simulates a misbehaving adapter that returns successfully but never
+  /// persists the value — exercises the read-after-write verification path.
+  final bool silentlyDropWrites;
   @override
   Future<String?> read(String key) async => _store[key];
   @override
   Future<void> write(String key, String value) async {
     if (failOnWrite) throw StateError('boom');
+    if (silentlyDropWrites) return;
     _store[key] = value;
   }
 
@@ -77,6 +82,20 @@ void main() {
 
       await SessionMigration.run(secureStorage: flaky, localStorage: local);
 
+      expect(await local.read('jwtToken'), 'JWT_VALUE');
+    });
+
+    test('retains legacy key when secure write silently fails to persist', () async {
+      // Simulates a misbehaving adapter that returns without throwing but
+      // drops the write. The read-after-write check should catch this and
+      // leave the legacy SharedPreferences value intact so the user is not
+      // logged out.
+      final silent = _MemorySecureStorage(silentlyDropWrites: true);
+      await local.save('jwtToken', 'JWT_VALUE');
+
+      await SessionMigration.run(secureStorage: silent, localStorage: local);
+
+      expect(await silent.read('jwtToken'), isNull);
       expect(await local.read('jwtToken'), 'JWT_VALUE');
     });
   });

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -14,10 +14,14 @@ import 'package:shared_preferences_platform_interface/shared_preferences_async_p
 ///
 /// This class contains utility methods that are used in the tests
 class TestUtils {
-  /// In-memory backing for the mocked flutter_secure_storage channel so
-  /// production code that creates a [FlutterSecureStorageAdapter()] —
-  /// including [AppLocalStorageCached.loadCache] when called with an
-  /// adapter — does not throw `MissingPluginException` in unit tests.
+  /// In-memory backing for the mocked flutter_secure_storage channel.
+  ///
+  /// Production code instantiates [FlutterSecureStorageAdapter] in
+  /// several places — `AuthInterceptor`, `TokenRefreshInterceptor`,
+  /// `SessionCubit`, `AuthSessionRepository`, `LoginRepository.logout`,
+  /// `SessionMigration` — and each adapter call routes through this
+  /// MethodChannel. Without a mock, every test that touches those paths
+  /// would throw `MissingPluginException`.
   static final Map<String, String> _secureStore = {};
 
   static const _secureChannel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
@@ -83,8 +87,11 @@ class TestUtils {
     return await _clearStorage();
   }
 
-  /// Seed a mock JWT in the secure store backing — the single source of
-  /// truth read by `SecurityUtils`, `AuthInterceptor`, and `SessionCubit`.
+  /// Seed a mock JWT in the secure-store backing. This is the only
+  /// place tokens live in the shipped architecture — `AuthInterceptor`
+  /// and `SessionCubit.restore` both read it on demand. `SecurityUtils`
+  /// itself takes the token as an argument (no I/O), so seeding here
+  /// is sufficient for any auth-dependent test path.
   Future<void> setupAuthentication() async {
     _secureStore['jwtToken'] = 'MOCK_TOKEN';
   }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -79,18 +79,16 @@ class TestUtils {
     return await _clearStorage();
   }
 
-  /// Seed a mock JWT visible to both sync (`AppLocalStorageCached.jwtToken`)
-  /// and async (`FlutterSecureStorageAdapter().read(...)`) call paths.
+  /// Seed a mock JWT in the secure store backing — the single source of
+  /// truth read by `SecurityUtils`, `AuthInterceptor`, and `SessionCubit`.
   Future<void> setupAuthentication() async {
     _secureStore['jwtToken'] = 'MOCK_TOKEN';
-    AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
   }
 
   Future<void> _clearStorage() async {
     SharedPreferences.setMockInitialValues({});
     SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
     _secureStore.clear();
-    AppLocalStorageCached.jwtToken = null;
     await AppLocalStorage().clear();
   }
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
@@ -13,19 +14,52 @@ import 'package:shared_preferences_platform_interface/shared_preferences_async_p
 ///
 /// This class contains utility methods that are used in the tests
 class TestUtils {
-  /// Initialize the dependencies for the BLoC tests
-  ///
-  /// This method initializes the following dependencies: <p>
-  /// 1. Flutter Test Binding <p>
-  /// 3. Shared Preferences <p>
-  /// 4. Equatable Configuration <p>
-  /// 5. Mock Method Call Handler for Path Provider <p>
+  /// In-memory backing for the mocked flutter_secure_storage channel so
+  /// production code that creates a [FlutterSecureStorageAdapter()] —
+  /// including [AppLocalStorageCached.loadCache] when called with an
+  /// adapter — does not throw `MissingPluginException` in unit tests.
+  static final Map<String, String> _secureStore = {};
+
+  static const _secureChannel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+  static bool _secureMockInstalled = false;
+
+  static void _installSecureStorageMock() {
+    if (_secureMockInstalled) return;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(_secureChannel, (
+      call,
+    ) async {
+      final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? const {};
+      final key = args['key'] as String?;
+      switch (call.method) {
+        case 'read':
+          return _secureStore[key];
+        case 'readAll':
+          return Map<String, String>.from(_secureStore);
+        case 'write':
+          _secureStore[key!] = args['value'] as String;
+          return null;
+        case 'delete':
+          _secureStore.remove(key);
+          return null;
+        case 'deleteAll':
+          _secureStore.clear();
+          return null;
+        case 'containsKey':
+          return _secureStore.containsKey(key);
+        default:
+          return null;
+      }
+    });
+    _secureMockInstalled = true;
+  }
 
   Future<void> setupUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
     ProfileConstants.setEnvironment(Environment.test);
     TestWidgetsFlutterBinding.ensureInitialized();
     EquatableConfig.stringify = true;
+    _installSecureStorageMock();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);
@@ -34,6 +68,7 @@ class TestUtils {
   Future<void> setupRepositoryUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
     ProfileConstants.setEnvironment(Environment.test);
+    _installSecureStorageMock();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);
@@ -44,16 +79,18 @@ class TestUtils {
     return await _clearStorage();
   }
 
-  // Set mock token in the sync cache so SecurityUtils.isUserLoggedIn() returns true in tests.
-  // FlutterSecureStorageAdapter is unavailable in unit/widget tests, so we seed
-  // AppLocalStorageCached.jwtToken directly.
+  /// Seed a mock JWT visible to both sync (`AppLocalStorageCached.jwtToken`)
+  /// and async (`FlutterSecureStorageAdapter().read(...)`) call paths.
   Future<void> setupAuthentication() async {
-    AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
+    _secureStore['jwtToken'] = 'MOCK_TOKEN';
+    AppLocalStorageCached.jwtToken = 'MOCK_TOKEN';
   }
 
   Future<void> _clearStorage() async {
     SharedPreferences.setMockInitialValues({});
     SharedPreferencesAsyncPlatform.instance = InMemorySharedPreferencesAsync.empty();
+    _secureStore.clear();
+    AppLocalStorageCached.jwtToken = null;
     await AppLocalStorage().clear();
   }
 }

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -44,9 +44,11 @@ class TestUtils {
     return await _clearStorage();
   }
 
-  // add mock token to storage
+  // Set mock token in the sync cache so SecurityUtils.isUserLoggedIn() returns true in tests.
+  // FlutterSecureStorageAdapter is unavailable in unit/widget tests, so we seed
+  // AppLocalStorageCached.jwtToken directly.
   Future<void> setupAuthentication() async {
-    await AppLocalStorage().save(StorageKeys.jwtToken.key, "MOCK_TOKEN");
+    AppLocalStorageCached.jwtToken = "MOCK_TOKEN";
   }
 
   Future<void> _clearStorage() async {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -68,6 +68,10 @@ class TestUtils {
   Future<void> setupRepositoryUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
     ProfileConstants.setEnvironment(Environment.test);
+    // Binding must be initialized BEFORE installing the MethodChannel
+    // mock — `TestDefaultBinaryMessengerBinding.instance` throws
+    // otherwise. setupUnitTest does the same.
+    TestWidgetsFlutterBinding.ensureInitialized();
     _installSecureStorageMock();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
+import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -97,7 +98,7 @@ class TestUtils {
   /// historically called this without `await`. Keeping it sync makes
   /// the no-await call sites correct rather than racy.
   void setupAuthentication() {
-    _secureStore['jwtToken'] = 'MOCK_TOKEN';
+    _secureStore[SecureStorageKeys.jwtToken.key] = 'MOCK_TOKEN';
   }
 
   Future<void> _clearStorage() async {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -65,6 +65,14 @@ class TestUtils {
     TestWidgetsFlutterBinding.ensureInitialized();
     EquatableConfig.stringify = true;
     _installSecureStorageMock();
+    // Wire ApiClient to a shared FlutterSecureStorageAdapter so the
+    // HTTP interceptors read from the same MethodChannel-mocked store
+    // as the repository layer. Without this, tests touching both
+    // ApiClient.instance and a repository would silently use two
+    // different adapter instances — both backed by the same mock so
+    // tests pass, but the test harness would not catch a future
+    // production refactor that breaks SoT.
+    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);
@@ -78,6 +86,7 @@ class TestUtils {
     // otherwise. setupUnitTest does the same.
     TestWidgetsFlutterBinding.ensureInitialized();
     _installSecureStorageMock();
+    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -92,7 +92,11 @@ class TestUtils {
   /// and `SessionCubit.restore` both read it on demand. `SecurityUtils`
   /// itself takes the token as an argument (no I/O), so seeding here
   /// is sufficient for any auth-dependent test path.
-  Future<void> setupAuthentication() async {
+  ///
+  /// Synchronous: the backing is just an in-memory map and tests have
+  /// historically called this without `await`. Keeping it sync makes
+  /// the no-await call sites correct rather than racy.
+  void setupAuthentication() {
     _secureStore['jwtToken'] = 'MOCK_TOKEN';
   }
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -27,10 +27,16 @@ class TestUtils {
 
   static const _secureChannel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
 
-  static bool _secureMockInstalled = false;
-
+  /// Always re-installs the handler. Previously short-circuited via
+  /// a `_secureMockInstalled` flag, but `secure_storage_test.dart`
+  /// (C3 throw-on-failure contract tests) temporarily overrides the
+  /// same channel and its `tearDown` resets the handler to `null`.
+  /// If this util ran first and set the flag, a later run of
+  /// `setupUnitTest()` would skip re-installation and leave the
+  /// channel with the null handler → `MissingPluginException` for
+  /// every secure-storage call. Re-installing is cheap and
+  /// idempotent.
   static void _installSecureStorageMock() {
-    if (_secureMockInstalled) return;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(_secureChannel, (
       call,
     ) async {
@@ -56,7 +62,6 @@ class TestUtils {
           return null;
       }
     });
-    _secureMockInstalled = true;
   }
 
   Future<void> setupUnitTest() async {
@@ -94,6 +99,15 @@ class TestUtils {
 
   Future<void> tearDownUnitTest() async {
     ApiClient.reset();
+    // [ApiClient.reset] now also clears `secureStorage` and
+    // `onSessionExpired` (Copilot finding: hot-reload / multi-test
+    // leakage). Test files that rely on `setUpAll` + per-test
+    // `tearDown` (instead of per-test `setUp`) would otherwise see a
+    // null `secureStorage` after the first teardown. Re-wire the
+    // shared adapter here so the next test in the same file starts
+    // with the same SoT invariants `setupUnitTest` established.
+    _installSecureStorageMock();
+    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     return await _clearStorage();
   }
 


### PR DESCRIPTION
## Summary

Closes #129. Routes JWT and refresh tokens through `flutter_secure_storage` (iOS Keychain, Android Keystore-backed EncryptedSharedPreferences, AES on web) instead of plaintext SharedPreferences. Migrates existing installations transparently. Adds structural log masking so tokens are unloggable even if `Equatable.stringify` is later flipped on.

The PR went through four rounds of Copilot review and one major refactor (eliminating an in-memory JWT cache that turned out to be the root cause of every silent-failure gap reviewers found). Final architecture: secure storage is the single source of truth; no parallel cache, no coordination invariants.

## Architecture

**JWT lives only in `ISecureStorage`.** Every consumer reads it on demand:

| Caller | Path |
|---|---|
| `AuthInterceptor.onRequest` | `await _secureStorage.read(...)` per HTTP request |
| `SessionCubit.restore` | secure read → `SecurityUtils.hasToken / isTokenExpired` (pure) → emit `isAuthenticated` |
| `AuthSessionRepository.persist / clear` | writes / deletes via `ISecureStorage` |
| `TokenRefreshInterceptor` | reads refresh token, writes rotated pair via `ISecureStorage` |
| `LoginRepository.logout` | deletes secure JWT + refreshToken, then `AppLocalStorage.clear()` |

`StorageKeys` enum was split:
- `SecureStorageKeys` — `jwtToken`, `refreshToken` (encrypted backend)
- `StorageKeys` — `username`, `roles`, `language`, `theme`, `brightness` (plaintext, non-secret)

`SecurityUtils` was rewritten as pure functions (`hasToken`, `isTokenExpired`, `isCurrentUserAdmin`, `getTokenExpiration`) so `core/` has no `infrastructure/` imports — the architecture-guard test enforces this.

`SessionCubit` is the only authority for `isAuthenticated`; the router redirect reads its sync state and no longer calls `SecurityUtils.isTokenExpired()` directly. A new redirect rule ("authenticated user on public route → home") absorbs the async-restore race that the sync cache used to mask.

## Migration

`SessionMigration.run` executes once at bootstrap. For each legacy SharedPreferences key (`jwtToken`, `refreshToken`):

1. If the value already exists in secure storage → no-op (idempotent).
2. If the legacy plaintext value exists → write to secure storage, **verify via read-after-write**, then remove the legacy key.
3. On any failure → warn and retain the legacy key (best-effort, never orphans the token).

Run-once at bootstrap, before any consumer reads the secure store.

## Atomic persist + cross-backend rollback

`AuthSessionRepository.persist` writes to both backends in order (secure first, then local). Before the first write it snapshots prior values on **both** sides. On any mid-persist failure, `_rollback` restores each backend to its pre-call state (write prior value, or delete if there was none). This is symmetric across secure + local — a re-login that fails halfway can no longer wipe a previously persisted username/roles.

`FlutterSecureStorageAdapter.write/delete/deleteAll` were changed to **propagate exceptions** instead of swallowing them, and `AppLocalStorage.save/remove/clear` now **await SharedPreferences setters and honor their `Future<bool>` return values**. Both adapters previously silently absorbed failures, which made the `Result<void>` / rollback semantics theatre.

## Log masking

- `LogSanitizer.maskToken(String?)` renders `"abcd…wxyz"` for normal tokens, `<redacted>` for short, `<empty>` for null/empty.
- `AuthSession.toString()` overrides Equatable to render masked tokens. Resilient to a future `EquatableConfig.stringify = true` flip — the leak vector flagged in the issue is structurally closed, not just absent.
- `login_bloc.dart:140` OTP debug log uses `LogSanitizer.maskToken(data.idToken)` instead of `data.toString()`.

## Code paths repaired or refactored

| File | Change |
|---|---|
| `lib/core/logging/log_sanitizer.dart` | **NEW** — pure mask helper |
| `lib/core/security/security_utils.dart` | rewritten as pure functions (no I/O) |
| `lib/infrastructure/storage/secure_storage.dart` | `SecureStorageKeys` enum; adapter throws on write/delete failure |
| `lib/infrastructure/storage/local_storage.dart` | jwtToken removed from cached fields; save/remove/clear await Future<bool>; cache layer no longer takes ISecureStorage |
| `lib/infrastructure/storage/session_migration.dart` | **NEW** — one-shot migration with read-after-write verify |
| `lib/infrastructure/http/interceptors/auth_interceptor.dart` | reads JWT directly from secure storage every request; LogSanitizer-masked debug preview |
| `lib/infrastructure/http/interceptors/token_refresh_interceptor.dart` | reads / writes via ISecureStorage; no cache mutation |
| `lib/features/auth/data/repositories/auth_session_repository_impl.dart` | cross-backend persist + symmetric rollback with prior-value snapshots |
| `lib/features/auth/data/repositories/auth_repository_impl.dart` | logout wipes secure storage in addition to AppLocalStorage |
| `lib/features/auth/domain/entities/auth_session.dart` | toString() masked |
| `lib/features/auth/application/login_bloc.dart` | OTP debug log sanitized |
| `lib/app/session/session_cubit.dart` | takes ISecureStorage; restore is async; emits derived isAuthenticated |
| `lib/app/router/app_router.dart` | drops direct SecurityUtils call; adds auth-on-public-route → home rule |
| `lib/app/di/app_dependencies.dart` + `app_scope.dart` | ISecureStorage factory + provider |
| `lib/app/bootstrap/app_bootstrap.dart` | runs SessionMigration before cache load |
| `README.md` | auth section documents the token storage model |

## Test plan

- [x] `fvm flutter test` — **1454 / 1454 tests pass**
- [x] `fvm dart analyze` — 0 errors, 0 warnings (3 cosmetic info-level `prefer_initializing_formals` lints unchanged from main)
- [x] `fvm dart format --set-exit-if-changed --line-length=120 .` — clean
- [x] `import_guard_test` confirms `core/` ↔ `infrastructure/` separation (SecurityUtils refactor required this)
- [x] **End-to-end behavioural verification on Chrome (web):**
  - Bootstrap cold start → secure read returns null → `/login` ✅
  - Login → 2 secure writes + 2 local writes → next request carries `Authorization: Bearer <token>` from a fresh secure read (no cache) ✅
  - localStorage inspected: token keys are AES ciphertext, legacy `flutter.jwtToken` plaintext key absent ✅
  - Logout wipe → reload → `restore` returns unauthenticated (no in-memory residue) ✅
  - Login + reload → `restore` rehydrates from secure store → router lands on home without race ✅
  - Full report: `docs/superpowers/specs/2026-05-20-secure-storage-wiring-e2e-verification.md`
- [x] Four rounds of Copilot review addressed (silent-failure gaps in adapter and `AppLocalStorage`, logout-secure-miss, rollback asymmetry, doc/comment rot)

## New tests added

- `test/core/logging/log_sanitizer_test.dart` — boundary tests for `maskToken`
- `test/features/auth/domain/entities/auth_session_test.dart` — `toString()` does not contain raw token
- `test/infrastructure/storage/session_migration_test.dart` — happy path, idempotency, no-op, write-failure best-effort, silent-drop verification
- `test/features/auth/data/repositories/auth_session_repository_impl_test.dart` — round-trip, cross-backend rollback (jwt + refresh restored), stale-refresh-restore, re-login local-rollback (prior username/roles restored), clear-both-backends
- `test/features/auth/data/repositories/login_repository_test.dart` — logout wipes JWT + refresh from secure store
- Updated: `test_utils.dart` (MethodChannel mock for `flutter_secure_storage` so unit tests don't throw `MissingPluginException`), `token_refresh_interceptor_test.dart`, `security_utils_test.dart`, `session_cubit_test.dart`, `login_bloc_test.dart`, `login_otp_verify_widget_test.dart`, `home_screen_test.dart`

## Design + plan + verification docs

- Spec: `docs/superpowers/specs/2026-05-20-secure-storage-wiring-design.md`
- Plan: `docs/superpowers/plans/2026-05-20-secure-storage-wiring.md` (header marks Tasks 7/8 as superseded by the cache-elimination refactor)
- E2E verification: `docs/superpowers/specs/2026-05-20-secure-storage-wiring-e2e-verification.md`

## Out of scope (separate issues exist or were filed)

- Certificate pinning (#133), screen capture protection (#134), idle timeout (#130) — tracked separately.
- Token encryption beyond what platform Keystore/Keychain provides. (Bonus side-effect: `flutter_secure_storage` on web uses AES, so JWT is now encrypted at rest on web too.)
- Refresh-token rotation policy on the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
