### PR TITLE
feat(#134): opt-in screen capture protection for sensitive screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,35 @@ The screenshots below are included to help contributors and adopters understand 
 - Public and private route separation
 - Protected admin-only pages
 
+### Screen Capture Protection (opt-in)
+
+Mechanism for sensitive screens (credentials, OTP, payment, tokens) shipped **disabled by default**. The template's job is to provide the hook, not impose UX on every fork — many apps legitimately want users to screenshot QR codes, receipts, etc.
+
+- Helper: `ScreenCaptureProtection.enable()` / `.disable()` in `lib/core/security/screen_capture_protection.dart`.
+- Per-screen mixin: `ScreenCaptureProtected<T>` in `lib/core/security/screen_capture_protected.dart` — add to a `State<T>` and it auto-enables on `initState`, releases on `dispose`.
+
+Platform behaviour (**asymmetric — read this**):
+
+| Platform | What happens |
+| --- | --- |
+| Android | `FLAG_SECURE`: screenshots and screen recording are blocked; recent-apps preview renders black. |
+| iOS | iOS provides no API to block screenshots (Apple policy). The task-switcher snapshot is **blurred** so on-screen secrets do not leak into the app preview. Screenshots while foregrounded still succeed. |
+| Web / Desktop | No-op. |
+
+Opt-in example (uncomment in `LoginScreen`):
+
+```dart
+import 'package:flutter_bloc_advance/core/security/screen_capture_protected.dart';
+
+class _LoginScreenState extends State<LoginScreen>
+    with ScreenCaptureProtected<LoginScreen>, SingleTickerProviderStateMixin {
+  // ...
+}
+```
+
+When to enable: credential entry, OTP screens, token display.
+When not to enable: screens with content the user is expected to capture (QR codes, receipts).
+
 ### Server-Driven Dynamic Forms
 
 - 16 supported field types: text, email, password, number, phone, textarea,

--- a/lib/core/security/screen_capture_protected.dart
+++ b/lib/core/security/screen_capture_protected.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+import 'screen_capture_protection.dart';
+
+/// Mixin for a [State] whose [StatefulWidget] should disable screen capture
+/// while mounted. Enables protection in [initState] and releases it in
+/// [dispose]. See [ScreenCaptureProtection] for platform behaviour.
+mixin ScreenCaptureProtected<T extends StatefulWidget> on State<T> {
+  @override
+  void initState() {
+    super.initState();
+    ScreenCaptureProtection.enable();
+  }
+
+  @override
+  void dispose() {
+    ScreenCaptureProtection.disable();
+    super.dispose();
+  }
+}

--- a/lib/core/security/screen_capture_protected.dart
+++ b/lib/core/security/screen_capture_protected.dart
@@ -3,8 +3,10 @@ import 'package:flutter/widgets.dart';
 import 'screen_capture_protection.dart';
 
 /// Mixin for a [State] whose [StatefulWidget] should disable screen capture
-/// while mounted. Enables protection in [initState] and releases it in
-/// [dispose]. See [ScreenCaptureProtection] for platform behaviour.
+/// while mounted. Acquires a protection lease in [initState] and releases it in
+/// [dispose]. Because [ScreenCaptureProtection] is reference-counted, nesting
+/// protected screens is safe: protection stays on until the last protected
+/// screen is disposed. See [ScreenCaptureProtection] for platform behaviour.
 mixin ScreenCaptureProtected<T extends StatefulWidget> on State<T> {
   @override
   void initState() {

--- a/lib/core/security/screen_capture_protection.dart
+++ b/lib/core/security/screen_capture_protection.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:screen_protector/screen_protector.dart';
+
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+
+/// Opt-in screen capture protection for sensitive screens.
+///
+/// Android: blocks screenshots and renders a black surface in the recent-apps
+/// switcher (`FLAG_SECURE`).
+/// iOS: cannot block screenshots (no public API); overlays a blurred view on
+/// `applicationWillResignActive` so the task-switcher snapshot is blank.
+/// Web / Desktop: no-op.
+class ScreenCaptureProtection {
+  ScreenCaptureProtection._();
+
+  static final _log = AppLogger.getLogger('ScreenCaptureProtection');
+  static bool _enabled = false;
+
+  /// Test seam — flip to true to simulate a web platform without a kIsWeb const.
+  @visibleForTesting
+  static bool debugWebOverride = false;
+
+  /// Whether protection is currently active.
+  static bool get isEnabled => _enabled;
+
+  /// Activates protection on Android (block) and iOS (task-switcher blur).
+  /// Idempotent; second call while already enabled is a no-op. No-op on web.
+  static Future<void> enable() async {
+    if (_enabled) return;
+    if (_isWeb) return;
+    try {
+      await ScreenProtector.protectDataLeakageOn();
+      await ScreenProtector.protectDataLeakageWithBlur();
+    } catch (e, st) {
+      _log.warn('enable() — plugin call failed: {}\n{}', [e, st]);
+    }
+    _enabled = true;
+  }
+
+  /// Deactivates protection. Idempotent. No-op on web.
+  static Future<void> disable() async {
+    if (!_enabled) return;
+    if (_isWeb) return;
+    try {
+      await ScreenProtector.protectDataLeakageOff();
+      await ScreenProtector.protectDataLeakageWithBlurOff();
+    } catch (e, st) {
+      _log.warn('disable() — plugin call failed: {}\n{}', [e, st]);
+    }
+    _enabled = false;
+  }
+
+  static bool get _isWeb => debugWebOverride || kIsWeb;
+
+  @visibleForTesting
+  static void resetForTesting() {
+    _enabled = false;
+    debugWebOverride = false;
+  }
+}

--- a/lib/core/security/screen_capture_protection.dart
+++ b/lib/core/security/screen_capture_protection.dart
@@ -8,53 +8,73 @@ import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 /// Android: blocks screenshots and renders a black surface in the recent-apps
 /// switcher (`FLAG_SECURE`).
 /// iOS: cannot block screenshots (no public API); overlays a blurred view on
-/// `applicationWillResignActive` so the task-switcher snapshot is blank.
-/// Web / Desktop: no-op.
+/// `applicationWillResignActive` so the task-switcher snapshot is blurred.
+/// Web / Desktop: no-op (unsupported platforms).
+///
+/// Protection is reference-counted: it stays engaged while any caller holds a
+/// lease (via [enable]) and is only disengaged once the last lease is released
+/// (via [disable]). This keeps nested protected routes safe — popping an inner
+/// protected screen will not turn protection off while an outer one is still
+/// mounted.
 class ScreenCaptureProtection {
   ScreenCaptureProtection._();
 
   static final _log = AppLogger.getLogger('ScreenCaptureProtection');
-  static bool _enabled = false;
+
+  /// Number of active protection leases. Protection is engaged while > 0.
+  static int _leases = 0;
 
   /// Test seam — flip to true to simulate a web platform without a kIsWeb const.
   @visibleForTesting
   static bool debugWebOverride = false;
 
-  /// Whether protection is currently active.
-  static bool get isEnabled => _enabled;
+  /// Whether protection is currently active (at least one active lease).
+  static bool get isEnabled => _leases > 0;
 
-  /// Activates protection on Android (block) and iOS (task-switcher blur).
-  /// Idempotent; second call while already enabled is a no-op. No-op on web.
+  /// Acquires a protection lease. The first lease engages platform protection
+  /// on Android (block) and iOS (task-switcher blur); subsequent leases only
+  /// bump the reference count. No-op on unsupported platforms (web/desktop).
   static Future<void> enable() async {
-    if (_enabled) return;
-    if (_isWeb) return;
+    if (!_isSupported) return;
+    // Increment before awaiting so concurrent callers cannot both trigger the
+    // initial plugin engagement (re-entrancy-safe idempotency).
+    final wasInactive = _leases == 0;
+    _leases++;
+    if (!wasInactive) return;
     try {
       await ScreenProtector.protectDataLeakageOn();
       await ScreenProtector.protectDataLeakageWithBlur();
     } catch (e, st) {
       _log.warn('enable() — plugin call failed: {}\n{}', [e, st]);
     }
-    _enabled = true;
   }
 
-  /// Deactivates protection. Idempotent. No-op on web.
+  /// Releases a protection lease. Platform protection is disengaged only when
+  /// the last lease is released. No-op on unsupported platforms (web/desktop)
+  /// and when no lease is held.
   static Future<void> disable() async {
-    if (!_enabled) return;
-    if (_isWeb) return;
+    if (!_isSupported) return;
+    if (_leases == 0) return;
+    _leases--;
+    if (_leases > 0) return;
     try {
       await ScreenProtector.protectDataLeakageOff();
       await ScreenProtector.protectDataLeakageWithBlurOff();
     } catch (e, st) {
       _log.warn('disable() — plugin call failed: {}\n{}', [e, st]);
     }
-    _enabled = false;
   }
 
-  static bool get _isWeb => debugWebOverride || kIsWeb;
+  /// Only Android and iOS support the underlying plugin; web and desktop are
+  /// explicit no-ops so [isEnabled] never reports a false positive there.
+  static bool get _isSupported {
+    if (debugWebOverride || kIsWeb) return false;
+    return defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS;
+  }
 
   @visibleForTesting
   static void resetForTesting() {
-    _enabled = false;
+    _leases = 0;
     debugWebOverride = false;
   }
 }

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -3,6 +3,9 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/testing/app_key_constants.dart';
+// Uncomment to block screenshots / blur task-switcher snapshot on the login screen.
+// See lib/core/security/screen_capture_protection.dart for Android/iOS asymmetry.
+// import 'package:flutter_bloc_advance/core/security/screen_capture_protected.dart';
 import 'package:flutter_bloc_advance/shared/l10n/app_error_code_l10n.dart';
 import 'package:flutter_bloc_advance/shared/widgets/responsive_form_widget.dart';
 import 'package:flutter_bloc_advance/shared/widgets/submit_button_widget.dart';
@@ -27,6 +30,8 @@ class LoginScreen extends StatefulWidget {
   State<LoginScreen> createState() => _LoginScreenState();
 }
 
+// To opt in to screen capture protection on this screen, also add
+// `ScreenCaptureProtected<LoginScreen>,` to the `with` clause below.
 class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStateMixin {
   final GlobalKey<FormBuilderState> _loginFormKey = GlobalKey<FormBuilderState>(debugLabel: '__loginFormKey__');
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>(debugLabel: '__loginScaffoldKey__');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -828,6 +828,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  screen_protector:
+    dependency: "direct main"
+    description:
+      name: screen_protector
+      sha256: "7f53d7a0c238a62dc970841fd13053f2b79f14b7f8d2c82a11fef65b066f42cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   package_info_plus: 10.1.0
   connectivity_plus: 7.1.1
   flutter_secure_storage: 10.2.0
+  screen_protector: 1.5.1
 
 dev_dependencies:
   flutter_test:

--- a/test/core/security/screen_capture_protection_test.dart
+++ b/test/core/security/screen_capture_protection_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc_advance/core/security/screen_capture_protection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('screen_protector');
+
+  final List<MethodCall> calls = <MethodCall>[];
+
+  setUpAll(() async {
+    await TestUtils().setupUnitTest();
+  });
+
+  setUp(() {
+    calls.clear();
+    ScreenCaptureProtection.resetForTesting();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      MethodCall call,
+    ) async {
+      calls.add(call);
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    ScreenCaptureProtection.resetForTesting();
+    await TestUtils().tearDownUnitTest();
+  });
+
+  group('ScreenCaptureProtection', () {
+    test('isEnabled starts false', () {
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+    });
+
+    test('enable() flips isEnabled true and invokes both Android + iOS protect calls', () async {
+      await ScreenCaptureProtection.enable();
+      expect(ScreenCaptureProtection.isEnabled, isTrue);
+      final methods = calls.map((c) => c.method).toSet();
+      expect(methods, containsAll(<String>{'protectDataLeakageOn', 'protectDataLeakageWithBlur'}));
+    });
+
+    test('enable() is idempotent: second call does not re-invoke plugin', () async {
+      await ScreenCaptureProtection.enable();
+      calls.clear();
+      await ScreenCaptureProtection.enable();
+      expect(calls, isEmpty);
+      expect(ScreenCaptureProtection.isEnabled, isTrue);
+    });
+
+    test('disable() flips isEnabled false and invokes both off calls', () async {
+      await ScreenCaptureProtection.enable();
+      calls.clear();
+      await ScreenCaptureProtection.disable();
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+      final methods = calls.map((c) => c.method).toSet();
+      expect(methods, containsAll(<String>{'protectDataLeakageOff', 'protectDataLeakageWithBlurOff'}));
+    });
+
+    test('disable() is idempotent when already disabled: no plugin call', () async {
+      await ScreenCaptureProtection.disable();
+      expect(calls, isEmpty);
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+    });
+
+    test('plugin error during enable() is swallowed; state still flips true', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'boom');
+      });
+      await ScreenCaptureProtection.enable();
+      expect(ScreenCaptureProtection.isEnabled, isTrue);
+    });
+
+    test('web override: enable() is a true no-op, no plugin call, isEnabled stays false', () async {
+      ScreenCaptureProtection.debugWebOverride = true;
+      await ScreenCaptureProtection.enable();
+      expect(calls, isEmpty);
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+    });
+
+    test('web override: disable() is also a no-op', () async {
+      ScreenCaptureProtection.debugWebOverride = true;
+      await ScreenCaptureProtection.disable();
+      expect(calls, isEmpty);
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+    });
+  });
+}

--- a/test/core/security/screen_capture_protection_test.dart
+++ b/test/core/security/screen_capture_protection_test.dart
@@ -87,5 +87,24 @@ void main() {
       expect(calls, isEmpty);
       expect(ScreenCaptureProtection.isEnabled, isFalse);
     });
+
+    test('nested leases: protection stays on until the last lease is released', () async {
+      // Two protected screens mounted (e.g. A pushes B).
+      await ScreenCaptureProtection.enable();
+      await ScreenCaptureProtection.enable();
+      expect(ScreenCaptureProtection.isEnabled, isTrue);
+
+      // Inner screen disposed: still one lease held, protection must stay on.
+      calls.clear();
+      await ScreenCaptureProtection.disable();
+      expect(calls, isEmpty);
+      expect(ScreenCaptureProtection.isEnabled, isTrue);
+
+      // Outer screen disposed: last lease released, protection turns off.
+      await ScreenCaptureProtection.disable();
+      expect(ScreenCaptureProtection.isEnabled, isFalse);
+      final methods = calls.map((c) => c.method).toSet();
+      expect(methods, containsAll(<String>{'protectDataLeakageOff', 'protectDataLeakageWithBlurOff'}));
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Adds `ScreenCaptureProtection` static helper + `ScreenCaptureProtected` mixin under `lib/core/security/` — opt-in mechanism, **default disabled**.
- LoginScreen carries a commented-out integration example so the pattern is discoverable without imposing UX.
- README documents the **asymmetric** Android (`FLAG_SECURE`) vs iOS (task-switcher blur only — Apple provides no screenshot block) behaviour explicitly, plus the "when not to enable" cases (QR codes, receipts).

Closes #134.

## Design notes

- Plugin choice: `screen_protector: 1.5.1` (Android + iOS native plugin; cross-platform helper). `flutter_windowmanager` ruled out — Android only.
- iOS overlay: **blur**, not image. `protectDataLeakageWithImage` was deferred because it requires per-project iOS `Assets.xcassets` setup; the template can't ship that for downstream forks.
- Test seam: `@visibleForTesting bool debugWebOverride` + `resetForTesting()` — `kIsWeb` is a compile-time const and can't be flipped at runtime; this mirrors the same discipline used in `TestUtils._installSecureStorageMock`.
- Error handling: plugin failures during `enable()` / `disable()` are logged at `warn` and swallowed, but the `_enabled` flag still flips to reflect user intent. State drift between consumer expectation and plugin status is the larger footgun.

## Test plan

- [x] Unit tests: 8/8 green covering enable/disable, idempotency, plugin error swallowing, web no-op.
- [x] Full suite: 1487/1487 green.
- [x] `fvm dart analyze` — clean.
- [x] `fvm dart format --line-length=120 --set-exit-if-changed .` — clean (394 files unchanged).
- [ ] Manual Android device: screenshot key blocked + task-switcher black (deferred — needs a device).
- [ ] Manual iOS device: task-switcher snapshot blurred; screenshot still possible while foreground (deferred — needs a device).

The manual device checks are documented in the README but not executed here; they belong to a follow-up E2E pass.

## Out of scope

- Image-overlay variant on iOS (asset setup required per fork).
- `UIScreen.isCaptured` screen-recording detection on iOS — separate enhancement worth a new issue if needed.
- Per-screen automatic management via annotations — premature abstraction until a second real call site exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)