### PR TITLE
feat(#133): configurable certificate pinning for production HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,35 @@ The screenshots below are included to help contributors and adopters understand 
 - Public and private route separation
 - Protected admin-only pages
 
+### Certificate Pinning (opt-in)
+
+The HTTP client supports certificate pinning to defend against MITM via user-installed root CAs, rogue intermediates, and other forms of device-trust-store compromise. **Default off** — the template ships with an empty pin list because pinning the wrong cert bricks every install.
+
+How it works:
+
+- `ProfileConstants.certificatePins` is a `List<String>` of base64 SHA-256 hashes. Empty list = pinning disabled (use system trust); non-empty list installs a custom Dio adapter that uses `SecurityContext(withTrustedRoots: false)` so **every** certificate falls through `badCertificateCallback` for pin checking. This is the only correct way to enforce pinning even against system-trusted but adversarial CAs.
+- Pin mismatch → `DioExceptionType.badCertificate`, which `ResilienceInterceptor` already treats as non-retryable. `AppErrorCode.networkCertInvalid` is available for repository-layer code paths that want to surface a typed error.
+- **Web platform is a hard no-op.** Browsers control TLS; from JS we cannot intercept the handshake. Use HSTS / CT pinning at the server side instead.
+
+Extract pins from your live backend:
+
+```shell
+openssl s_client -servername api.example.com -connect api.example.com:443 < /dev/null 2>/dev/null \
+  | openssl x509 -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64
+```
+
+(**v1 caveat — full-cert hash, not SPKI.** The OWASP-recommended pin is `SHA-256(SubjectPublicKeyInfo)`, which survives certificate rotation as long as the keypair is reused. Extracting SPKI from X.509 DER requires ASN.1 parsing; we ship full-cert hash for simplicity and auditability. Stored pin shape stays identical when upgrading — only the hash input changes. Track this gap in your fork before adopting in production.)
+
+Key rotation procedure:
+
+1. Add the new (backup) pin to `certificatePins` **before** rotating server keys. Ship that app version.
+2. Rotate server certs to the new keypair.
+3. In a later release, remove the old pin.
+
+This avoids a window where in-flight users with the old app version cannot reach the new cert.
+
 ### Server-Driven Dynamic Forms
 
 - 16 supported field types: text, email, password, number, phone, textarea,

--- a/lib/core/errors/app_error_code.dart
+++ b/lib/core/errors/app_error_code.dart
@@ -33,6 +33,9 @@ enum AppErrorCode {
   // --- settings ---
   settingsChangeLanguageFailed('settings.change_language_failed'),
 
+  // --- network ---
+  networkCertInvalid('network.cert_invalid'),
+
   // --- generic fallback ---
   generic('error.generic');
 

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -72,6 +72,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "error_auth_send_otp_failed": MessageLookupByLibrary.simpleMessage("Could not send the OTP code"),
     "error_auth_session_persist_failed": MessageLookupByLibrary.simpleMessage("Could not save the session"),
     "error_generic": MessageLookupByLibrary.simpleMessage("Something went wrong"),
+    "error_network_cert_invalid": MessageLookupByLibrary.simpleMessage(
+      "Could not verify the server\'s identity. Connection blocked.",
+    ),
     "error_settings_change_language_failed": MessageLookupByLibrary.simpleMessage("Could not change the language"),
     "error_user_cannot_delete_admin": MessageLookupByLibrary.simpleMessage("Admin user cannot be deleted"),
     "error_user_no_authorities": MessageLookupByLibrary.simpleMessage("No authorities found"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -68,6 +68,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "error_auth_send_otp_failed": MessageLookupByLibrary.simpleMessage("OTP kodu gönderilemedi"),
     "error_auth_session_persist_failed": MessageLookupByLibrary.simpleMessage("Oturum kaydedilemedi"),
     "error_generic": MessageLookupByLibrary.simpleMessage("Bir şeyler ters gitti"),
+    "error_network_cert_invalid": MessageLookupByLibrary.simpleMessage(
+      "Sunucu kimliği doğrulanamadı. Bağlantı engellendi.",
+    ),
     "error_settings_change_language_failed": MessageLookupByLibrary.simpleMessage("Dil değiştirilemedi"),
     "error_user_cannot_delete_admin": MessageLookupByLibrary.simpleMessage("Yönetici kullanıcı silinemez"),
     "error_user_no_authorities": MessageLookupByLibrary.simpleMessage("Yetki bulunamadı"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -728,6 +728,16 @@ class S {
   String user_extended_info_save_failed(String error) {
     return Intl.message('Save failed: $error', name: 'user_extended_info_save_failed', desc: '', args: [error]);
   }
+
+  /// `Could not verify the server's identity. Connection blocked.`
+  String get error_network_cert_invalid {
+    return Intl.message(
+      'Could not verify the server\'s identity. Connection blocked.',
+      name: 'error_network_cert_invalid',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/infrastructure/config/environment.dart
+++ b/lib/infrastructure/config/environment.dart
@@ -38,14 +38,32 @@ class ProfileConstants {
   static dynamic get api {
     return _config![_Config.api];
   }
+
+  /// Pinned certificate SHA-256 hashes (base64, e.g. produced by
+  /// `openssl dgst -sha256 -binary | openssl enc -base64`).
+  /// Empty list = pinning disabled (default).
+  ///
+  /// See `lib/infrastructure/http/certificate_pinning_adapter.dart` for
+  /// the live validation behaviour, and the README "Certificate Pinning"
+  /// section for the extraction one-liner + key-rotation procedure.
+  static List<String> get certificatePins {
+    final raw = _config?[_Config.certificatePins];
+    if (raw is! List) return const [];
+    return raw.whereType<String>().toList(growable: false);
+  }
 }
 
 class _Config {
   static const api = "API";
+  static const certificatePins = "CERTIFICATE_PINS";
 
-  static Map<String, dynamic> devConstants = {api: "mock"};
+  static Map<String, dynamic> devConstants = {api: "mock", certificatePins: <String>[]};
 
-  static Map<String, dynamic> testConstants = {api: "mock"};
+  static Map<String, dynamic> testConstants = {api: "mock", certificatePins: <String>[]};
 
-  static Map<String, dynamic> prodConstants = {api: TemplateConfig.prodApiUrl};
+  /// Production default: pinning ships disabled (empty list). Add
+  /// base64 SHA-256 pins extracted from your live backend's certificate
+  /// to enable. Backup pin support is automatic — list two and rotate
+  /// per the README procedure.
+  static Map<String, dynamic> prodConstants = {api: TemplateConfig.prodApiUrl, certificatePins: <String>[]};
 }

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_bloc_advance/core/errors/app_api_exception.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/certificate_pinning_adapter.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/auth_interceptor.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/connectivity_interceptor.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/cache_interceptor.dart';
@@ -130,6 +131,16 @@ class ApiClient {
         headers: {'Accept': 'application/json', 'Content-Type': 'application/json'},
       ),
     );
+
+    // Certificate pinning. Empty pin list (default) keeps the system
+    // adapter; populating ProfileConstants.certificatePins swaps in a
+    // pinning adapter that fails closed on any non-matching cert. Web
+    // is a hard no-op — see buildPinnedAdapter docs.
+    final pins = ProfileConstants.certificatePins;
+    if (pins.isNotEmpty) {
+      _log.info('Installing certificate pinning adapter ({} pin(s))', [pins.length]);
+      dio.httpClientAdapter = buildPinnedAdapter(pins);
+    }
 
     // Single source of truth for the chain: each entry pairs the live
     // [Interceptor] with the human-readable metadata that the dashboard

--- a/lib/infrastructure/http/certificate_pinner.dart
+++ b/lib/infrastructure/http/certificate_pinner.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+/// Pure pin-matcher: SHA-256 the certificate DER, base64-encode it, and
+/// check membership against a list of expected pins.
+///
+/// **v1 caveat — full-cert hash, not SPKI hash.** The IETF / OWASP
+/// recommended pin format is `SHA-256(SubjectPublicKeyInfo)`, which
+/// survives certificate rotation as long as the keypair is reused.
+/// Extracting SPKI bytes from an X.509 cert requires ASN.1 parsing
+/// (e.g. via `asn1lib`). We start with the full-cert hash to keep the
+/// dep surface small and the implementation auditable. Forks needing
+/// rotation-resilient pinning should swap to SPKI in a follow-up — the
+/// pin storage shape (base64 SHA-256 string in
+/// `Environment.certificatePins`) stays identical; only this
+/// computation changes.
+///
+/// **Comparison is constant-time-equivalent.** Both inputs are base64
+/// strings of the same length; Dart's String `==` is non-secret-safe
+/// in principle but the pin list is local config (not user-supplied),
+/// so timing attacks have no leverage here.
+class CertificatePinner {
+  CertificatePinner._();
+
+  /// True if `pins` contains the SHA-256 hash of `certDer`. Returns
+  /// false on an empty pin list — disabled mode is enforced one level
+  /// up (adapter wiring), so an empty list reaching this function means
+  /// something is misconfigured and the safe default is "fail closed".
+  static bool matches(Uint8List certDer, List<String> pins) {
+    if (pins.isEmpty) return false;
+    final pin = computePin(certDer);
+    for (final expected in pins) {
+      if (expected == pin) return true;
+    }
+    return false;
+  }
+
+  /// Compute the base64-encoded SHA-256 of `certDer`. The canonical
+  /// pin format used by the OpenSSL one-liner in the README.
+  static String computePin(Uint8List certDer) {
+    return base64.encode(sha256.convert(certDer).bytes);
+  }
+}

--- a/lib/infrastructure/http/certificate_pinning_adapter.dart
+++ b/lib/infrastructure/http/certificate_pinning_adapter.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/certificate_pinner.dart';
+
+/// Returns the [HttpClientAdapter] Dio should use given the pin
+/// configuration:
+///
+/// - **Empty pins or web platform** → default adapter (`IOHttpClientAdapter`
+///   with system trust). Pinning is disabled; behaviour matches today.
+/// - **Non-empty pins on mobile/desktop** → custom adapter that builds
+///   `HttpClient` instances with `SecurityContext(withTrustedRoots: false)`
+///   so **every** certificate falls through `badCertificateCallback` (the
+///   only way to enforce pinning even against system-trusted but
+///   adversarial CAs — e.g. a corporate MITM proxy or malware-installed
+///   root). The callback returns true only when the live cert matches
+///   one of the configured pins; otherwise Dio raises
+///   `DioExceptionType.badCertificate`, which `ResilienceInterceptor`
+///   already treats as non-retryable.
+///
+/// Web is a hard no-op: browsers control TLS validation; from JS we
+/// cannot intercept the handshake. Forks running on web should pin via
+/// HTTP-layer signals (HSTS, CT) instead.
+HttpClientAdapter buildPinnedAdapter(List<String> pins) {
+  if (kIsWeb || pins.isEmpty) {
+    return IOHttpClientAdapter();
+  }
+  return IOHttpClientAdapter()
+    ..createHttpClient = () {
+      final ctx = SecurityContext(withTrustedRoots: false);
+      final client = HttpClient(context: ctx);
+      client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+        final accepted = CertificatePinner.matches(cert.der, pins);
+        if (!accepted) {
+          AppLogger.getLogger(
+            'CertificatePinningAdapter',
+          ).warn('Pin mismatch — rejecting connection to {}:{} (subject={})', [host, port, cert.subject]);
+        }
+        return accepted;
+      };
+      return client;
+    };
+}

--- a/lib/infrastructure/http/certificate_pinning_adapter.dart
+++ b/lib/infrastructure/http/certificate_pinning_adapter.dart
@@ -1,46 +1,13 @@
-import 'dart:io';
-
-import 'package:dio/dio.dart';
-import 'package:dio/io.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/certificate_pinner.dart';
-
-/// Returns the [HttpClientAdapter] Dio should use given the pin
-/// configuration:
+/// Platform-dispatching entry point for the certificate-pinning Dio adapter.
 ///
-/// - **Empty pins or web platform** → default adapter (`IOHttpClientAdapter`
-///   with system trust). Pinning is disabled; behaviour matches today.
-/// - **Non-empty pins on mobile/desktop** → custom adapter that builds
-///   `HttpClient` instances with `SecurityContext(withTrustedRoots: false)`
-///   so **every** certificate falls through `badCertificateCallback` (the
-///   only way to enforce pinning even against system-trusted but
-///   adversarial CAs — e.g. a corporate MITM proxy or malware-installed
-///   root). The callback returns true only when the live cert matches
-///   one of the configured pins; otherwise Dio raises
-///   `DioExceptionType.badCertificate`, which `ResilienceInterceptor`
-///   already treats as non-retryable.
+/// Importers (e.g. `ApiClient`) get the IO implementation on mobile/desktop and
+/// a no-op browser implementation on web — both expose the same
+/// `HttpClientAdapter buildPinnedAdapter(List<String> pins)` signature.
 ///
-/// Web is a hard no-op: browsers control TLS validation; from JS we
-/// cannot intercept the handshake. Forks running on web should pin via
-/// HTTP-layer signals (HSTS, CT) instead.
-HttpClientAdapter buildPinnedAdapter(List<String> pins) {
-  if (kIsWeb || pins.isEmpty) {
-    return IOHttpClientAdapter();
-  }
-  return IOHttpClientAdapter()
-    ..createHttpClient = () {
-      final ctx = SecurityContext(withTrustedRoots: false);
-      final client = HttpClient(context: ctx);
-      client.badCertificateCallback = (X509Certificate cert, String host, int port) {
-        final accepted = CertificatePinner.matches(cert.der, pins);
-        if (!accepted) {
-          AppLogger.getLogger(
-            'CertificatePinningAdapter',
-          ).warn('Pin mismatch — rejecting connection to {}:{} (subject={})', [host, port, cert.subject]);
-        }
-        return accepted;
-      };
-      return client;
-    };
-}
+/// The conditional export defaults to the web stub and selects the `dart:io`
+/// implementation only when `dart:io` is available, so web builds (JS and WASM)
+/// never attempt to compile `dart:io` / `dio/io.dart`. A `kIsWeb` runtime guard
+/// alone is insufficient because the import itself must compile on web.
+library;
+
+export 'certificate_pinning_adapter_web.dart' if (dart.library.io) 'certificate_pinning_adapter_io.dart';

--- a/lib/infrastructure/http/certificate_pinning_adapter_io.dart
+++ b/lib/infrastructure/http/certificate_pinning_adapter_io.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/certificate_pinner.dart';
+
+/// IO (mobile/desktop) build of [buildPinnedAdapter].
+///
+/// - **Empty pins** → default adapter (`IOHttpClientAdapter` with system
+///   trust). Pinning is disabled; behaviour matches today.
+/// - **Non-empty pins** → custom adapter that builds `HttpClient` instances
+///   with `SecurityContext(withTrustedRoots: false)` so **every** certificate
+///   falls through `badCertificateCallback` (the only way to enforce pinning
+///   even against system-trusted but adversarial CAs — e.g. a corporate MITM
+///   proxy or malware-installed root). The callback returns true only when the
+///   live cert matches one of the configured pins; otherwise Dio raises
+///   `DioExceptionType.badCertificate`, which `ResilienceInterceptor` already
+///   treats as non-retryable.
+HttpClientAdapter buildPinnedAdapter(List<String> pins) {
+  if (pins.isEmpty) {
+    return IOHttpClientAdapter();
+  }
+  return IOHttpClientAdapter()
+    ..createHttpClient = () {
+      final ctx = SecurityContext(withTrustedRoots: false);
+      final client = HttpClient(context: ctx);
+      client.badCertificateCallback = (X509Certificate cert, String host, int port) {
+        final accepted = CertificatePinner.matches(cert.der, pins);
+        if (!accepted) {
+          AppLogger.getLogger(
+            'CertificatePinningAdapter',
+          ).warn('Pin mismatch — rejecting connection to {}:{} (subject={})', [host, port, cert.subject]);
+        }
+        return accepted;
+      };
+      return client;
+    };
+}

--- a/lib/infrastructure/http/certificate_pinning_adapter_web.dart
+++ b/lib/infrastructure/http/certificate_pinning_adapter_web.dart
@@ -1,0 +1,12 @@
+import 'package:dio/browser.dart';
+import 'package:dio/dio.dart';
+
+/// Web build of [buildPinnedAdapter].
+///
+/// Browsers own TLS validation and JavaScript cannot intercept the handshake,
+/// so certificate pinning is a hard no-op here: we return the default browser
+/// adapter regardless of [pins]. Forks that need transport integrity on web
+/// should rely on HTTP-layer signals (HSTS, Certificate Transparency) instead.
+///
+/// This file deliberately avoids `dart:io` so web (JS and WASM) builds compile.
+HttpClientAdapter buildPinnedAdapter(List<String> pins) => BrowserHttpClientAdapter();

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -138,5 +138,7 @@
         "type": "String"
       }
     }
-  }
+  },
+  "error_network_cert_invalid": "Could not verify the server's identity. Connection blocked.",
+  "@error_network_cert_invalid": {}
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -138,5 +138,7 @@
         "type": "String"
       }
     }
-  }
+  },
+  "error_network_cert_invalid": "Sunucu kimliği doğrulanamadı. Bağlantı engellendi.",
+  "@error_network_cert_invalid": {}
 }

--- a/lib/shared/l10n/app_error_code_l10n.dart
+++ b/lib/shared/l10n/app_error_code_l10n.dart
@@ -21,6 +21,7 @@ extension AppErrorCodeL10n on AppErrorCode {
       AppErrorCode.accountPasswordRequired => s.error_account_password_required,
       AppErrorCode.accountPasswordsSame => s.error_account_passwords_same,
       AppErrorCode.settingsChangeLanguageFailed => s.error_settings_change_language_failed,
+      AppErrorCode.networkCertInvalid => s.error_network_cert_invalid,
       AppErrorCode.generic => s.error_generic,
     };
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -170,7 +170,7 @@ packages:
     source: hosted
     version: "1.15.0"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   package_info_plus: 10.1.0
   connectivity_plus: 7.1.1
   flutter_secure_storage: 10.2.0
+  crypto: 3.0.7
 
 dev_dependencies:
   flutter_test:

--- a/test/infrastructure/http/certificate_pinner_test.dart
+++ b/test/infrastructure/http/certificate_pinner_test.dart
@@ -39,10 +39,21 @@ void main() {
     });
 
     test('pin comparison is case-sensitive (base64 is case-sensitive)', () {
-      final lowercased = pinA.toLowerCase();
-      // If pinA happens to be already all lowercase (rare for base64), skip.
-      if (lowercased == pinA) return;
-      expect(CertificatePinner.matches(certA, [lowercased]), isFalse);
+      // Deterministically pick a fixture whose pin contains at least one
+      // uppercase letter so the lowercased variant is guaranteed to differ —
+      // otherwise the assertion below could vacuously pass.
+      var seed = 0;
+      late Uint8List cert;
+      late String pin;
+      do {
+        cert = Uint8List.fromList([seed, seed + 1, seed + 2, seed + 3]);
+        pin = _hashOf(cert);
+        seed++;
+      } while (pin == pin.toLowerCase() && seed < 256);
+
+      expect(pin, isNot(equals(pin.toLowerCase())), reason: 'fixture must contain an uppercase base64 char');
+      expect(CertificatePinner.matches(cert, [pin.toLowerCase()]), isFalse);
+      expect(CertificatePinner.matches(cert, [pin]), isTrue);
     });
   });
 

--- a/test/infrastructure/http/certificate_pinner_test.dart
+++ b/test/infrastructure/http/certificate_pinner_test.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/certificate_pinner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+String _hashOf(Uint8List bytes) => base64.encode(sha256.convert(bytes).bytes);
+
+void main() {
+  group('CertificatePinner.matches', () {
+    final certA = Uint8List.fromList([1, 2, 3, 4]);
+    final certB = Uint8List.fromList([5, 6, 7, 8]);
+    final pinA = _hashOf(certA);
+    final pinB = _hashOf(certB);
+
+    test('empty pin list returns false (pinning misconfigured — fail closed)', () {
+      // Disabled mode is enforced at the adapter wiring level, not here.
+      // If pinner is invoked with an empty list, it must reject — never
+      // silently allow.
+      expect(CertificatePinner.matches(certA, const []), isFalse);
+    });
+
+    test('exact pin match returns true', () {
+      expect(CertificatePinner.matches(certA, [pinA]), isTrue);
+    });
+
+    test('non-matching pin returns false', () {
+      expect(CertificatePinner.matches(certA, [pinB]), isFalse);
+    });
+
+    test('multiple pins, one matching returns true (backup pin scenario)', () {
+      expect(CertificatePinner.matches(certA, [pinB, pinA]), isTrue);
+    });
+
+    test('multiple pins, none matching returns false', () {
+      final pinC = _hashOf(Uint8List.fromList([9, 9, 9]));
+      expect(CertificatePinner.matches(certA, [pinB, pinC]), isFalse);
+    });
+
+    test('pin comparison is case-sensitive (base64 is case-sensitive)', () {
+      final lowercased = pinA.toLowerCase();
+      // If pinA happens to be already all lowercase (rare for base64), skip.
+      if (lowercased == pinA) return;
+      expect(CertificatePinner.matches(certA, [lowercased]), isFalse);
+    });
+  });
+
+  group('CertificatePinner.computePin', () {
+    test('produces the canonical base64(sha256(cert.der)) string', () {
+      final der = Uint8List.fromList(List.generate(64, (i) => i));
+      final expected = base64.encode(sha256.convert(der).bytes);
+      expect(CertificatePinner.computePin(der), equals(expected));
+    });
+
+    test('different cert bytes → different pins', () {
+      final a = CertificatePinner.computePin(Uint8List.fromList([1, 2, 3]));
+      final b = CertificatePinner.computePin(Uint8List.fromList([3, 2, 1]));
+      expect(a, isNot(equals(b)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- New `CertificatePinner` pure matcher + `buildPinnedAdapter` Dio glue under `lib/infrastructure/http/`.
- `ProfileConstants.certificatePins` config — `List<String>` of base64 SHA-256 pins; empty = disabled (default).
- New `AppErrorCode.networkCertInvalid` + en/tr ARB translations for typed error surfacing.
- README documents the SecurityContext approach, OpenSSL extraction one-liner, backup-pin rotation procedure, and the v1 SPKI gap.

Closes #133.

## Threat model

The whole reason for pinning is that **system trust validation is not enough**. A user-installed root CA (corporate MITM proxy, malware), a rogue public-CA intermediate (DigiNotar / Symantec historical cases), or a carrier-installed cert all pass `badCertificateCallback` because the device already trusts them. Pinning narrows acceptance to a specific certificate.

The implementation uses `SecurityContext(withTrustedRoots: false)` so **every** cert falls through `badCertificateCallback` for explicit pin checking. This is the only correct way to enforce pinning even against system-trusted but adversarial CAs.

## Pin format — v1 decision

**Full-cert SHA-256, not SPKI.** Pre-empting the obvious review question: the OWASP-recommended pin is `SHA-256(SubjectPublicKeyInfo)`, which survives certificate rotation as long as the keypair is reused. Extracting SPKI from X.509 DER requires ASN.1 parsing (e.g. via `asn1lib`). 

I chose full-cert hash for v1 because:

1. Zero new ASN.1 dependency surface.
2. Implementation is ~30 lines, fully auditable, no subtle off-by-one risks in DER navigation.
3. The pin storage shape (`List<String>` of base64 SHA-256) is identical for both modes — upgrading to SPKI is a follow-up patch that swaps `CertificatePinner.computePin` and doesn't touch the config / adapter / public API.

README explicitly documents this gap so forks can plan around it. If a reviewer pushes back, the upgrade to SPKI is bounded (~50 lines of `asn1lib` navigation + golden fixture tests) and can be a separate PR.

## Behaviour matrix

| Pins | Platform | What happens |
| --- | --- | --- |
| Empty | any | Default `IOHttpClientAdapter` with system trust. Pinning disabled. |
| Non-empty | mobile / desktop | Pinning adapter installed; every cert checked against the list. |
| Non-empty | web | Hard no-op — `kIsWeb` short-circuits to the default adapter. |

## Retry semantics

No change to `ResilienceInterceptor`. Pin failure → Dio raises `DioExceptionType.badCertificate`. The existing `_isRetryable` table already treats that as non-retryable (retrying a pin failure would mask a real MITM, exactly per the issue spec).

## Test plan

- [x] `CertificatePinner` unit tests (8): empty list (fail-closed), exact match, non-match, multiple pins with one matching, none matching, case-sensitivity, canonical format, different bytes → different pins.
- [x] Full suite: 1487/1487 green.
- [x] `fvm dart analyze` — clean.
- [x] `fvm dart format --line-length=120 --set-exit-if-changed .` — clean.
- [ ] Manual: with a real backend pin populated, confirm successful connection; with a wrong pin, confirm `DioExceptionType.badCertificate`. **Deferred** — requires a real backend or `dart:io` test server with custom certs.

## Out of scope

- SPKI hash variant (documented as follow-up).
- HPKP (HTTP Public Key Pinning) — deprecated by browsers; doesn't apply to mobile.
- Remote-config pin distribution. **Intentionally avoided** — pins delivered over the same TLS connection you are pinning is a footgun.
- Per-environment pin lists via `--dart-define`. Achievable via the existing `_Config` map shape; defer until a real need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)