### PR TITLE
feat(#130): inactivity-based auto-logout (configurable idle timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ The screenshots below are included to help contributors and adopters understand 
 - Public and private route separation
 - Protected admin-only pages
 
+### Inactivity Auto-Logout
+
+`IdleTimeoutObserver` (`lib/core/security/`) signs the user out after a configurable window of pointer / key inactivity. Default threshold is **15 minutes** in production, **disabled** in dev/test (where hot-reload + mocked sessions would make a 15-minute kick out hostile).
+
+- Configured via `ProfileConstants.idleTimeout`. Override per environment in `lib/infrastructure/config/environment.dart` (`_Config.prodConstants[idleTimeoutSeconds]`). Set to `null` to disable.
+- Background-aware: on iOS the Dart `Timer` pauses while the app is suspended, so the observer also captures wall-clock `DateTime.now()` on lifecycle transitions; resumes past the threshold fire immediately.
+- Surfacing: when the timer fires, the user sees a localized snackbar ("You were signed out due to inactivity.") and the router redirects to login. The reason is tagged `SessionExpiredReason.idleTimeout` so logs and UI can distinguish it from a manual sign-out.
+- Activity scope: pointer down / pointer move events on the `MaterialApp.router` subtree reset the timer. Scroll-only sessions (a long-form reading view) do extend, since scroll causes pointer move events.
+
+Compliance baselines that expect inactivity timeouts: SOC2 CC6.1, ISO 27001 A.9.4.2, GDPR Art. 32.
+
 ### Server-Driven Dynamic Forms
 
 - 16 supported field types: text, email, password, number, phone, textarea,

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ The screenshots below are included to help contributors and adopters understand 
 
 ### Inactivity Auto-Logout
 
-`IdleTimeoutObserver` (`lib/core/security/`) signs the user out after a configurable window of pointer / key inactivity. Default threshold is **15 minutes** in production, **disabled** in dev/test (where hot-reload + mocked sessions would make a 15-minute kick out hostile).
+`IdleTimeoutObserver` (`lib/core/security/`) signs the user out after a configurable window of pointer inactivity. Default threshold is **15 minutes** in production, **disabled** in dev/test (where hot-reload + mocked sessions would make a 15-minute kick out hostile).
 
-- Configured via `ProfileConstants.idleTimeout`. Override per environment in `lib/infrastructure/config/environment.dart` (`_Config.prodConstants[idleTimeoutSeconds]`). Set to `null` to disable.
+- Configured via `ProfileConstants.idleTimeout`. Override per environment in `lib/infrastructure/config/environment.dart` by editing the `IDLE_TIMEOUT_SECONDS` entry (an int in seconds) of the env map (e.g. `_Config.prodConstants`). Set to `null` to disable.
 - Background-aware: on iOS the Dart `Timer` pauses while the app is suspended, so the observer also captures wall-clock `DateTime.now()` on lifecycle transitions; resumes past the threshold fire immediately.
 - Surfacing: when the timer fires, the user sees a localized snackbar ("You were signed out due to inactivity.") and the router redirects to login. The reason is tagged `SessionExpiredReason.idleTimeout` so logs and UI can distinguish it from a manual sign-out.
 - Activity scope: pointer down / pointer move events on the `MaterialApp.router` subtree reset the timer. Scroll-only sessions (a long-form reading view) do extend, since scroll causes pointer move events.

--- a/lib/app/bootstrap/app_session_listeners.dart
+++ b/lib/app/bootstrap/app_session_listeners.dart
@@ -1,13 +1,62 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_bloc_advance/app/shell/menu_bloc/menu_bloc.dart';
 import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
+import 'package:flutter_bloc_advance/app/shell/menu_bloc/menu_bloc.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/core/security/idle_timeout_observer.dart';
 import 'package:flutter_bloc_advance/features/auth/application/login_bloc.dart';
+import 'package:flutter_bloc_advance/generated/l10n.dart';
+import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 
-class AppSessionListeners extends StatelessWidget {
-  const AppSessionListeners({super.key, required this.child});
+class AppSessionListeners extends StatefulWidget {
+  const AppSessionListeners({super.key, required this.child, this.idleTimeoutOverride});
 
   final Widget child;
+
+  /// Test seam — lets a widget test inject a smaller threshold than
+  /// production without re-pointing [ProfileConstants]. Null falls back
+  /// to [ProfileConstants.idleTimeout].
+  final Duration? idleTimeoutOverride;
+
+  @override
+  State<AppSessionListeners> createState() => _AppSessionListenersState();
+}
+
+class _AppSessionListenersState extends State<AppSessionListeners> {
+  static final _log = AppLogger.getLogger('AppSessionListeners');
+
+  IdleTimeoutObserver? _idleObserver;
+
+  @override
+  void dispose() {
+    _idleObserver?.stop();
+    _idleObserver = null;
+    super.dispose();
+  }
+
+  void _startIdleObserver() {
+    if (_idleObserver != null) return;
+    final threshold = widget.idleTimeoutOverride ?? ProfileConstants.idleTimeout;
+    if (threshold == null) {
+      _log.debug('idle timeout disabled (no threshold configured)');
+      return;
+    }
+    final cubit = context.read<SessionCubit>();
+    final observer = IdleTimeoutObserver(
+      idleThreshold: threshold,
+      onTimeout: () {
+        _log.info('idle timeout fired — signing out');
+        cubit.markLoggedOut(reason: SessionExpiredReason.idleTimeout);
+      },
+    );
+    observer.start();
+    _idleObserver = observer;
+  }
+
+  void _stopIdleObserver() {
+    _idleObserver?.stop();
+    _idleObserver = null;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,8 +78,35 @@ class AppSessionListeners extends StatelessWidget {
             }
           },
         ),
+        BlocListener<SessionCubit, SessionState>(
+          listenWhen: (previous, current) => previous.runtimeType != current.runtimeType,
+          listener: (context, state) {
+            switch (state) {
+              case SessionAuthenticated():
+                _startIdleObserver();
+              case SessionUnauthenticated(:final reason):
+                _stopIdleObserver();
+                if (reason == SessionExpiredReason.idleTimeout) {
+                  _showIdleTimeoutNotice(context);
+                }
+              case SessionUnknown():
+                break;
+            }
+          },
+        ),
       ],
-      child: child,
+      child: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: (_) => _idleObserver?.recordActivity(),
+        onPointerMove: (_) => _idleObserver?.recordActivity(),
+        child: widget.child,
+      ),
     );
+  }
+
+  void _showIdleTimeoutNotice(BuildContext context) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger.showSnackBar(SnackBar(content: Text(S.of(context).idle_timeout_signed_out)));
   }
 }

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -64,6 +64,11 @@ enum SessionExpiredReason {
   /// [SessionUnknown] forever.
   storageError,
 
+  /// User was inactive past the configured idle threshold and the
+  /// session was forcibly ended. Surfaced to the UI as a localized
+  /// notice so the user understands why they were signed out.
+  idleTimeout,
+
   /// Initial or otherwise uncategorized — e.g. an explicit logout
   /// flow that does not need to distinguish further.
   unknown,

--- a/lib/core/security/idle_timeout_observer.dart
+++ b/lib/core/security/idle_timeout_observer.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+
+/// Callback fired when the user has been inactive past the configured
+/// idle threshold. Wiring layer translates this to
+/// `SessionCubit.markLoggedOut(reason: SessionExpiredReason.idleTimeout)`.
+typedef OnIdleTimeout = void Function();
+
+/// Inactivity-based auto-logout helper.
+///
+/// **Wiring contract.** The observer is a passive object: it owns a
+/// [Timer] that fires after [idleThreshold] of no activity and a
+/// [WidgetsBindingObserver] registration that handles background /
+/// foreground transitions. It does **not** know about session state or
+/// the widget tree. The integration layer (see `AppSessionListeners`)
+/// starts it when authenticated, stops it on logout, and pumps
+/// [recordActivity] from a top-level pointer / key listener.
+///
+/// **Background timing.** Dart [Timer]s pause on iOS while the app is
+/// backgrounded. Relying on the timer alone would let a 12-hour
+/// background pass and the user would still be logged in on resume.
+/// The lifecycle callback captures `_backgroundedAt = clock()` on
+/// pause and computes elapsed wall time on resume — if the elapsed
+/// time exceeds [idleThreshold], it fires immediately; otherwise it
+/// resumes the timer with the remaining duration.
+///
+/// **Disabled mode.** Passing `idleThreshold: null` makes every method
+/// a no-op so a template fork can ship with idle-timeout off without
+/// per-call-site conditionals.
+class IdleTimeoutObserver with WidgetsBindingObserver {
+  IdleTimeoutObserver({required this.idleThreshold, required this.onTimeout, DateTime Function()? clock})
+    : _clock = clock ?? DateTime.now;
+
+  /// Inactivity window before [onTimeout] fires. `null` disables the
+  /// observer entirely.
+  final Duration? idleThreshold;
+
+  /// Callback fired on timeout. Wired by integration layer to logout.
+  final OnIdleTimeout onTimeout;
+
+  /// Wall-clock source. Injected so tests can drive elapsed time
+  /// without sleeping.
+  final DateTime Function() _clock;
+
+  static final _log = AppLogger.getLogger('IdleTimeoutObserver');
+
+  Timer? _timer;
+  DateTime? _backgroundedAt;
+  bool _started = false;
+
+  /// Registers the lifecycle observer and starts the idle timer.
+  /// Idempotent: a second call while already started is a no-op.
+  void start() {
+    if (idleThreshold == null || _started) return;
+    WidgetsBinding.instance.addObserver(this);
+    _resetTimer();
+    _started = true;
+    _log.debug('start — threshold={}s', [idleThreshold!.inSeconds]);
+  }
+
+  /// Cancels the timer and removes the lifecycle observer.
+  /// Idempotent: a second call after stop is a no-op.
+  void stop() {
+    if (!_started) return;
+    _timer?.cancel();
+    _timer = null;
+    _backgroundedAt = null;
+    WidgetsBinding.instance.removeObserver(this);
+    _started = false;
+    _log.debug('stop');
+  }
+
+  /// Pings the observer from the activity listener. Resets the timer
+  /// so the user has another [idleThreshold] window of inactivity
+  /// before logout.
+  void recordActivity() {
+    if (!_started || idleThreshold == null) return;
+    _resetTimer();
+  }
+
+  void _resetTimer() {
+    final threshold = idleThreshold;
+    if (threshold == null) return;
+    _timer?.cancel();
+    _timer = Timer(threshold, _fire);
+  }
+
+  void _fire() {
+    _log.info('idle threshold reached — firing onTimeout');
+    onTimeout();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (idleThreshold == null) return;
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.inactive:
+        // Capture background instant once. The first pause-style
+        // transition wins; subsequent ones do not re-anchor (e.g.
+        // hidden after paused). We only care about the earliest
+        // moment of no-foreground.
+        _backgroundedAt ??= _clock();
+        _timer?.cancel();
+        _timer = null;
+      case AppLifecycleState.resumed:
+        final backgroundedAt = _backgroundedAt;
+        _backgroundedAt = null;
+        if (backgroundedAt == null) return;
+        final elapsed = _clock().difference(backgroundedAt);
+        if (elapsed >= idleThreshold!) {
+          _log.info('resumed after {}s of background (threshold {}s) — firing timeout', [
+            elapsed.inSeconds,
+            idleThreshold!.inSeconds,
+          ]);
+          _fire();
+          return;
+        }
+        final remaining = idleThreshold! - elapsed;
+        _log.debug('resumed; remaining {}ms before timeout', [remaining.inMilliseconds]);
+        _timer = Timer(remaining, _fire);
+      case AppLifecycleState.detached:
+        // Process is detaching; stop() will be called by the host or
+        // the app is closing. No work here.
+        break;
+    }
+  }
+}

--- a/lib/core/security/idle_timeout_observer.dart
+++ b/lib/core/security/idle_timeout_observer.dart
@@ -17,7 +17,7 @@ typedef OnIdleTimeout = void Function();
 /// foreground transitions. It does **not** know about session state or
 /// the widget tree. The integration layer (see `AppSessionListeners`)
 /// starts it when authenticated, stops it on logout, and pumps
-/// [recordActivity] from a top-level pointer / key listener.
+/// [recordActivity] from a top-level pointer listener.
 ///
 /// **Background timing.** Dart [Timer]s pause on iOS while the app is
 /// backgrounded. Relying on the timer alone would let a 12-hour
@@ -47,8 +47,15 @@ class IdleTimeoutObserver with WidgetsBindingObserver {
 
   static final _log = AppLogger.getLogger('IdleTimeoutObserver');
 
+  /// Minimum spacing between two activity records. High-frequency signals
+  /// (e.g. `onPointerMove` during a drag/scroll) would otherwise cancel and
+  /// recreate the timer on every event; throttling collapses that churn while
+  /// staying well below any realistic [idleThreshold].
+  static const Duration _activityThrottle = Duration(seconds: 1);
+
   Timer? _timer;
   DateTime? _backgroundedAt;
+  DateTime? _lastActivity;
   bool _started = false;
 
   /// Registers the lifecycle observer and starts the idle timer.
@@ -68,6 +75,7 @@ class IdleTimeoutObserver with WidgetsBindingObserver {
     _timer?.cancel();
     _timer = null;
     _backgroundedAt = null;
+    _lastActivity = null;
     WidgetsBinding.instance.removeObserver(this);
     _started = false;
     _log.debug('stop');
@@ -78,6 +86,10 @@ class IdleTimeoutObserver with WidgetsBindingObserver {
   /// before logout.
   void recordActivity() {
     if (!_started || idleThreshold == null) return;
+    final now = _clock();
+    final last = _lastActivity;
+    if (last != null && now.difference(last) < _activityThrottle) return;
+    _lastActivity = now;
     _resetTimer();
   }
 

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -81,6 +81,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "guest": MessageLookupByLibrary.simpleMessage("Guest"),
     "help_resources": MessageLookupByLibrary.simpleMessage("Help & Resources"),
     "help_resources_subtitle": MessageLookupByLibrary.simpleMessage("Visit our website for documentation and guides"),
+    "idle_timeout_signed_out": MessageLookupByLibrary.simpleMessage("You were signed out due to inactivity."),
     "invalid_email": MessageLookupByLibrary.simpleMessage("Invalid email address"),
     "just_now": MessageLookupByLibrary.simpleMessage("just now"),
     "language": MessageLookupByLibrary.simpleMessage("Language"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -79,6 +79,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "help_resources_subtitle": MessageLookupByLibrary.simpleMessage(
       "Dokümantasyon ve rehberler için web sitemizi ziyaret edin",
     ),
+    "idle_timeout_signed_out": MessageLookupByLibrary.simpleMessage("Hareketsizlik nedeniyle oturumunuz kapatıldı."),
     "invalid_email": MessageLookupByLibrary.simpleMessage("Geçersiz e-posta adresi"),
     "just_now": MessageLookupByLibrary.simpleMessage("az önce"),
     "language": MessageLookupByLibrary.simpleMessage("Dil"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -728,6 +728,11 @@ class S {
   String user_extended_info_save_failed(String error) {
     return Intl.message('Save failed: $error', name: 'user_extended_info_save_failed', desc: '', args: [error]);
   }
+
+  /// `You were signed out due to inactivity.`
+  String get idle_timeout_signed_out {
+    return Intl.message('You were signed out due to inactivity.', name: 'idle_timeout_signed_out', desc: '', args: []);
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/infrastructure/config/environment.dart
+++ b/lib/infrastructure/config/environment.dart
@@ -38,14 +38,29 @@ class ProfileConstants {
   static dynamic get api {
     return _config![_Config.api];
   }
+
+  /// Inactivity threshold for auto-logout. `null` disables the
+  /// [IdleTimeoutObserver]; downstream forks override by editing
+  /// [_Config.prodConstants] (or any env map). Stored as an int (seconds)
+  /// in the map so the config can stay a plain `Map<String, dynamic>`.
+  static Duration? get idleTimeout {
+    final raw = _config?[_Config.idleTimeoutSeconds];
+    if (raw is! int || raw <= 0) return null;
+    return Duration(seconds: raw);
+  }
 }
 
 class _Config {
   static const api = "API";
+  static const idleTimeoutSeconds = "IDLE_TIMEOUT_SECONDS";
 
-  static Map<String, dynamic> devConstants = {api: "mock"};
+  /// Dev / test default: disabled. Mocked sessions and rapid hot-reload
+  /// flows would be hostile if the observer logged the user out mid-edit.
+  static Map<String, dynamic> devConstants = {api: "mock", idleTimeoutSeconds: null};
 
-  static Map<String, dynamic> testConstants = {api: "mock"};
+  static Map<String, dynamic> testConstants = {api: "mock", idleTimeoutSeconds: null};
 
-  static Map<String, dynamic> prodConstants = {api: TemplateConfig.prodApiUrl};
+  /// Production default: 15 minutes. Industry baseline for non-financial
+  /// apps; financial-grade forks should lower to 5 minutes.
+  static Map<String, dynamic> prodConstants = {api: TemplateConfig.prodApiUrl, idleTimeoutSeconds: 15 * 60};
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -138,5 +138,7 @@
         "type": "String"
       }
     }
-  }
+  },
+  "idle_timeout_signed_out": "You were signed out due to inactivity.",
+  "@idle_timeout_signed_out": {}
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -138,5 +138,7 @@
         "type": "String"
       }
     }
-  }
+  },
+  "idle_timeout_signed_out": "Hareketsizlik nedeniyle oturumunuz kapatıldı.",
+  "@idle_timeout_signed_out": {}
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -250,7 +250,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dev_dependencies:
   test: 1.31.0
   bloc_test: 10.0.0
   mocktail: 1.0.5
+  fake_async: 1.3.3
   shared_preferences_platform_interface: 2.4.2
   device_preview: 1.3.1
 

--- a/test/core/security/idle_timeout_observer_test.dart
+++ b/test/core/security/idle_timeout_observer_test.dart
@@ -1,0 +1,144 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc_advance/core/security/idle_timeout_observer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await TestUtils().setupUnitTest();
+  });
+
+  tearDownAll(() async {
+    await TestUtils().tearDownUnitTest();
+  });
+
+  group('IdleTimeoutObserver', () {
+    test('disabled (null threshold): timeout never fires regardless of inactivity', () {
+      fakeAsync((async) {
+        var fired = 0;
+        final observer = IdleTimeoutObserver(idleThreshold: null, onTimeout: () => fired++);
+        observer.start();
+
+        async.elapse(const Duration(hours: 24));
+
+        expect(fired, 0);
+        observer.stop();
+      });
+    });
+
+    test('fires onTimeout after idleThreshold of inactivity', () {
+      fakeAsync((async) {
+        var fired = 0;
+        final observer = IdleTimeoutObserver(idleThreshold: const Duration(minutes: 5), onTimeout: () => fired++);
+        observer.start();
+
+        async.elapse(const Duration(minutes: 4));
+        expect(fired, 0);
+
+        async.elapse(const Duration(minutes: 1, milliseconds: 1));
+        expect(fired, 1);
+
+        observer.stop();
+      });
+    });
+
+    test('recordActivity resets the timer; timeout does not fire if activity is within threshold', () {
+      fakeAsync((async) {
+        var fired = 0;
+        final observer = IdleTimeoutObserver(idleThreshold: const Duration(minutes: 5), onTimeout: () => fired++);
+        observer.start();
+
+        for (var i = 0; i < 10; i++) {
+          async.elapse(const Duration(minutes: 4));
+          observer.recordActivity();
+        }
+        // Cumulative wall time = 40 minutes, but each tick reset before threshold.
+        expect(fired, 0);
+
+        // Now stop pinging; the timer should expire 5 minutes later.
+        async.elapse(const Duration(minutes: 5, milliseconds: 1));
+        expect(fired, 1);
+
+        observer.stop();
+      });
+    });
+
+    test('stop() cancels the timer; no further timeouts fire', () {
+      fakeAsync((async) {
+        var fired = 0;
+        final observer = IdleTimeoutObserver(idleThreshold: const Duration(minutes: 5), onTimeout: () => fired++);
+        observer.start();
+        observer.stop();
+
+        async.elapse(const Duration(hours: 1));
+        expect(fired, 0);
+      });
+    });
+
+    test('background-to-foreground elapsed past threshold: timeout fires on resume', () {
+      // Cannot use fakeAsync here because didChangeAppLifecycleState reads
+      // wall-clock DateTime.now() to compute elapsed; use a clock seam.
+      var fired = 0;
+      var now = DateTime(2026, 5, 21, 12);
+      final observer = IdleTimeoutObserver(
+        idleThreshold: const Duration(minutes: 5),
+        onTimeout: () => fired++,
+        clock: () => now,
+      );
+      observer.start();
+
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      now = now.add(const Duration(minutes: 10));
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(fired, 1);
+      observer.stop();
+    });
+
+    test('background-to-foreground within threshold: timer resumes with remaining duration', () {
+      fakeAsync((async) {
+        var fired = 0;
+        var now = DateTime(2026, 5, 21, 12);
+        final observer = IdleTimeoutObserver(
+          idleThreshold: const Duration(minutes: 5),
+          onTimeout: () => fired++,
+          clock: () => now,
+        );
+        observer.start();
+
+        // 1 minute in foreground, then background for 3 minutes.
+        async.elapse(const Duration(minutes: 1));
+        now = now.add(const Duration(minutes: 1));
+        observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        now = now.add(const Duration(minutes: 3));
+        observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+        // After resume, remaining is 5 - 3 = 2 minutes from the resume instant.
+        expect(fired, 0);
+        async.elapse(const Duration(minutes: 1, seconds: 59));
+        expect(fired, 0);
+        async.elapse(const Duration(seconds: 2));
+        expect(fired, 1);
+
+        observer.stop();
+      });
+    });
+
+    test('disabled observer is unaffected by lifecycle callbacks', () {
+      var fired = 0;
+      final observer = IdleTimeoutObserver(idleThreshold: null, onTimeout: () => fired++);
+      observer.start();
+
+      observer.didChangeAppLifecycleState(AppLifecycleState.paused);
+      observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      expect(fired, 0);
+      observer.stop();
+    });
+  });
+}

--- a/test/core/security/idle_timeout_observer_test.dart
+++ b/test/core/security/idle_timeout_observer_test.dart
@@ -49,17 +49,49 @@ void main() {
     test('recordActivity resets the timer; timeout does not fire if activity is within threshold', () {
       fakeAsync((async) {
         var fired = 0;
-        final observer = IdleTimeoutObserver(idleThreshold: const Duration(minutes: 5), onTimeout: () => fired++);
+        var now = DateTime(2026, 5, 21, 12);
+        final observer = IdleTimeoutObserver(
+          idleThreshold: const Duration(minutes: 5),
+          onTimeout: () => fired++,
+          clock: () => now,
+        );
         observer.start();
 
         for (var i = 0; i < 10; i++) {
           async.elapse(const Duration(minutes: 4));
+          now = now.add(const Duration(minutes: 4));
           observer.recordActivity();
         }
         // Cumulative wall time = 40 minutes, but each tick reset before threshold.
         expect(fired, 0);
 
         // Now stop pinging; the timer should expire 5 minutes later.
+        async.elapse(const Duration(minutes: 5, milliseconds: 1));
+        expect(fired, 1);
+
+        observer.stop();
+      });
+    });
+
+    test('recordActivity is throttled: rapid pings within the throttle window reset the timer only once', () {
+      fakeAsync((async) {
+        var fired = 0;
+        var now = DateTime(2026, 5, 21, 12);
+        final observer = IdleTimeoutObserver(
+          idleThreshold: const Duration(minutes: 5),
+          onTimeout: () => fired++,
+          clock: () => now,
+        );
+        observer.start();
+
+        // Burst of high-frequency activity (e.g. pointer move during a drag)
+        // all landing inside the 1s throttle window: only the first records.
+        for (var i = 0; i < 100; i++) {
+          observer.recordActivity();
+        }
+
+        // The first ping reset the timer at t=0; throttled pings did not. So the
+        // timeout still fires 5 minutes after that first (and only) reset.
         async.elapse(const Duration(minutes: 5, milliseconds: 1));
         expect(fired, 1);
 


### PR DESCRIPTION
## Summary

- New `IdleTimeoutObserver` in `lib/core/security/` — Timer + `WidgetsBindingObserver` with injectable clock.
- Wired through `AppSessionListeners` (now Stateful): observer starts on `SessionAuthenticated`, stops on `SessionUnauthenticated`, activity pinged from a top-level `Listener`.
- Default threshold: **15 minutes in production, disabled in dev/test** (configurable per env in `ProfileConstants`).
- `SessionExpiredReason.idleTimeout` added; localized snackbar surfaces the reason to the user (en + tr).

Closes #130.

## Design notes

- **Architecture guard preserved.** `core/` cannot import `app/`. The observer takes a `void Function()` callback; `AppSessionListeners` translates that to `SessionCubit.markLoggedOut(reason: SessionExpiredReason.idleTimeout)`. Same pattern as `OnSessionExpired` in `TokenRefreshInterceptor`.
- **Background timing.** iOS pauses Dart `Timer`s in background, so the observer also captures wall-clock `DateTime.now()` on lifecycle transitions. On `resumed`, elapsed wall time is computed; if it exceeds the threshold the timeout fires immediately, otherwise the timer resumes with the remaining duration. Without this, a 12-hour background pass would leave the session alive on resume.
- **Disabled mode is a real no-op.** Passing `idleThreshold: null` makes every method short-circuit and skips lifecycle observer registration. Forks that want it off pay zero runtime cost.
- **Activity scope.** Pointer down / pointer move via top-level `Listener` (translucent hit-test). No keyboard events yet — defer until a real need (most form inputs already produce pointer events when focused).

## Test plan

- [x] `IdleTimeoutObserver` unit tests (7): disabled mode, fires after threshold, recordActivity resets, stop cancels, background-elapsed-past-threshold fires on resume, background-within-threshold resumes with remaining, disabled ignores lifecycle.
- [x] Uses `fake_async` + injectable `clock` — added as direct dev_dependency (was transitive).
- [x] Full suite: 1486/1486 green.
- [x] `fvm dart analyze` — clean.
- [x] `fvm dart format --line-length=120 --set-exit-if-changed .` — clean.
- [ ] Manual device run: leave the app for 16 minutes, confirm redirect to login + snackbar. **Not executed in this PR** — best done on real iOS/Android hardware as part of the next release sanity check.

## Out of scope

- 30-second warning dialog before logout. Issue marked it a stretch; second timer + focus management edge case. Defer to a follow-up if a real UX ask appears.
- Per-screen overrides (e.g. don't time out on a long-form video). No call site needs it yet.
- Keyboard event activity. Pointer is sufficient for current UX.
- Server-side session invalidation. Backend concern.

## Threshold guidance

| Profile | Recommended | Rationale |
| --- | --- | --- |
| Generic B2C / B2B | 15 min (default) | Industry baseline; SOC2 / ISO 27001 expectations |
| Fintech / healthcare | 5 min | Stricter compliance floor (HIPAA, PCI-DSS contexts) |
| Internal enterprise tools | 30 min | Higher friction tolerated; explicit business owner sign-off recommended |

Forks override via `_Config.prodConstants[idleTimeoutSeconds]` in `environment.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)