### PR TITLE
feat(#131): Sentry as production crash reporting backend (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,33 @@ The screenshots below are included to help contributors and adopters understand 
 - Public and private route separation
 - Protected admin-only pages
 
+### Crash Reporting (Sentry, opt-in)
+
+The template ships with a Sentry adapter (`SentryAnalyticsService`) and a conservative PII / token scrubber, but **no DSN is committed** — public templates with a committed DSN bleed events from every fork into the original project's quota. Provide a DSN at build time:
+
+```shell
+fvm flutter run --target lib/main/main_prod.dart \
+  --dart-define=SENTRY_DSN=https://YOUR_PUBLIC_KEY@oXXX.ingest.sentry.io/YOUR_PROJECT_ID
+```
+
+```shell
+fvm flutter build apk --release --target lib/main/main_prod.dart \
+  --dart-define=SENTRY_DSN=https://...
+```
+
+- **No DSN, or non-prod build:** `AppDependencies.createAnalyticsService()` returns `LogAnalyticsService`. Errors land in `AppLogger`. No network egress.
+- **DSN + prod build:** bootstrap calls `SentryFlutter.init(...)` and the analytics interface switches to the Sentry-backed implementation. `SentryNavigatorObserver` registers automatically so route changes become breadcrumbs.
+
+`sentryBeforeSend` (see `lib/infrastructure/analytics/sentry_scrub.dart`) drops the following before any event leaves the device:
+
+- `Authorization` / `Cookie` / `Set-Cookie` headers (case-insensitive)
+- Body keys whose names contain `password`, `otp`, `token`, `refreshToken` (case-insensitive substring)
+- JWT-shaped strings (3 base64url segments) in exception values + event message — replaced with `[REDACTED_JWT]`
+
+The scrubber is unit-tested independently of the SDK; review it against your fork's PII surface before adopting in production. Adding new redaction rules is a single-file change.
+
+Default sample rate: `tracesSampleRate: 0.2`. Adjust in `AppBootstrap.run` if your event budget needs different cadence.
+
 ### Server-Driven Dynamic Forms
 
 - 16 supported field types: text, email, password, number, phone, textarea,

--- a/lib/app/analytics/crash_reporter.dart
+++ b/lib/app/analytics/crash_reporter.dart
@@ -10,15 +10,25 @@ class CrashReporter {
   static final _log = AppLogger.getLogger('CrashReporter');
 
   /// Install global error handlers. Call once during app bootstrap.
-  static void install(IAnalyticsService analytics) {
+  ///
+  /// [forwardToAnalytics] controls whether uncaught errors are forwarded to
+  /// [analytics]. Set it to `false` when the Sentry SDK is active: Sentry
+  /// installs its own `FlutterError.onError` / `PlatformDispatcher.onError`
+  /// integrations that both capture the error AND chain to the handler
+  /// installed here. Forwarding to the Sentry-backed analytics in that case
+  /// reports every crash twice. With forwarding off, this reporter keeps doing
+  /// local logging and Sentry remains the single uncaught-error sink.
+  static void install(IAnalyticsService analytics, {bool forwardToAnalytics = true}) {
     // Flutter framework errors (widget build, layout, paint)
     FlutterError.onError = (details) {
       _log.error('FlutterError: {}', [details.exceptionAsString()]);
-      analytics.logError(
-        error: details.exception,
-        stackTrace: details.stack,
-        reason: 'FlutterError: ${details.library}',
-      );
+      if (forwardToAnalytics) {
+        analytics.logError(
+          error: details.exception,
+          stackTrace: details.stack,
+          reason: 'FlutterError: ${details.library}',
+        );
+      }
 
       // In debug mode, also print the default Flutter error output
       if (kDebugMode) {
@@ -29,10 +39,12 @@ class CrashReporter {
     // Async errors, isolate errors, platform errors
     PlatformDispatcher.instance.onError = (error, stack) {
       _log.error('PlatformError: {}', [error]);
-      analytics.logError(error: error, stackTrace: stack, reason: 'PlatformDispatcher.onError');
+      if (forwardToAnalytics) {
+        analytics.logError(error: error, stackTrace: stack, reason: 'PlatformDispatcher.onError');
+      }
       return true; // Mark as handled
     };
 
-    _log.info('Crash reporter installed');
+    _log.info('Crash reporter installed (forwardToAnalytics={})', [forwardToAnalytics]);
   }
 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -10,7 +10,9 @@ import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
 import 'package:flutter_bloc_advance/core/analytics/analytics_service.dart';
 import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
 import 'package:flutter_bloc_advance/generated/l10n.dart';
+import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flutter_bloc_advance/shared/design_system/theme/app_theme.dart';
 import 'package:flutter_bloc_advance/shared/widgets/web_back_button_disabler.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -68,7 +70,13 @@ class _AppViewState extends State<_AppView> {
     super.didChangeDependencies();
     _router ??= AppRouterFactory(
       sessionCubit: context.read<SessionCubit>(),
-      observers: [AnalyticsRouteObserver(widget.analytics)],
+      observers: [
+        AnalyticsRouteObserver(widget.analytics),
+        // Sentry breadcrumbs from navigation. Only meaningful when the
+        // Sentry SDK was initialized in bootstrap (production + DSN);
+        // outside that window the observer is harmless overhead.
+        if (ProfileConstants.sentryDsn != null) SentryNavigatorObserver(),
+      ],
     ).create();
   }
 

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -7,8 +7,8 @@ import 'package:flutter_bloc_advance/app/bootstrap/app_bootstrap_config.dart';
 import 'package:flutter_bloc_advance/app/di/app_dependencies.dart';
 import 'package:flutter_bloc_advance/app/analytics/crash_reporter.dart';
 import 'package:flutter_bloc_advance/app/dev_console/time_travel/time_travel_bloc_observer.dart';
-import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
 import 'package:flutter_bloc_advance/core/logging/app_bloc_observer.dart';
+import 'package:flutter_bloc_advance/infrastructure/analytics/sentry_scrub.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
@@ -17,6 +17,7 @@ import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_bloc_advance/shared/utils/app_constants.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 class AppBootstrap {
   static Future<void> run(AppBootstrapConfig config) async {
@@ -59,8 +60,14 @@ class AppBootstrap {
     // Connectivity monitoring
     await ConnectivityService.instance.initialize();
 
-    // Analytics & crash reporting
-    final analytics = LogAnalyticsService();
+    // Analytics & crash reporting. When `--dart-define=SENTRY_DSN=...`
+    // is provided in a production build, [AppDependencies] returns the
+    // Sentry-backed implementation. Anywhere else, the local-only
+    // logging implementation. CrashReporter installs framework /
+    // PlatformDispatcher hooks regardless — Sentry has its own
+    // hooks too, the two are additive (Sentry receives the captured
+    // exception, AppLogger gets a local trace).
+    final analytics = dependencies.createAnalyticsService();
     CrashReporter.install(analytics);
 
     Bloc.observer = kDebugMode ? TimeTravelBlocObserver() : AppBlocObserver();
@@ -80,13 +87,34 @@ class AppBootstrap {
     // the entire widget tree shares one adapter instance — no config
     // drift between migration and runtime consumers, and overriding
     // for tests / alternate environments is a single hand-off.
-    runApp(
-      App(
-        language: config.defaultLanguage,
-        dependencies: dependencies,
-        secureStorage: secureStorage,
-        analytics: analytics,
-      ),
-    );
+    final dsn = ProfileConstants.sentryDsn;
+    if (dsn != null) {
+      log.info('Initializing Sentry (release: {}+{})', [AppConstants.appVersion, AppConstants.appBuildNumber]);
+      await SentryFlutter.init(
+        (options) {
+          options.dsn = dsn;
+          options.beforeSend = (event, hint) => sentryBeforeSend(event);
+          options.tracesSampleRate = 0.2;
+          options.release = '${AppConstants.appVersion}+${AppConstants.appBuildNumber}';
+        },
+        appRunner: () => runApp(
+          App(
+            language: config.defaultLanguage,
+            dependencies: dependencies,
+            secureStorage: secureStorage,
+            analytics: analytics,
+          ),
+        ),
+      );
+    } else {
+      runApp(
+        App(
+          language: config.defaultLanguage,
+          dependencies: dependencies,
+          secureStorage: secureStorage,
+          analytics: analytics,
+        ),
+      );
+    }
   }
 }

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -63,12 +63,17 @@ class AppBootstrap {
     // Analytics & crash reporting. When `--dart-define=SENTRY_DSN=...`
     // is provided in a production build, [AppDependencies] returns the
     // Sentry-backed implementation. Anywhere else, the local-only
-    // logging implementation. CrashReporter installs framework /
-    // PlatformDispatcher hooks regardless — Sentry has its own
-    // hooks too, the two are additive (Sentry receives the captured
-    // exception, AppLogger gets a local trace).
+    // logging implementation.
+    //
+    // CrashReporter always installs framework / PlatformDispatcher hooks for
+    // local logging. When Sentry is active it installs its OWN hooks that both
+    // capture the error and chain to ours, so we must NOT also forward uncaught
+    // errors to the Sentry-backed analytics here — doing so reports every crash
+    // twice. With Sentry off, forwarding to the local logging analytics is the
+    // only sink, so it stays enabled.
     final analytics = dependencies.createAnalyticsService();
-    CrashReporter.install(analytics);
+    final sentryActive = ProfileConstants.sentryDsn != null;
+    CrashReporter.install(analytics, forwardToAnalytics: !sentryActive);
 
     Bloc.observer = kDebugMode ? TimeTravelBlocObserver() : AppBlocObserver();
 

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -11,6 +11,9 @@ import 'package:flutter_bloc_advance/shared/dynamic_forms/domain/repositories/dy
 import 'package:flutter_bloc_advance/features/users/data/repositories/user_repository.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/authority_repository.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
+import 'package:flutter_bloc_advance/core/analytics/analytics_service.dart';
+import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
+import 'package:flutter_bloc_advance/infrastructure/analytics/sentry_analytics_service.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
@@ -18,6 +21,17 @@ class AppDependencies {
   const AppDependencies({this.environment = Environment.dev});
 
   final Environment environment;
+
+  /// Returns the analytics implementation appropriate for the active
+  /// environment. Production + non-empty DSN → [SentryAnalyticsService]
+  /// (Sentry SDK assumed already-initialized by bootstrap); any other
+  /// case → [LogAnalyticsService] (local-only, no network egress).
+  IAnalyticsService createAnalyticsService() {
+    if (ProfileConstants.sentryDsn != null) {
+      return SentryAnalyticsService();
+    }
+    return LogAnalyticsService();
+  }
 
   IAccountRepository createAccountRepository() => AccountRepository();
 

--- a/lib/infrastructure/analytics/sentry_analytics_service.dart
+++ b/lib/infrastructure/analytics/sentry_analytics_service.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_bloc_advance/core/analytics/analytics_service.dart';
+import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// [IAnalyticsService] implementation backed by the Sentry SDK.
+///
+/// Pre-condition: `SentryFlutter.init(...)` has already run with a
+/// configured DSN. The bootstrap layer gates that on
+/// `ProfileConstants.sentryDsn != null` and only swaps this service
+/// in when the SDK is live; tests + non-prod builds keep
+/// `LogAnalyticsService` so this file is not even constructed
+/// without a DSN.
+///
+/// **PII contract.** Every outgoing event passes through
+/// [sentryBeforeSend] (wired in the SDK init), which drops
+/// Authorization / Cookie headers, redacts `password` / `otp` /
+/// `token` / `refreshToken` body keys, and masks JWT-shaped strings
+/// in exception values / message. See `sentry_scrub.dart` for the
+/// pure scrubber implementation that backs this guarantee.
+class SentryAnalyticsService implements IAnalyticsService {
+  static final _log = AppLogger.getLogger('SentryAnalyticsService');
+
+  @override
+  void logError({required Object error, StackTrace? stackTrace, String? reason}) {
+    Sentry.captureException(
+      error,
+      stackTrace: stackTrace,
+      hint: reason != null ? Hint.withMap({'reason': reason}) : null,
+    );
+  }
+
+  @override
+  void logEvent({required String name, Map<String, dynamic>? parameters}) {
+    Sentry.addBreadcrumb(Breadcrumb(category: 'event', message: name, data: parameters));
+  }
+
+  @override
+  void logScreenView({required String screenName, String? screenClass}) {
+    Sentry.addBreadcrumb(Breadcrumb(category: 'navigation', message: screenName, data: {'screenClass': screenClass}));
+  }
+
+  @override
+  void logUserAction({required String action, String? target, Map<String, dynamic>? parameters}) {
+    Sentry.addBreadcrumb(Breadcrumb(category: 'ui.action', message: action, data: {'target': target, ...?parameters}));
+  }
+
+  @override
+  void setUserId(String? userId) {
+    Sentry.configureScope((scope) {
+      if (userId == null) {
+        scope.setUser(null);
+      } else {
+        scope.setUser(SentryUser(id: userId));
+      }
+    });
+    _log.debug('setUserId: {}', [userId]);
+  }
+
+  @override
+  void setUserProperty({required String name, required String? value}) {
+    Sentry.configureScope((scope) {
+      if (value == null) {
+        scope.removeTag(name);
+      } else {
+        scope.setTag(name, value);
+      }
+    });
+  }
+}

--- a/lib/infrastructure/analytics/sentry_scrub.dart
+++ b/lib/infrastructure/analytics/sentry_scrub.dart
@@ -1,0 +1,101 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// PII / token scrubber for Sentry events. Runs as the SDK's
+/// `beforeSend` hook (see `bootstrap`) so every event is sanitized
+/// before leaving the device.
+///
+/// **Default-on, conservative.** Forks with looser privacy posture can
+/// either disable the hook or relax the rules below. The conservative
+/// default exists because the alternative — a single forgotten log
+/// statement leaking a JWT to Sentry — is much worse than dropping a
+/// few extra fields you wanted to keep.
+///
+/// Pure function: mutates the [SentryEvent] in place (matching the
+/// post-deprecation SDK API where `copyWith` is gone) and returns it.
+/// Lives in its own file specifically so tests can exercise it without
+/// booting the SDK.
+
+const Set<String> _redactedHeaderNames = {'authorization', 'cookie', 'set-cookie'};
+
+const Set<String> _redactedBodyKeySubstrings = {'password', 'otp', 'token', 'refreshtoken'};
+
+/// JWT shape: 3 base64url segments separated by dots, each at least 4
+/// chars. Conservative — does not match every theoretical JWT, but
+/// matches every JWT this app actually mints.
+final RegExp _jwtPattern = RegExp(r'eyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}');
+
+const String _jwtMask = '[REDACTED_JWT]';
+
+SentryEvent sentryBeforeSend(SentryEvent event) {
+  final request = event.request;
+  if (request != null) {
+    // SentryRequest.data has no public setter (the SDK exposes only
+    // an unmodifiable view). Reconstruct with sanitized values while
+    // preserving every other field so we don't drop URL/method/env
+    // context that's harmless and useful for triage.
+    event.request = SentryRequest(
+      url: request.url,
+      method: request.method,
+      queryString: request.queryString,
+      cookies: null, // drop entire Cookie field — covered by header scrub but doubled here
+      fragment: request.fragment,
+      apiTarget: request.apiTarget,
+      data: _scrubBody(request.data),
+      headers: _scrubHeaders(request.headers),
+      env: request.env,
+    );
+  }
+
+  final exceptions = event.exceptions;
+  if (exceptions != null) {
+    for (final ex in exceptions) {
+      final v = ex.value;
+      if (v != null) ex.value = _maskJwt(v);
+    }
+  }
+
+  final msg = event.message;
+  if (msg != null) {
+    final formatted = msg.formatted;
+    final masked = _maskJwt(formatted);
+    if (masked != formatted) {
+      event.message = SentryMessage(masked);
+    }
+  }
+
+  return event;
+}
+
+Map<String, String>? _scrubHeaders(Map<String, String>? headers) {
+  if (headers == null) return null;
+  final out = <String, String>{};
+  headers.forEach((k, v) {
+    if (!_redactedHeaderNames.contains(k.toLowerCase())) {
+      out[k] = v;
+    }
+  });
+  return out;
+}
+
+/// Body shapes we strip: `Map` (the common JSON case after Dio
+/// decoding). Non-Map bodies (raw String, List, multipart) pass
+/// through untouched — they would require shape-specific scrubbing
+/// and the risk/reward is poor.
+Object? _scrubBody(Object? body) {
+  if (body is! Map) return body;
+  final out = <String, dynamic>{};
+  body.forEach((k, v) {
+    if (k is! String) {
+      out[k.toString()] = v;
+      return;
+    }
+    final lower = k.toLowerCase();
+    final isSecret = _redactedBodyKeySubstrings.any(lower.contains);
+    if (!isSecret) out[k] = v;
+  });
+  return out;
+}
+
+String _maskJwt(String input) {
+  return input.replaceAll(_jwtPattern, _jwtMask);
+}

--- a/lib/infrastructure/analytics/sentry_scrub.dart
+++ b/lib/infrastructure/analytics/sentry_scrub.dart
@@ -10,10 +10,11 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 /// statement leaking a JWT to Sentry — is much worse than dropping a
 /// few extra fields you wanted to keep.
 ///
-/// Pure function: mutates the [SentryEvent] in place (matching the
-/// post-deprecation SDK API where `copyWith` is gone) and returns it.
-/// Lives in its own file specifically so tests can exercise it without
-/// booting the SDK.
+/// Deterministic and free of external side effects, but **mutates the
+/// passed-in [SentryEvent] in place** (replacing `event.request` / `event.message`
+/// and editing exception values) before returning it — matching the
+/// post-deprecation SDK API where `copyWith` is gone. Lives in its own file
+/// specifically so tests can exercise it without booting the SDK.
 
 const Set<String> _redactedHeaderNames = {'authorization', 'cookie', 'set-cookie'};
 

--- a/lib/infrastructure/config/environment.dart
+++ b/lib/infrastructure/config/environment.dart
@@ -38,6 +38,20 @@ class ProfileConstants {
   static dynamic get api {
     return _config![_Config.api];
   }
+
+  /// Production-only DSN passed via `--dart-define=SENTRY_DSN=...`.
+  /// Returns null in non-prod, or when the define is absent / empty
+  /// so the bootstrap falls back to [LogAnalyticsService] without
+  /// touching the Sentry SDK.
+  ///
+  /// **Never** commit a DSN to source. The repo is a public template;
+  /// a checked-in DSN means anyone running the fork ships events into
+  /// the original project's Sentry quota.
+  static String? get sentryDsn {
+    if (!isProduction) return null;
+    const dsn = String.fromEnvironment('SENTRY_DSN');
+    return dsn.isEmpty ? null : dsn;
+  }
 }
 
 class _Config {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  sentry_flutter
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import connectivity_plus
 import flutter_secure_storage_darwin
 import package_info_plus
+import sentry_flutter
 import shared_preferences_foundation
 import sqflite_darwin
 import url_launcher_macos
@@ -16,6 +17,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -512,18 +512,10 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: d2c361082d554d4593c3012e26f6b188f902acd291330f13d6427641a92b3da1
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
-  jni_flutter:
-    dependency: transitive
-    description:
-      name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
+    version: "0.14.2"
   json_annotation:
     dependency: transitive
     description:
@@ -712,10 +704,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.2.23"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -828,6 +820,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      sha256: f04095a25ff02b202a914174c73ec309570aa93d61098cb4a0a9e715b4aaa465
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.20.0"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      sha256: "4f0a914d8c37e5015d7b86dd42b92dd265948fd31875b43e62ddfc2e7bea0e41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.20.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   package_info_plus: 10.1.0
   connectivity_plus: 7.1.1
   flutter_secure_storage: 10.2.0
+  sentry_flutter: 9.20.0
 
 dev_dependencies:
   flutter_test:

--- a/test/infrastructure/analytics/sentry_scrub_test.dart
+++ b/test/infrastructure/analytics/sentry_scrub_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_bloc_advance/infrastructure/analytics/sentry_scrub.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+SentryEvent _eventWithHeaders(Map<String, String> headers) => SentryEvent(request: SentryRequest(headers: headers));
+
+SentryEvent _eventWithBody(Object? body) => SentryEvent(request: SentryRequest(data: body));
+
+SentryEvent _eventWithMessage(String message) => SentryEvent(message: SentryMessage(message));
+
+SentryEvent _eventWithExceptionValue(String value) {
+  return SentryEvent(
+    exceptions: [SentryException(type: 'TestException', value: value)],
+  );
+}
+
+void main() {
+  group('sentryBeforeSend — header scrubbing', () {
+    test('removes Authorization header (case-insensitive)', () {
+      final result = sentryBeforeSend(
+        _eventWithHeaders({'Authorization': 'Bearer token', 'Accept': 'application/json'}),
+      );
+      expect(result.request?.headers.containsKey('Authorization'), isFalse);
+      expect(result.request?.headers['Accept'], 'application/json');
+    });
+
+    test('removes lowercase authorization', () {
+      final result = sentryBeforeSend(_eventWithHeaders({'authorization': 'Bearer x', 'X-Other': 'y'}));
+      expect(result.request?.headers.containsKey('authorization'), isFalse);
+      expect(result.request?.headers['X-Other'], 'y');
+    });
+
+    test('removes Cookie and Set-Cookie headers', () {
+      final result = sentryBeforeSend(_eventWithHeaders({'Cookie': 'sid=abc', 'Set-Cookie': 'sid=abc', 'X-K': 'v'}));
+      expect(result.request?.headers.containsKey('Cookie'), isFalse);
+      expect(result.request?.headers.containsKey('Set-Cookie'), isFalse);
+      expect(result.request?.headers['X-K'], 'v');
+    });
+  });
+
+  group('sentryBeforeSend — body scrubbing (Map shape)', () {
+    test('drops password, otp, token, refreshToken keys', () {
+      final body = {
+        'username': 'alice',
+        'password': 'p@ss',
+        'otp': '123456',
+        'token': 'xxx',
+        'refreshToken': 'yyy',
+        'note': 'kept',
+      };
+      final result = sentryBeforeSend(_eventWithBody(body));
+      final data = Map<String, dynamic>.from(result.request!.data as Map);
+      expect(data.containsKey('password'), isFalse);
+      expect(data.containsKey('otp'), isFalse);
+      expect(data.containsKey('token'), isFalse);
+      expect(data.containsKey('refreshToken'), isFalse);
+      expect(data['username'], 'alice');
+      expect(data['note'], 'kept');
+    });
+
+    test('key match is case-insensitive', () {
+      final body = {'Password': 'a', 'OTP': 'b', 'newPassword': 'c'};
+      final result = sentryBeforeSend(_eventWithBody(body));
+      final data = Map<String, dynamic>.from(result.request!.data as Map);
+      expect(data.containsKey('Password'), isFalse);
+      expect(data.containsKey('OTP'), isFalse);
+      expect(data.containsKey('newPassword'), isFalse);
+    });
+
+    test('non-Map body is left untouched', () {
+      final result = sentryBeforeSend(_eventWithBody('plain string body'));
+      expect(result.request?.data, 'plain string body');
+    });
+  });
+
+  group('sentryBeforeSend — JWT masking', () {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYmMifQ.signaturepart';
+
+    test('masks a JWT-shaped token inside an exception value', () {
+      final result = sentryBeforeSend(_eventWithExceptionValue('Failed with token=$jwt — try again'));
+      final value = result.exceptions?.first.value ?? '';
+      expect(value.contains(jwt), isFalse, reason: 'raw JWT must not appear');
+      expect(value.contains('[REDACTED_JWT]'), isTrue);
+    });
+
+    test('masks JWT in event.message', () {
+      final result = sentryBeforeSend(_eventWithMessage('Token rotated: $jwt'));
+      final formatted = result.message?.formatted ?? '';
+      expect(formatted.contains(jwt), isFalse);
+      expect(formatted.contains('[REDACTED_JWT]'), isTrue);
+    });
+
+    test('leaves non-JWT content untouched', () {
+      final result = sentryBeforeSend(_eventWithExceptionValue('Server returned 500 with body {"error":"oops"}'));
+      expect(result.exceptions?.first.value, 'Server returned 500 with body {"error":"oops"}');
+    });
+  });
+
+  group('sentryBeforeSend — passthroughs', () {
+    test('event with no request or exception passes through unchanged', () {
+      final event = SentryEvent(message: SentryMessage('Plain note'));
+      final result = sentryBeforeSend(event);
+      expect(result.message?.formatted, 'Plain note');
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -15,6 +16,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   flutter_secure_storage_windows
+  sentry_flutter
   url_launcher_windows
 )
 


### PR DESCRIPTION
## Summary

- `SentryAnalyticsService` (`lib/infrastructure/analytics/`) implements `IAnalyticsService` and is selected by `AppDependencies.createAnalyticsService()` only when `ProfileConstants.sentryDsn` is non-null. In every other case, `LogAnalyticsService` (local-only, zero network) keeps shipping.
- Conservative `sentryBeforeSend` PII / token scrubber, isolated in `sentry_scrub.dart` so the rules are testable independently of an initialized SDK.
- `AppBootstrap.run` conditionally calls `SentryFlutter.init(..., appRunner: ...)` — the off path runs `runApp(...)` directly with no SDK touch.
- `_AppView` registers `SentryNavigatorObserver` when the DSN is configured; otherwise it stays out of the router's observer list.
- README "Crash Reporting" section.

Closes #131.

## DSN handling

**No DSN is committed.** Provide it at build time:

```shell
fvm flutter run --target lib/main/main_prod.dart \
  --dart-define=SENTRY_DSN=https://YOUR_PUBLIC_KEY@oXXX.ingest.sentry.io/YOUR_PROJECT_ID
```

`Environment.sentryDsn` resolves via `String.fromEnvironment('SENTRY_DSN')`, returns null in non-prod and when the define is absent / empty. A committed DSN on a public template would bleed fork events into the original project's Sentry quota — that's the deliberate gap this design closes.

## Scrubber rules (unit-tested)

| Source | Rule |
| --- | --- |
| Request headers | Drop `Authorization`, `Cookie`, `Set-Cookie` (case-insensitive) |
| Request body (Map shape) | Drop keys whose names contain `password`, `otp`, `token`, `refreshToken` (case-insensitive substring) |
| Exception value | Replace JWT-shaped tokens with `[REDACTED_JWT]` |
| Event message | Same JWT replacement |
| Non-Map bodies (String / List / multipart) | Passthrough — shape-specific scrubbing has poor risk/reward; revisit if a real leak surfaces |

The scrubber lives in its own file precisely so the rules can grow without touching SDK glue. Adding a new redaction rule is a one-file change with a unit test.

## SDK API note

Sentry 9.x deprecated `copyWith` in favour of direct field assignment. `SentryRequest.data` has no public setter (returns an `UnmodifiableMapView`), so the scrubber reconstructs a `SentryRequest` with sanitized `data` + `headers` while preserving URL / method / queryString / env. This intentionally drops the `unknown` field (package-private to Sentry).

## Test plan

- [x] 10 scrubber unit tests cover header / body / JWT / passthrough cases.
- [x] Full suite: 1489/1489 green.
- [x] `fvm dart analyze` — clean.
- [x] `fvm dart format --line-length=120 --set-exit-if-changed .` — clean.
- [ ] **Manual smoke** with the project's real DSN. Procedure: `fvm flutter run --target lib/main/main_prod.dart --dart-define=SENTRY_DSN=...`, then trigger an exception (e.g. `throw StateError('Test exception')` from a button). Confirm event lands in Sentry **with the Authorization header absent** in the event payload. Deferred — needs the project owner's local DSN.

## Default sample rate

`tracesSampleRate: 0.2` for production. Adjust in `AppBootstrap.run`. The issue suggested `1.0` for dev / `0.2` for prod; since SDK only initializes in prod here, the single value suffices.

## Out of scope (per issue + practical limits)

- Per-screen performance tracing (`Sentry.startTransaction`).
- Bloc transition → breadcrumb behind a feature flag. The existing `AppBlocObserver` covers the local logging side; piping into Sentry breadcrumbs is a small follow-up if signal-to-noise warrants it.
- Session replay.
- User-feedback dialog on crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)