### PR TITLE
feat(#144): immutable AppConfig + DI-injected ApiClient (no global state)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-appconfig-apiclient-di.md
+++ b/docs/superpowers/plans/2026-06-02-appconfig-apiclient-di.md
@@ -1,0 +1,579 @@
+# AppConfig + DI-injected ApiClient Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the global `ProfileConstants` map with an immutable `AppConfig`, and the static `ApiClient` with an instance injected through the existing `RepositoryProvider` DI spine — eliminating all mutable global state in the config + HTTP layer.
+
+**Architecture:** Expand → Migrate → Contract. First introduce `AppConfig` and re-establish behavior parity (≈ PR #145). Then add an instance API to `ApiClient` *alongside* a thin temporary static facade so nothing breaks. Migrate each repository/consumer to the injected instance one at a time (full suite green after every commit). Finally delete the static facade and all static config — leaving zero globals.
+
+**Tech Stack:** Flutter 3.44 / Dart 3.12, `flutter_bloc` `RepositoryProvider` DI, `dio` HTTP, `mocktail` tests, FVM.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-appconfig-apiclient-di-design.md`
+
+**Invariant for every task:** after the final step, `fvm flutter test` is fully green, `fvm dart analyze` is clean. Commit only on green.
+
+---
+
+## File Structure
+
+**Created:** none (design doc + this plan already exist).
+
+**Modified — production:**
+- `lib/infrastructure/config/environment.dart` — `AppConfig`, delete `ProfileConstants`/`_Config`
+- `lib/infrastructure/http/api_client.dart` — static → instance (+ temporary facade, later removed)
+- `lib/infrastructure/http/interceptors/mock_interceptor.dart` — `appConfig` ctor param
+- `lib/app/bootstrap/app_bootstrap.dart` — build `AppConfig`, drop `ApiClient` statics (final state)
+- `lib/app/bootstrap/app_session_listeners.dart`, `lib/app/app.dart`, `lib/app/session/session_cubit.dart`, `lib/app/dev_console/tabs/environment_tab.dart`, `lib/infrastructure/analytics/sentry_analytics_service.dart` — read `AppConfig` (Task 1)
+- `lib/app/di/app_dependencies.dart`, `lib/app/di/app_scope.dart` — `createApiClient` + repo factories + providers
+- 6 repos: `lib/features/users/data/repositories/{user_repository,authority_repository}.dart`, `lib/features/account/data/repositories/account_repository.dart`, `lib/features/auth/data/repositories/auth_repository_impl.dart`, `lib/features/lifecycle/data/repositories/lifecycle_repository.dart`, `lib/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart`
+- `lib/features/dashboard/application/dashboard_cubit.dart`, `lib/features/dashboard/presentation/pages/dashboard_home_page.dart`
+
+**Modified — tests:** `test/test_utils.dart`, `test/infrastructure/config/environment_test.dart`, `test/infrastructure/http/api_client_test.dart`, `test/app/session/session_cubit_test.dart`, plus ~30 files constructing concrete repos (enumerated per migrate task via grep).
+
+---
+
+## Task 1: Introduce `AppConfig`, delete `ProfileConstants` (behavior parity ≈ #145)
+
+**Files:**
+- Modify: `lib/infrastructure/config/environment.dart`
+- Modify: `lib/infrastructure/http/api_client.dart` (temporary `static AppConfig _appConfig` + setter — removed in Task 5)
+- Modify: `lib/infrastructure/http/interceptors/mock_interceptor.dart`
+- Modify: `lib/app/app.dart`, `lib/app/bootstrap/app_bootstrap.dart`, `lib/app/bootstrap/app_session_listeners.dart`, `lib/app/session/session_cubit.dart`, `lib/app/dev_console/tabs/environment_tab.dart`, `lib/app/di/app_dependencies.dart`, `lib/app/di/app_scope.dart`, `lib/infrastructure/analytics/sentry_analytics_service.dart`, `lib/features/dashboard/presentation/pages/dashboard_home_page.dart`
+- Test: `test/infrastructure/config/environment_test.dart`, `test/app/session/session_cubit_test.dart`, `test/test_utils.dart`
+
+- [ ] **Step 1: Write the failing `AppConfig` test**
+
+Replace the body of `test/infrastructure/config/environment_test.dart`'s first group with:
+
+```dart
+group('AppConfig', () {
+  test('dev config sets development environment', () {
+    const config = AppConfig.dev();
+    expect(config.isDevelopment, true);
+    expect(config.apiBaseUrl, isNull);
+  });
+  test('test config sets test environment', () {
+    const config = AppConfig.test();
+    expect(config.isDevelopment, false);
+    expect(config.isProduction, false);
+    expect(config.apiBaseUrl, isNull);
+  });
+  test('prod config sets production environment', () {
+    const config = AppConfig.prod();
+    expect(config.isProduction, true);
+    expect(config.apiBaseUrl, TemplateConfig.prodApiUrl);
+  });
+  test('fromEnvironment maps each enum value', () {
+    expect(AppConfig.fromEnvironment(Environment.dev).isDevelopment, true);
+    expect(AppConfig.fromEnvironment(Environment.test).isTest, true);
+    expect(AppConfig.fromEnvironment(Environment.prod).isProduction, true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `fvm flutter test test/infrastructure/config/environment_test.dart`
+Expected: FAIL — `AppConfig` undefined.
+
+- [ ] **Step 3: Replace `ProfileConstants` with `AppConfig` in `environment.dart`**
+
+Replace the entire `ProfileConstants` class and the `_Config` class with:
+
+```dart
+final class AppConfig {
+  const AppConfig({
+    required this.environment,
+    required this.apiBaseUrl,
+    required this.certificatePins,
+    required this.idleTimeout,
+  });
+
+  const AppConfig.dev()
+    : environment = Environment.dev,
+      apiBaseUrl = null,
+      certificatePins = const <String>[],
+      idleTimeout = null;
+
+  const AppConfig.test()
+    : environment = Environment.test,
+      apiBaseUrl = null,
+      certificatePins = const <String>[],
+      idleTimeout = null;
+
+  const AppConfig.prod()
+    : environment = Environment.prod,
+      apiBaseUrl = TemplateConfig.prodApiUrl,
+      certificatePins = const <String>[],
+      idleTimeout = const Duration(minutes: 15);
+
+  factory AppConfig.fromEnvironment(Environment environment) => switch (environment) {
+    Environment.dev => const AppConfig.dev(),
+    Environment.prod => const AppConfig.prod(),
+    Environment.test => const AppConfig.test(),
+  };
+
+  final Environment environment;
+  final String? apiBaseUrl;
+  final List<String> certificatePins;
+  final Duration? idleTimeout;
+
+  bool get isProduction => environment == Environment.prod;
+  bool get isDevelopment => environment == Environment.dev;
+  bool get isTest => environment == Environment.test;
+
+  /// Production-only DSN passed via `--dart-define=SENTRY_DSN=...`.
+  /// Returns null in non-prod, or when the define is absent / empty.
+  /// **Never** commit a DSN to source (public template).
+  String? get sentryDsn {
+    if (!isProduction) return null;
+    const dsn = String.fromEnvironment('SENTRY_DSN');
+    return dsn.isEmpty ? null : dsn;
+  }
+}
+```
+
+Keep `enum Environment { dev, prod, test }` and the `template_config.dart` import.
+
+- [ ] **Step 4: Add a TEMPORARY static config to `ApiClient` so it still compiles**
+
+In `lib/infrastructure/http/api_client.dart`, add a temporary static (this is migration scaffolding, deleted in Task 5):
+
+```dart
+  static AppConfig _appConfig = const AppConfig.dev();
+  static AppConfig get appConfig => _appConfig;
+  static set appConfig(AppConfig value) {
+    _appConfig = value;
+    _dio?.close();
+    _dio = null;
+    _interceptorChainSnapshot = const [];
+  }
+```
+
+Replace inside the existing static methods: `ProfileConstants.isProduction` → `_appConfig.isProduction`; `(ProfileConstants.api as String)` in `baseUrl` → `_appConfig.apiBaseUrl ?? ''`; `ProfileConstants.certificatePins` → `_appConfig.certificatePins`; `!ProfileConstants.isProduction` → `!_appConfig.isProduction`; pass `MockInterceptor(appConfig: _appConfig)`. In `reset()` add `appConfig = const AppConfig.dev();`.
+
+- [ ] **Step 5: Migrate the remaining `ProfileConstants` consumers to `AppConfig`**
+
+Apply these exact edits (identical to PR #145):
+
+- `lib/infrastructure/http/interceptors/mock_interceptor.dart`: add `MockInterceptor({this.appConfig = const AppConfig.dev()});` + `final AppConfig appConfig;`; change `!ProfileConstants.isTest` → `!appConfig.isTest`.
+- `lib/app/di/app_dependencies.dart`: `const AppDependencies({this.appConfig = const AppConfig.dev()});` + `final AppConfig appConfig;`; `createAnalyticsService` uses `appConfig.sentryDsn`.
+- `lib/app/di/app_scope.dart`: add `RepositoryProvider<AppConfig>.value(value: dependencies.appConfig),` and `SessionCubit(secureStorage: context.read<ISecureStorage>(), appConfig: context.read<AppConfig>())..restore()`; import `environment.dart`.
+- `lib/app/session/session_cubit.dart`: ctor `SessionCubit({ISecureStorage? secureStorage, this.appConfig = const AppConfig.dev()})`; `final AppConfig appConfig;`; `if (appConfig.isProduction)`.
+- `lib/app/bootstrap/app_bootstrap.dart`: replace `ProfileConstants.setEnvironment(config.environment); final dependencies = AppDependencies(environment: config.environment);` with `final appConfig = AppConfig.fromEnvironment(config.environment); final dependencies = AppDependencies(appConfig: appConfig); ApiClient.appConfig = appConfig;`; `sentryActive`/`dsn` use `appConfig.sentryDsn`.
+- `lib/app/app.dart`: `if (context.read<AppConfig>().sentryDsn != null) SentryNavigatorObserver(),`.
+- `lib/app/bootstrap/app_session_listeners.dart`: `widget.idleTimeoutOverride ?? context.read<AppConfig>().idleTimeout`.
+- `lib/app/dev_console/tabs/environment_tab.dart`: `_buildEnvironmentInfo(context.read<AppConfig>())`; signature `Map<String,String> _buildEnvironmentInfo(AppConfig appConfig)`; `'Environment': appConfig.isProduction ? 'Production' : (appConfig.isTest ? 'Test' : 'Development')`; `'API Endpoint': appConfig.apiBaseUrl ?? 'Mock'`; import `flutter_bloc`.
+- `lib/features/dashboard/presentation/pages/dashboard_home_page.dart`: `final environment = switch (context.read<AppConfig>().environment) { Environment.prod => 'prod', Environment.dev => 'dev', Environment.test => 'test' };`.
+- `lib/infrastructure/analytics/sentry_analytics_service.dart`: doc comment `ProfileConstants.sentryDsn` → `AppConfig.sentryDsn`.
+
+- [ ] **Step 6: Update tests that mutated the old global**
+
+- `test/test_utils.dart`: replace both `ProfileConstants.setEnvironment(Environment.test);` with `ApiClient.appConfig = const AppConfig.test();` (in `setupUnitTest` and `setupRepositoryUnitTest`).
+- `test/app/session/session_cubit_test.dart`: delete the `setUp`/`tearDown` `ProfileConstants.setEnvironment(...)` lines; in the expired-prod test `build:` use `SessionCubit(secureStorage: secure, appConfig: const AppConfig.prod())`.
+
+- [ ] **Step 7: Run analyze + full suite**
+
+Run: `fvm dart analyze && fvm flutter test`
+Expected: analyze clean; all tests pass (behavior parity with #145).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "$(printf 'refactor(#144): introduce immutable AppConfig, remove ProfileConstants\n\nReplaces the global ProfileConstants map with a typed final AppConfig.\nApiClient temporarily keeps a static appConfig (removed once it becomes\ninstance-injected). Behavior parity with the test suite.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2 (EXPAND): Add instance API to `ApiClient` + DI provider + test helper, keep static facade
+
+Goal: `ApiClient` gains a full instance API while the existing static API keeps working by delegating to a single lazily-built default instance. Nothing else changes behavior. Suite stays green.
+
+**Files:**
+- Modify: `lib/infrastructure/http/api_client.dart`
+- Modify: `lib/app/di/app_dependencies.dart`, `lib/app/di/app_scope.dart`
+- Modify: `test/test_utils.dart`
+- Test: `test/infrastructure/http/api_client_test.dart`
+
+- [ ] **Step 1: Write a failing instance-API test**
+
+Add to `test/infrastructure/http/api_client_test.dart`:
+
+```dart
+group('ApiClient instance API', () {
+  test('instance get goes through MockInterceptor in test config', () async {
+    final client = ApiClient(appConfig: const AppConfig.test(), secureStorage: FlutterSecureStorageAdapter());
+    final res = await client.get('/admin/users', pathParams: 'user-1');
+    expect(res.statusCode, 200);
+  });
+
+  test('interceptorChainSnapshot is per-instance and unmodifiable', () {
+    final client = ApiClient(appConfig: const AppConfig.test(), secureStorage: FlutterSecureStorageAdapter());
+    client.instance; // build dio
+    expect(client.interceptorChainSnapshot, isNotEmpty);
+    expect(() => client.interceptorChainSnapshot.add(
+      const InterceptorChainEntry(name: 'X', detail: 'X')), throwsUnsupportedError);
+  });
+
+  test('injected dio is used as-is (test seam)', () {
+    final testDio = Dio(BaseOptions(baseUrl: 'https://x', responseType: ResponseType.plain));
+    final client = ApiClient(appConfig: const AppConfig.prod(), dio: testDio);
+    expect(identical(client.instance, testDio), true);
+  });
+});
+```
+
+Ensure imports: `package:dio/dio.dart`, `environment.dart`, `secure_storage.dart`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `fvm flutter test test/infrastructure/http/api_client_test.dart -p vm`
+Expected: FAIL — `ApiClient` has no generative constructor / `client.get` not defined.
+
+- [ ] **Step 3: Convert the body of `ApiClient` to instance, with a delegating static facade**
+
+Rewrite `lib/infrastructure/http/api_client.dart` so the class holds instance state and the statics delegate. Target shape:
+
+```dart
+class ApiClient {
+  ApiClient({
+    required this.appConfig,
+    ISecureStorage? secureStorage,
+    this.onSessionExpired,
+    Dio? dio,
+  }) : _secureStorage = secureStorage,
+       _dio = dio;
+
+  static final _log = AppLogger.getLogger('ApiClient');
+  static const int _timeoutSeconds = 30;
+
+  final AppConfig appConfig;
+  final OnSessionExpired? onSessionExpired;
+  final ISecureStorage? _secureStorage;
+  Dio? _dio;
+  List<InterceptorChainEntry> _chainSnapshot = const [];
+
+  Dio get instance => _dio ??= _createDio();
+  List<InterceptorChainEntry> get interceptorChainSnapshot => List.unmodifiable(_chainSnapshot);
+
+  Future<Response<String>> get(String path, {String? pathParams, Map<String, dynamic>? queryParams}) async {
+    final fullPath = pathParams != null ? '$path/$pathParams' : path;
+    try {
+      return await instance.get<String>(fullPath, queryParameters: queryParams,
+        options: Options(extra: {'_basePath': path, '_pathParams': pathParams, '_queryParams': queryParams}));
+    } on DioException catch (e) { throw _mapDioException(e); }
+  }
+  // post/put/patch/delete: copy the existing bodies verbatim, drop `static`, call `instance.<verb>`.
+
+  Dio _createDio() {
+    _log.debug('Creating Dio instance (production: {})', [appConfig.isProduction]);
+    if (_secureStorage == null) {
+      _log.warn('ApiClient.secureStorage is null at Dio creation — interceptors will fall back '
+        'to a private FlutterSecureStorageAdapter and diverge from the repository layer.');
+    }
+    final dio = Dio(BaseOptions(
+      baseUrl: appConfig.apiBaseUrl ?? '',
+      connectTimeout: const Duration(seconds: _timeoutSeconds),
+      receiveTimeout: const Duration(seconds: _timeoutSeconds),
+      responseType: ResponseType.plain,
+      headers: {'Accept': 'application/json', 'Content-Type': 'application/json'}));
+    final pins = appConfig.certificatePins;
+    if (pins.isNotEmpty) { dio.httpClientAdapter = buildPinnedAdapter(pins); }
+    final chain = <({Interceptor interceptor, InterceptorChainEntry meta})>[
+      // …existing entries verbatim, but: AuthInterceptor(secureStorage: _secureStorage),
+      // TokenRefreshInterceptor(dio: dio, onSessionExpired: onSessionExpired, secureStorage: _secureStorage),
+      // if (!appConfig.isProduction) MockInterceptor(appConfig: appConfig) entry,
+    ];
+    dio.interceptors.addAll(chain.map((e) => e.interceptor));
+    _chainSnapshot = chain.map((e) => e.meta).toList(growable: false);
+    return dio;
+  }
+
+  // Pure static utilities — UNCHANGED (no global state):
+  static String decodeUTF8(String toEncode) { /* existing body */ }
+  static dynamic _serializeData<T>(T data) { /* existing body */ }
+  static AppException _mapDioException(DioException e) { /* existing body */ }
+  static AppException _mapBadResponse(DioException e) { /* existing body */ }
+  static AppException _mapUnknown(DioException e) { /* existing body */ }
+
+  // ---- TEMPORARY static facade (removed in Task 5) ----
+  static ApiClient? _default;
+  static AppConfig _staticConfig = const AppConfig.dev();
+  static ISecureStorage? secureStorage;        // set by bootstrap/tests during migration
+  static OnSessionExpired? onSessionExpired_;   // unused dormant; kept for parity
+  static ApiClient get _facade => _default ??=
+      ApiClient(appConfig: _staticConfig, secureStorage: secureStorage);
+  static set appConfig(AppConfig v) { _staticConfig = v; _default = null; }
+  static AppConfig get appConfig => _staticConfig;
+  static Dio? _testDio;
+  static void setTestInstance(Dio dio) { _testDio = dio; _default = ApiClient(appConfig: _staticConfig, secureStorage: secureStorage, dio: dio); }
+  static void resetTestInstance() { _testDio = null; _default = null; }
+  static void reset() { _default = null; _testDio = null; secureStorage = null; _staticConfig = const AppConfig.dev(); }
+  static List<InterceptorChainEntry> get interceptorChainSnapshotStatic => _facade.interceptorChainSnapshot;
+}
+```
+
+Notes for the implementer:
+- The five static facade convenience methods (`static Future<Response<String>> get/post/put/patch/delete`) must remain too — each one-liner delegates: `static Future<Response<String>> get(...) => _facade.get(...);`. (Define instance methods first, then the static delegators with distinct internal routing — simplest is to keep the static delegators calling `_facade.<verb>`.)
+- Keep the existing static `interceptorChainSnapshot` getter name working by pointing it at `_facade.interceptorChainSnapshot` (so `dashboard_cubit` and `api_client_test` snapshot group stay green until migrated).
+
+> This facade is deliberately ugly and temporary. Task 5 deletes every `static` member below the pure utilities.
+
+- [ ] **Step 4: Add `createApiClient` + repo-factory params (signatures only) and the DI provider**
+
+`lib/app/di/app_dependencies.dart` — add:
+
+```dart
+ApiClient createApiClient(ISecureStorage secureStorage) =>
+    ApiClient(appConfig: appConfig, secureStorage: secureStorage);
+```
+(Import `api_client.dart`. Do NOT yet change the repo-factory signatures — that happens per migrate task.)
+
+`lib/app/di/app_scope.dart` — add the provider immediately AFTER the `RepositoryProvider<ISecureStorage>` block and BEFORE the repos:
+
+```dart
+RepositoryProvider<ApiClient>(create: (context) => dependencies.createApiClient(context.read<ISecureStorage>())),
+```
+(Import `api_client.dart`.)
+
+- [ ] **Step 5: Add the test helper**
+
+`test/test_utils.dart` — add inside `class TestUtils`:
+
+```dart
+/// Mock-backed client for tests: test AppConfig → MockInterceptor serves
+/// assets/mock/*.json; shared secure adapter → same MethodChannel mock the
+/// repo layer reads. Pass [dio] to inject a stub.
+static ApiClient apiClient({Dio? dio}) => ApiClient(
+    appConfig: const AppConfig.test(),
+    secureStorage: FlutterSecureStorageAdapter(),
+    dio: dio);
+```
+(Import `package:dio/dio.dart`.)
+
+- [ ] **Step 6: Run analyze + full suite**
+
+Run: `fvm dart analyze && fvm flutter test`
+Expected: analyze clean; all tests pass (static callers untouched, new instance tests pass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "$(printf 'refactor(#144): add instance ApiClient API + DI provider (expand phase)\n\nApiClient gains a full instance API and a single-instance RepositoryProvider.\nA temporary static facade delegates to one default instance so existing\nstatic callers keep working while repos migrate. TestUtils.apiClient() added.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3 (MIGRATE): Convert repositories to the injected instance, one feature per commit
+
+For EACH repository below, the recipe is identical. **Repeat all steps per sub-task.**
+
+### Generic recipe (apply per repo)
+
+1. **Repo file** — add constructor + field, replace static calls:
+   - 5 default-ctor repos (`UserRepository`, `AuthorityRepositoryImpl`, `AccountRepository`, `LifecycleRepository`, `DynamicFormRepository`): add as the first member
+     ```dart
+     <ClassName>(this._apiClient);
+     final ApiClient _apiClient;
+     ```
+   - In that file replace every `ApiClient.get(` → `_apiClient.get(` (and `.post(`/`.put(`/`.patch(`/`.delete(`). Leave `ApiClient.decodeUTF8(` unchanged (pure static util).
+2. **DI factory** — `app_dependencies.dart`: change the factory to take `ApiClient`:
+   `I<X>Repository create<X>Repository(ApiClient api) => <X>Repository(api);`
+3. **DI provider** — `app_scope.dart`: change the repo provider to thread it:
+   `create: (context) => dependencies.create<X>Repository(context.read<ApiClient>())`.
+4. **Tests** — find every concrete construction and inject the helper:
+   - Run: `grep -rln "<ClassName>(" test/`
+   - In each hit, replace `<ClassName>()` → `<ClassName>(TestUtils.apiClient())`. If the test imports `dio`/uses `setTestInstance`, pass `TestUtils.apiClient(dio: testDio)` and delete the `ApiClient.setTestInstance(...)` line. Remove now-redundant `ApiClient.reset()` only if the file no longer references any other static (otherwise leave until Task 5).
+5. Run: `fvm flutter test` → green. Commit `refactor(#144): inject ApiClient into <X>Repository`.
+
+### Task 3a: UserRepository
+
+- [ ] Repo: `lib/features/users/data/repositories/user_repository.dart` — add `UserRepository(this._apiClient); final ApiClient _apiClient;`; replace `ApiClient.<verb>(` → `_apiClient.<verb>(`.
+- [ ] DI: `app_dependencies.dart` → `IUserRepository createUserRepository(ApiClient api) => UserRepository(api);`
+- [ ] DI: `app_scope.dart` → `RepositoryProvider<IUserRepository>(create: (context) => dependencies.createUserRepository(context.read<ApiClient>()))`.
+- [ ] Tests: `grep -rln "UserRepository(" test/` → in each, `UserRepository()` → `UserRepository(TestUtils.apiClient())`. (Known: `test/features/users/data/repositories/user_repository_test.dart`, `.../application/user_list_bloc_test.dart`, `.../user_editor_bloc_test.dart`, `.../presentation/pages/user_editor_screen_test.dart`, `.../application/usecases/{fetch_user,delete_user,save_user,search_users}_usecase_test.dart`, `test/app/di/repository_contracts_test.dart`.)
+- [ ] Run `fvm flutter test`; expected green. Commit.
+
+### Task 3b: AuthorityRepositoryImpl
+
+- [ ] Repo: `lib/features/users/data/repositories/authority_repository.dart` — add ctor/field; replace verbs.
+- [ ] DI: `createAuthorityRepository(ApiClient api) => AuthorityRepositoryImpl(api);` + provider reads `context.read<ApiClient>()`.
+- [ ] Tests: `grep -rln "AuthorityRepositoryImpl(" test/` → inject helper. (Known: `.../data/repositories/authority_reporitory_test.dart`, `.../application/authority_bloc_test.dart`, `.../application/usecases/list_authorities_usecase_test.dart`, `repository_contracts_test.dart`.)
+- [ ] Run `fvm flutter test`; green. Commit.
+
+### Task 3c: AccountRepository
+
+- [ ] Repo: `lib/features/account/data/repositories/account_repository.dart` — add ctor/field; replace `ApiClient.<verb>(` → `_apiClient.<verb>(`; **keep** `ApiClient.decodeUTF8(...)` static.
+- [ ] DI: `createAccountRepository(ApiClient api) => AccountRepository(api);` + provider reads `context.read<ApiClient>()`.
+- [ ] Tests: `grep -rln "AccountRepository(" test/` → inject helper. (Known: `.../data/repositories/account_repository_test.dart`, `.../application/account_bloc_test.dart`, `.../application/usecases/{register_account,reset_password,get_account,update_account,change_password}_usecase_test.dart`, `register_bloc_test.dart`, `change_password_bloc_test.dart`, `forgot_password_bloc_test.dart`, `repository_contracts_test.dart`.)
+- [ ] Run `fvm flutter test`; green. Commit.
+
+### Task 3d: LoginRepository (auth) — has an existing constructor
+
+- [ ] Repo: `lib/features/auth/data/repositories/auth_repository_impl.dart` — extend the ctor to require `apiClient`:
+  ```dart
+  LoginRepository({required ApiClient apiClient, ISecureStorage? secureStorage, IAuthSessionRepository? sessionRepository})
+      : _apiClient = apiClient,
+        _sessionRepository = sessionRepository ?? AuthSessionRepository(secureStorage: secureStorage ?? FlutterSecureStorageAdapter());
+  final ApiClient _apiClient;
+  ```
+  (Preserve the existing `_sessionRepository` init exactly; only add `_apiClient`.) Replace `ApiClient.<verb>(` → `_apiClient.<verb>(`.
+- [ ] DI: `app_dependencies.dart` → `IAuthRepository createAuthRepository(ISecureStorage secureStorage, ApiClient api) => LoginRepository(secureStorage: secureStorage, apiClient: api);`
+- [ ] DI: `app_scope.dart` → `RepositoryProvider<IAuthRepository>(create: (context) => dependencies.createAuthRepository(context.read<ISecureStorage>(), context.read<ApiClient>()))`.
+- [ ] Tests: `grep -rln "LoginRepository(" test/` → add `apiClient: TestUtils.apiClient()` to each construction (keep existing named args). (Known: `.../auth/data/repositories/login_repository_test.dart`, `login_bloc_test.dart`, `.../application/usecases/{authenticate_user,send_otp,verify_otp,logout,persist_auth_session}_usecase_test.dart` — verify with grep; some use `MockAuthRepository` and are unaffected.)
+- [ ] Run `fvm flutter test`; green. Commit.
+
+### Task 3e: DynamicFormRepository
+
+- [ ] Repo: `lib/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart` — add ctor/field; replace verbs.
+- [ ] DI: `createDynamicFormRepository(ApiClient api) => DynamicFormRepository(api);` + provider reads `context.read<ApiClient>()`.
+- [ ] Tests: these use `ApiClient.setTestInstance(testDio)` — switch to the `dio:` seam:
+  - `test/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl_test.dart`: replace `ApiClient.setTestInstance(testDio);` + `DynamicFormRepository()` with `final repo = DynamicFormRepository(TestUtils.apiClient(dio: testDio));`; delete the `ApiClient.reset()` line if no other static remains.
+  - `test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart`: same — build the repo (or whatever the bloc consumes) with `TestUtils.apiClient(dio: testDio)`; delete `setTestInstance`/`reset` lines that are now dead.
+- [ ] Run `fvm flutter test`; green. Commit.
+
+### Task 3f: LifecycleRepository (file-only — no wiring, no test)
+
+- [ ] Repo: `lib/features/lifecycle/data/repositories/lifecycle_repository.dart` — add `LifecycleRepository(this._apiClient); final ApiClient _apiClient;`; replace `ApiClient.get(` → `_apiClient.get(`.
+- [ ] Verify no production/test construction: `grep -rn "LifecycleRepository(" lib/ test/` → expect only the class definition (tests use `MockLifecycleRepository`). No DI/test edits.
+- [ ] Run `fvm flutter test`; green. Commit `refactor(#144): inject ApiClient into LifecycleRepository`.
+
+---
+
+## Task 4 (MIGRATE): Dashboard cubit reads instance snapshot + fix Finding #3 guard
+
+**Files:**
+- Modify: `lib/features/dashboard/application/dashboard_cubit.dart`
+- Modify: `lib/app/di/app_scope.dart`
+- Modify: `lib/features/dashboard/presentation/pages/dashboard_home_page.dart`
+- Test: `test/features/dashboard/application/dashboard_cubit_test.dart`
+
+- [ ] **Step 1: Inject `ApiClient` into `SystemDashboardCubit`**
+
+`dashboard_cubit.dart`: add `required ApiClient apiClient` to the constructor and a `final ApiClient _apiClient;` field; replace `final snapshot = ApiClient.interceptorChainSnapshot;` → `final snapshot = _apiClient.interceptorChainSnapshot;`. Import `api_client.dart`.
+
+- [ ] **Step 2: Wire it in `app_scope.dart`**
+
+In the `SystemDashboardCubit` provider add `apiClient: context.read<ApiClient>(),` to the existing named args.
+
+- [ ] **Step 3: Fix Finding #3 — guard the `AppConfig` read in `dashboard_home_page.dart`**
+
+In `_updateAppConfigFromLifecycle`, the `context.read<AppConfig>()` must not throw when the provider is absent (consistent with the sibling `LifecycleBloc` try/catch). Replace the `switch` block with a guarded read:
+
+```dart
+AppConfig? appConfig;
+try {
+  appConfig = context.read<AppConfig>();
+} catch (_) {
+  // AppConfig not provided (standalone/partial-DI pump) — fall back to dev label.
+}
+final environment = switch (appConfig?.environment) {
+  Environment.prod => 'prod',
+  Environment.test => 'test',
+  Environment.dev || null => 'dev',
+};
+```
+
+- [ ] **Step 4: Update `dashboard_cubit_test.dart` construction**
+
+`grep -n "SystemDashboardCubit(" test/features/dashboard/application/dashboard_cubit_test.dart` → add `apiClient: TestUtils.apiClient(),` to the named args. (`dashboard_page_test.dart` uses `MockSystemDashboardCubit` — unaffected.)
+
+- [ ] **Step 5: Run analyze + full suite**
+
+Run: `fvm dart analyze && fvm flutter test`
+Expected: clean + green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "$(printf 'refactor(#144): inject ApiClient into SystemDashboardCubit; guard dashboard AppConfig read\n\nDashboard reads interceptorChainSnapshot from the injected instance.\nGuards context.read<AppConfig>() to match the sibling LifecycleBloc\nfallback (review finding #3).\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5 (CONTRACT): Delete the static facade, all static config, and the `reset()` ceremony
+
+At this point `grep -rn "ApiClient\.\(get\|post\|put\|patch\|delete\|instance\|appConfig\|secureStorage\|setTestInstance\|reset\|interceptorChainSnapshot\)" lib/` should show NO production callers (only the class definition). Verify before deleting.
+
+**Files:**
+- Modify: `lib/infrastructure/http/api_client.dart`, `lib/app/bootstrap/app_bootstrap.dart`
+- Test: `test/infrastructure/http/api_client_test.dart`, `test/test_utils.dart`
+
+- [ ] **Step 1: Verify no static callers remain**
+
+Run: `grep -rn "ApiClient\.\(get\|post\|put\|patch\|delete\|instance\|appConfig\|secureStorage\|onSessionExpired\|setTestInstance\|resetTestInstance\|reset\|interceptorChainSnapshot\)" lib/`
+Expected: empty (the only `ApiClient.` left in lib is `ApiClient.decodeUTF8` in `account_repository.dart`, which is fine).
+
+- [ ] **Step 2: Delete the temporary static facade from `api_client.dart`**
+
+Remove: `_default`, `_staticConfig`, `static secureStorage`, `onSessionExpired_`, `_facade`, `static set/get appConfig`, `_testDio`, `setTestInstance`, `resetTestInstance`, `reset`, the static `get/post/put/patch/delete` delegators, and the static `interceptorChainSnapshot`/`interceptorChainSnapshotStatic`. Keep ONLY: the generative constructor, instance fields/getters/methods, `InterceptorChainEntry`, and the pure `static` utilities (`decodeUTF8`, `_serializeData`, `_mapDioException`, `_mapBadResponse`, `_mapUnknown`).
+
+- [ ] **Step 3: Clean `app_bootstrap.dart`**
+
+Delete the `ApiClient.appConfig = appConfig;` line and any `ApiClient.secureStorage = ...;`/`ApiClient.onSessionExpired = ...;` assignments. The shared `secureStorage` already flows to `ApiClient` via `AppScope` → `createApiClient`. Confirm `appConfig` is still built (`AppConfig.fromEnvironment`) and passed to `AppDependencies`.
+
+- [ ] **Step 4: Rewrite `api_client_test.dart` to pure instance form**
+
+Remove every `ApiClient.reset()`, `ApiClient.setTestInstance(...)`, `ApiClient.appConfig = ...`. Each test builds its own client: prod-stub group → `ApiClient(appConfig: const AppConfig.prod(), dio: testDio)`; mock group → `ApiClient(appConfig: const AppConfig.test(), secureStorage: FlutterSecureStorageAdapter())`; `decodeUTF8` group stays `ApiClient.decodeUTF8(...)` (static util); snapshot group uses a fresh `client.interceptorChainSnapshot`. No global teardown needed.
+
+- [ ] **Step 5: Clean `test_utils.dart`**
+
+Delete `ApiClient.appConfig = const AppConfig.test();` (both setups), `ApiClient.secureStorage = FlutterSecureStorageAdapter();` (both setups + teardown), and `ApiClient.reset();` in `tearDownUnitTest`. Keep `TestUtils.apiClient()`, the secure-storage MethodChannel mock, and `_clearStorage`. (The MethodChannel mock + `_clearStorage` remain the isolation mechanism; per-instance clients remove the need for `ApiClient.reset`.)
+
+- [ ] **Step 6: Run analyze + full suite + zero-globals check**
+
+Run: `fvm dart analyze && fvm flutter test`
+Then: `grep -rn "static " lib/infrastructure/http/api_client.dart` → only the logger, `_timeoutSeconds`, and the pure utility functions should remain (no mutable static state).
+Expected: clean + all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "$(printf 'refactor(#144): remove static ApiClient facade and all global config (contract phase)\n\nApiClient is now instance-only, injected via DI. Deletes the static\nfacade, static config/secureStorage, setTestInstance, and reset().\nbootstrap no longer mutates ApiClient statics. Zero mutable global state\nin the config + HTTP layer.\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: Final gates, format, PR, close #145
+
+- [ ] **Step 1: Format**
+
+Run: `fvm dart format . --line-length=120`
+If anything reformats: `git add -A && git commit -m "style: dart format"`.
+
+- [ ] **Step 2: Full verification**
+
+Run: `fvm dart analyze && fvm flutter test`
+Expected: analyze clean; all tests pass (target: same count as baseline, 1543+). Record the exact pass count from the output.
+
+- [ ] **Step 3: Push**
+
+Run: `git push -u origin feat/144-appconfig-apiclient-di`
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --repo cevheri/flutter-bloc-advanced --base main \
+  --title "feat(#144): immutable AppConfig + DI-injected ApiClient (no global state)" \
+  --body "$(printf 'Closes #144. Supersedes #145.\n\n## What\n- Replace global ProfileConstants map with immutable, typed AppConfig (kept from #145).\n- Convert static ApiClient to an instance injected through the existing RepositoryProvider DI spine.\n- 6 HTTP repositories receive ApiClient via constructor; one shared instance built in AppDependencies.\n- SystemDashboardCubit reads interceptorChainSnapshot from the injected instance.\n- Delete ApiClient.reset()/setTestInstance and all static config — test isolation is now structural.\n\n## Scope note (honest)\nIssue #144 asked for config DI. This PR also removes the *last* global by making ApiClient instance-injected (the review of #145 found ApiClient still held mutable global config). AuthSessionRepository/MenuRepository are untouched (no HTTP).\n\n## Review findings folded in\n- #2 dual source of truth: eliminated — one AppConfig, one ApiClient via DI.\n- #3 unguarded dashboard context.read<AppConfig>(): now guarded like the sibling LifecycleBloc read.\n\n## Verification\n- fvm dart analyze: clean\n- fvm flutter test: all green\n- fvm dart format --line-length=120: clean\n\nDesign + plan: docs/superpowers/specs and docs/superpowers/plans.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)')"
+```
+
+- [ ] **Step 5: Close #145 as superseded**
+
+```bash
+gh pr comment 145 --repo cevheri/flutter-bloc-advanced --body "Superseded by the new PR for #144, which keeps this AppConfig design and additionally removes the last global by making ApiClient instance-injected via DI. Closing as superseded."
+gh pr close 145 --repo cevheri/flutter-bloc-advanced
+```
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** §3.1 AppConfig→T1; §3.2 ApiClient instance→T2/T5; §3.3 repos→T3a–f; §3.4 DI→T2/T3/T4; §3.5 bootstrap→T1/T5; §3.6 finding #2→T5 (single source), finding #3→T4; §4 tests→T1–T5; §5 sequence→task order. All covered.
+- **Placeholder scan:** repo/test edits use exact paths + grep + explicit transforms; per-repo code shown. No TBD/TODO.
+- **Type consistency:** `ApiClient({required appConfig, secureStorage, onSessionExpired, dio})`, `_apiClient` field name, `createApiClient(ISecureStorage)`, `create<X>Repository(ApiClient)`, `TestUtils.apiClient({Dio? dio})`, `interceptorChainSnapshot` instance getter — consistent across tasks.
+- **Green invariant:** expand-migrate-contract keeps the full suite green at every commit; static facade removed only after all callers migrate (verified by grep in T5/S1).

--- a/docs/superpowers/plans/2026-06-02-appconfig-apiclient-di.md
+++ b/docs/superpowers/plans/2026-06-02-appconfig-apiclient-di.md
@@ -14,6 +14,18 @@
 
 ---
 
+## ⚠️ PLAN CORRECTION (during execution, after Task 1)
+
+The original Task 2 "expand" phase below is **not Dart-legal**: a class cannot declare a `static` member and an instance member with the same name (`get`, `instance`, `interceptorChainSnapshot`, …). So the member-level expand→migrate→contract for `ApiClient` cannot compile. Tasks 2–5 below are **superseded** by this convert-then-sweep flow (same end state, identical final diff):
+
+- **Task 2 (convert lib):** In ONE commit, convert `ApiClient` to a pure instance class (drop ALL mutable statics incl. the temporary `appConfig` from Task 1; keep only the pure-util statics `decodeUTF8`/`_serializeData`/`_mapDioException`/`_mapBadResponse`/`_mapUnknown`). Add ctor `ApiClient({required AppConfig appConfig, ISecureStorage? secureStorage, OnSessionExpired? onSessionExpired, Dio? dio})` storing private `_config`/`_secureStorage`/`_dio`; instance `instance`, `interceptorChainSnapshot`, `get/post/put/patch/delete`, `_createDio`. In the SAME commit update all *lib* consumers — the 6 repos (ctor `(this._apiClient)` + `ApiClient.<verb>` → `_apiClient.<verb>`; keep `ApiClient.decodeUTF8` static), `AppDependencies` (`createApiClient` + repo factories take `ApiClient`), `AppScope` (`RepositoryProvider<ApiClient>` after `ISecureStorage`; thread into repos + `SystemDashboardCubit`), `dashboard_cubit` (instance `interceptorChainSnapshot`), `dashboard_home_page` (Finding #3 guard), `app_bootstrap` (build `AppConfig`, NO `ApiClient` statics) — AND `test/test_utils.dart` (remove `ApiClient.appConfig/secureStorage/reset`; add `static ApiClient apiClient({Dio? dio})`). Outcome: `fvm dart analyze` clean (lib + test_utils compile); full `fvm flutter test` RED only for test files still constructing repos arg-lessly or using `ApiClient` statics.
+- **Task 3 (sweep tests):** Per feature, inject `TestUtils.apiClient()` into concrete repo/cubit constructions and switch `setTestInstance` → `dio:`; rewrite `api_client_test.dart` to instance form; delete dead `ApiClient.reset()`/`setTestInstance` lines. Each commit runs its touched files green; final commit = full suite green + zero-globals grep.
+- **Tasks 4 & 5 are folded into Task 2** (dashboard guard + global deletion happen in the single lib conversion). **Task 6 (PR) is unchanged.**
+
+The collision is why the facade in the original Task 2 below is struck; ignore the `_facade`/`_default`/`interceptorChainSnapshotStatic` mechanism — it cannot compile.
+
+---
+
 ## File Structure
 
 **Created:** none (design doc + this plan already exist).

--- a/docs/superpowers/specs/2026-06-02-appconfig-apiclient-di-design.md
+++ b/docs/superpowers/specs/2026-06-02-appconfig-apiclient-di-design.md
@@ -1,0 +1,141 @@
+# Design — Replace global config + static `ApiClient` with immutable `AppConfig` and DI-injected `ApiClient`
+
+- **Issue:** [#144](https://github.com/cevheri/flutter-bloc-advanced/issues/144) — *Replace `ProfileConstants` global map with immutable `AppConfig` injected via DI*
+- **Supersedes:** PR [#145](https://github.com/cevheri/flutter-bloc-advanced/pull/145) (draft) — keeps its `AppConfig` design, closes it as superseded
+- **Branch:** `feat/144-appconfig-apiclient-di` (from `main`)
+- **Date:** 2026-06-02
+- **Flutter/Dart:** 3.44.0 / Dart 3.12 — no 3.44 breaking change affects DI, providers, BLoC, or static patterns; direction (Dart 3 switch expressions, `final class`, null-aware spreads) reinforces this design.
+
+## 1. Problem
+
+Two coupled global-state problems:
+
+1. **`ProfileConstants`** (issue #144): a mutable global `static Map<String, dynamic>? _config`, environment re-derived by map *identity*, `dynamic` getters with `null!`, magic-string keys.
+2. **`ApiClient`**: a fully **static** class (`ApiClient.get/post/...`, `static Dio? _dio`, `static AppConfig`, `static secureStorage`, `static onSessionExpired`, `setTestInstance`/`reset`). PR #145 migrated `ProfileConstants` → `AppConfig` but **kept the config as a mutable static on `ApiClient`** (`ApiClient.appConfig = …`), reproducing the exact anti-pattern the issue targets and creating a **dual source of truth** (DI-provided `AppConfig` vs `ApiClient.appConfig` diverge outside bootstrap).
+
+This design eliminates **all** mutable global state in the config + HTTP layer. End state: **zero mutable global statics**; one immutable `AppConfig` and one `ApiClient`, both born in `AppDependencies` and injected through the existing `RepositoryProvider` DI spine.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Immutable, typed `AppConfig` (keep #145's `final class` design) as the single config object.
+- `ApiClient` becomes an injectable instance; repositories receive it via constructor.
+- One shared `ApiClient`/`AppConfig` provided once via DI; consumers read from DI, never from a global.
+- Delete `ApiClient.reset()`/`setTestInstance` ceremony — isolation becomes structural.
+- All 1543 tests green; `dart analyze` clean; `dart format` clean.
+
+**Non-goals (explicitly out of scope)**
+- Wiring `onSessionExpired` (currently dormant — never assigned in `lib/`; preserved as a nullable ctor param).
+- Converting other `.instance` singletons (`ResilienceInterceptor`, `ConnectivityService`, `FeatureFlagService`, `SharedPrefsCacheStorage`) to DI — separate concern.
+- Any change to interceptor behavior, error mapping, certificate pinning, or mock-data serving.
+
+## 3. Design
+
+### 3.1 `AppConfig` (from #145, kept as-is)
+
+`final class AppConfig` in `lib/infrastructure/config/environment.dart`: `Environment environment`, `String? apiBaseUrl`, `List<String> certificatePins`, `Duration? idleTimeout`; `const` `.dev()/.test()/.prod()` constructors + `factory AppConfig.fromEnvironment(Environment)`; `isProduction/isDevelopment/isTest` getters; prod-only `sentryDsn` (`String.fromEnvironment`). `ProfileConstants` + `_Config` deleted.
+
+### 3.2 `ApiClient` → instance (`lib/infrastructure/http/api_client.dart`)
+
+```dart
+class ApiClient {
+  ApiClient({
+    required this.appConfig,
+    ISecureStorage? secureStorage,
+    this.onSessionExpired,
+    Dio? dio,                       // test seam — replaces setTestInstance()
+  })  : _secureStorage = secureStorage,
+        _dio = dio;
+
+  final AppConfig appConfig;
+  final OnSessionExpired? onSessionExpired;
+  final ISecureStorage? _secureStorage;
+  Dio? _dio;
+  List<InterceptorChainEntry> _chainSnapshot = const [];
+
+  Dio get instance => _dio ??= _createDio();
+  List<InterceptorChainEntry> get interceptorChainSnapshot => List.unmodifiable(_chainSnapshot);
+
+  Future<Response<String>> get(...) { ... }   // get/post/put/patch/delete: static → instance
+  Dio _createDio() { ... }                     // reads this.appConfig / this._secureStorage / this.onSessionExpired
+
+  static String decodeUTF8(String s) { ... }   // PURE util → stays static (no global state)
+  static AppException _mapDioException(...) { } // pure mappers → stay static
+}
+```
+
+**Removed:** `static Dio? _dio`, `static Dio? _testDio`, `static AppConfig _appConfig` + setter, `static ISecureStorage? secureStorage`, `static OnSessionExpired? onSessionExpired`, `setTestInstance`, `resetTestInstance`, `reset`. `InterceptorChainEntry` and the static pure functions (`decodeUTF8`, `_mapDioException`, `_mapBadResponse`, `_mapUnknown`, `_serializeData`) stay.
+
+### 3.3 Repositories
+
+Exactly **six** repositories issue HTTP (confirmed by grep); each takes `ApiClient` via constructor (required, no default — nothing ambient):
+
+- `UserRepository(this._apiClient)`, `AccountRepository(this._apiClient)`, `AuthorityRepositoryImpl(this._apiClient)`, `DynamicFormRepository(this._apiClient)`, `LifecycleRepository(this._apiClient)`.
+- Auth login repo takes both: `LoginRepository({required ISecureStorage secureStorage, required ApiClient apiClient})`.
+- **Unchanged (no HTTP — verified):** `AuthSessionRepository` and `MenuRepository` make zero `ApiClient` calls, so their constructors and tests are NOT touched.
+- `ApiClient.get(...)` calls become `_apiClient.get(...)`; `ApiClient.decodeUTF8(...)` stays a static call (pure util).
+
+### 3.4 DI wiring
+
+`AppDependencies` (stays `const`-constructible, `appConfig` only):
+```dart
+ApiClient createApiClient(ISecureStorage secureStorage) =>
+    ApiClient(appConfig: appConfig, secureStorage: secureStorage);
+IUserRepository createUserRepository(ApiClient api) => UserRepository(api);
+// …one per repo; auth repos take (secureStorage, api)
+```
+
+`AppScope` (`MultiRepositoryProvider`, order: `ISecureStorage` → `AppConfig` → `ApiClient` → repos):
+```dart
+RepositoryProvider<AppConfig>.value(value: dependencies.appConfig),
+RepositoryProvider<ApiClient>(create: (ctx) => dependencies.createApiClient(ctx.read<ISecureStorage>())),
+RepositoryProvider<IUserRepository>(create: (ctx) => dependencies.createUserRepository(ctx.read<ApiClient>())),
+// …other repos read ctx.read<ApiClient>()
+```
+
+`SystemDashboardCubit`: inject `apiClient: ctx.read<ApiClient>()`, read `apiClient.interceptorChainSnapshot` (was static). `dashboard_home_page` env read uses `context.read<AppConfig>()` (guarded — see 3.6).
+
+### 3.5 Bootstrap
+
+`AppBootstrap.run` drops all `ApiClient.xxx =` static assignments. It still creates the shared `ISecureStorage` (for migration) and passes it to `App`; that same instance flows into `createApiClient` via DI, so the migration-vs-runtime single-source-of-truth (today guarded by comments + discipline) becomes **structural**. `AppConfig` built once via `AppConfig.fromEnvironment(config.environment)` and passed into `AppDependencies`.
+
+### 3.6 Review-finding fixes folded in
+
+- **Finding #2 (dual source of truth):** eliminated by construction — one `AppConfig`, one `ApiClient`, single DI spine.
+- **Finding #3 (unguarded `context.read<AppConfig>()` in `dashboard_home_page`):** the read sits outside the `try/catch` that guards the sibling `LifecycleBloc` read. Fix: read `AppConfig` defensively consistent with that guard (e.g. `context.read<AppConfig>()` inside the same resilience boundary, or `read<AppConfig?>` baseline fallback) so a dashboard pumped without the provider degrades instead of throwing.
+
+## 4. Test strategy
+
+Principle: **tests construct what they use; nothing ambient.**
+
+`test_utils.dart`: remove `ApiClient.appConfig/secureStorage/reset`. Add a factory:
+```dart
+static ApiClient apiClient({Dio? dio}) => ApiClient(
+    appConfig: const AppConfig.test(),
+    secureStorage: FlutterSecureStorageAdapter(), dio: dio);
+```
+(test `AppConfig` → `MockInterceptor` serves `assets/mock/*.json`; shared secure adapter → same MethodChannel mock the repo layer reads.)
+
+Mechanical sweep (~34 files):
+- Concrete repo construction `XRepository()` → `XRepository(TestUtils.apiClient())` (repo-impl, use-case, some bloc/presentation tests).
+- `ApiClient.setTestInstance(testDio)` → `dio: testDio` ctor arg (dynamic_form tests, `api_client_test` prod group).
+- Delete `ApiClient.reset()` + global re-wiring from `setUp`/`tearDown`.
+- `api_client_test.dart`: rewrite to instance form, incl. `interceptorChainSnapshot` + `decodeUTF8` groups.
+- Tests that **mock** repos (mocktail) are unaffected.
+
+## 5. Build sequence (TDD, suite green at each step)
+
+1. `AppConfig` in `environment.dart` + `environment_test.dart` (re-apply #145 design). Delete `ProfileConstants`.
+2. Rewrite `api_client_test.dart` to the new instance contract (red) → convert `ApiClient` to instance (green). Keep static pure utils.
+3. Convert repositories one feature at a time; update their impl tests as each converts (green per feature).
+4. Wire `AppDependencies` + `AppScope` + bootstrap + `SystemDashboardCubit`; fix Finding #3 in `dashboard_home_page`.
+5. Sweep remaining use-case/bloc/presentation tests + `test_utils`.
+6. Gates: `fvm flutter test` (1543 green), `fvm dart analyze` (clean), `fvm dart format . --line-length=120`.
+7. PR: fresh branch → new PR closing #144; close #145 as superseded with a note.
+
+## 6. Risks
+
+- **Largest risk — test churn (~34 files):** mitigated by the single `TestUtils.apiClient()` helper (one-token edits) and feature-by-feature conversion keeping the suite green.
+- **Provider ordering:** `ISecureStorage` must precede `ApiClient` must precede repos in `AppScope` (same constraint `IAuthRepository` already lives under).
+- **Hidden concrete-repo construction** in tests not caught by grep: surfaced by failing tests during the sweep.
+- **Behavior parity:** no interceptor/error/pinning/mock logic changes; `onSessionExpired` stays dormant (no behavior change).

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -75,7 +75,7 @@ class _AppViewState extends State<_AppView> {
         // Sentry breadcrumbs from navigation. Only meaningful when the
         // Sentry SDK was initialized in bootstrap (production + DSN);
         // outside that window the observer is harmless overhead.
-        if (ProfileConstants.sentryDsn != null) SentryNavigatorObserver(),
+        if (context.read<AppConfig>().sentryDsn != null) SentryNavigatorObserver(),
       ],
     ).create();
   }

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -28,9 +28,9 @@ class AppBootstrap {
     AppLogger.configure(isProduction: config.isProduction);
     final log = AppLogger.getLogger('AppBootstrap');
 
-    ProfileConstants.setEnvironment(config.environment);
-
-    final dependencies = AppDependencies(environment: config.environment);
+    final appConfig = AppConfig.fromEnvironment(config.environment);
+    final dependencies = AppDependencies(appConfig: appConfig);
+    ApiClient.appConfig = appConfig;
     final secureStorage = dependencies.createSecureStorage();
     // Publish the same adapter instance into the static [ApiClient]
     // hook so AuthInterceptor and TokenRefreshInterceptor share it
@@ -72,7 +72,7 @@ class AppBootstrap {
     // twice. With Sentry off, forwarding to the local logging analytics is the
     // only sink, so it stays enabled.
     final analytics = dependencies.createAnalyticsService();
-    final sentryActive = ProfileConstants.sentryDsn != null;
+    final sentryActive = appConfig.sentryDsn != null;
     CrashReporter.install(analytics, forwardToAnalytics: !sentryActive);
 
     Bloc.observer = kDebugMode ? TimeTravelBlocObserver() : AppBlocObserver();
@@ -92,7 +92,7 @@ class AppBootstrap {
     // the entire widget tree shares one adapter instance — no config
     // drift between migration and runtime consumers, and overriding
     // for tests / alternate environments is a single hand-off.
-    final dsn = ProfileConstants.sentryDsn;
+    final dsn = appConfig.sentryDsn;
     if (dsn != null) {
       log.info('Initializing Sentry (release: {}+{})', [AppConstants.appVersion, AppConstants.appBuildNumber]);
       await SentryFlutter.init(

--- a/lib/app/bootstrap/app_bootstrap.dart
+++ b/lib/app/bootstrap/app_bootstrap.dart
@@ -12,7 +12,6 @@ import 'package:flutter_bloc_advance/infrastructure/analytics/sentry_scrub.dart'
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/local_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/session_migration.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
@@ -30,15 +29,7 @@ class AppBootstrap {
 
     final appConfig = AppConfig.fromEnvironment(config.environment);
     final dependencies = AppDependencies(appConfig: appConfig);
-    ApiClient.appConfig = appConfig;
     final secureStorage = dependencies.createSecureStorage();
-    // Publish the same adapter instance into the static [ApiClient]
-    // hook so AuthInterceptor and TokenRefreshInterceptor share it
-    // with the repository layer and SessionCubit. Invariant: this
-    // must run before [ApiClient.instance] is touched anywhere —
-    // Dio is built lazily on first access. Any code path that may
-    // issue HTTP requests must come below this line.
-    ApiClient.secureStorage = secureStorage;
 
     // One-shot migration of legacy plaintext tokens (jwtToken/refreshToken).
     // Must run BEFORE any consumer reads the secure store (SessionCubit

--- a/lib/app/bootstrap/app_session_listeners.dart
+++ b/lib/app/bootstrap/app_session_listeners.dart
@@ -13,9 +13,9 @@ class AppSessionListeners extends StatefulWidget {
 
   final Widget child;
 
-  /// Test seam — lets a widget test inject a smaller threshold than
-  /// production without re-pointing [ProfileConstants]. Null falls back
-  /// to [ProfileConstants.idleTimeout].
+  /// Test seam — lets a widget test inject a smaller threshold than the
+  /// injected [AppConfig]. Null falls back to the [AppConfig.idleTimeout]
+  /// read from the widget tree via [context.read<AppConfig>()].
   final Duration? idleTimeoutOverride;
 
   @override
@@ -36,7 +36,7 @@ class _AppSessionListenersState extends State<AppSessionListeners> {
 
   void _startIdleObserver() {
     if (_idleObserver != null) return;
-    final threshold = widget.idleTimeoutOverride ?? ProfileConstants.idleTimeout;
+    final threshold = widget.idleTimeoutOverride ?? context.read<AppConfig>().idleTimeout;
     if (threshold == null) {
       _log.debug('idle timeout disabled (no threshold configured)');
       return;

--- a/lib/app/dev_console/tabs/environment_tab.dart
+++ b/lib/app/dev_console/tabs/environment_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/shared/utils/app_constants.dart';
 import 'package:flutter_bloc_advance/shared/design_system/tokens/app_spacing.dart';
@@ -15,7 +16,7 @@ class EnvironmentTab extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final semantic = context.semanticColors;
 
-    final envInfo = _buildEnvironmentInfo();
+    final envInfo = _buildEnvironmentInfo(context.read<AppConfig>());
     // Read everything from the router itself, not from GoRouterState.of(context):
     // the dev console is shown in a modal bottom sheet whose subtree is not
     // under any GoRoute.builder, so GoRouterState.of has no scope to resolve
@@ -44,10 +45,10 @@ class EnvironmentTab extends StatelessWidget {
     );
   }
 
-  Map<String, String> _buildEnvironmentInfo() {
+  Map<String, String> _buildEnvironmentInfo(AppConfig appConfig) {
     return {
-      'Environment': ProfileConstants.isProduction ? 'Production' : (ProfileConstants.isTest ? 'Test' : 'Development'),
-      'API Endpoint': ProfileConstants.isProduction ? (ProfileConstants.api?.toString() ?? 'N/A') : 'Mock',
+      'Environment': appConfig.isProduction ? 'Production' : (appConfig.isTest ? 'Test' : 'Development'),
+      'API Endpoint': appConfig.apiBaseUrl ?? 'Mock',
       'App Version': AppConstants.appVersion.isNotEmpty ? AppConstants.appVersion : 'N/A',
       'Build Number': AppConstants.appBuildNumber.isNotEmpty ? AppConstants.appBuildNumber : 'N/A',
       'App Name': AppConstants.appName.isNotEmpty ? AppConstants.appName : 'N/A',

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -18,16 +18,16 @@ import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class AppDependencies {
-  const AppDependencies({this.environment = Environment.dev});
+  const AppDependencies({this.appConfig = const AppConfig.dev()});
 
-  final Environment environment;
+  final AppConfig appConfig;
 
   /// Returns the analytics implementation appropriate for the active
   /// environment. Production + non-empty DSN → [SentryAnalyticsService]
   /// (Sentry SDK assumed already-initialized by bootstrap); any other
   /// case → [LogAnalyticsService] (local-only, no network egress).
   IAnalyticsService createAnalyticsService() {
-    if (ProfileConstants.sentryDsn != null) {
+    if (appConfig.sentryDsn != null) {
       return SentryAnalyticsService();
     }
     return LogAnalyticsService();

--- a/lib/app/di/app_dependencies.dart
+++ b/lib/app/di/app_dependencies.dart
@@ -15,6 +15,7 @@ import 'package:flutter_bloc_advance/core/analytics/analytics_service.dart';
 import 'package:flutter_bloc_advance/core/analytics/log_analytics_service.dart';
 import 'package:flutter_bloc_advance/infrastructure/analytics/sentry_analytics_service.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 
 class AppDependencies {
@@ -33,20 +34,24 @@ class AppDependencies {
     return LogAnalyticsService();
   }
 
-  IAccountRepository createAccountRepository() => AccountRepository();
+  ApiClient createApiClient(ISecureStorage secureStorage) =>
+      ApiClient(appConfig: appConfig, secureStorage: secureStorage);
 
-  IAuthRepository createAuthRepository(ISecureStorage secureStorage) => LoginRepository(secureStorage: secureStorage);
+  IAccountRepository createAccountRepository(ApiClient apiClient) => AccountRepository(apiClient);
+
+  IAuthRepository createAuthRepository(ISecureStorage secureStorage, ApiClient apiClient) =>
+      LoginRepository(secureStorage: secureStorage, apiClient: apiClient);
 
   IAuthSessionRepository createAuthSessionRepository(ISecureStorage secureStorage) =>
       AuthSessionRepository(secureStorage: secureStorage);
 
-  IAuthorityRepository createAuthorityRepository() => AuthorityRepositoryImpl();
+  IAuthorityRepository createAuthorityRepository(ApiClient apiClient) => AuthorityRepositoryImpl(apiClient);
 
-  IDynamicFormRepository createDynamicFormRepository() => DynamicFormRepository();
+  IDynamicFormRepository createDynamicFormRepository(ApiClient apiClient) => DynamicFormRepository(apiClient);
 
   MenuRepository createMenuRepository() => MenuRepository();
 
   ISecureStorage createSecureStorage() => FlutterSecureStorageAdapter();
 
-  IUserRepository createUserRepository() => UserRepository();
+  IUserRepository createUserRepository(ApiClient apiClient) => UserRepository(apiClient);
 }

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -24,6 +24,7 @@ import 'package:flutter_bloc_advance/features/users/application/authority_bloc.d
 import 'package:flutter_bloc_advance/features/users/application/usecases/list_authorities_usecase.dart';
 import 'package:flutter_bloc_advance/infrastructure/cache/shared_prefs_cache_storage.dart';
 import 'package:flutter_bloc_advance/infrastructure/connectivity/connectivity_service.dart';
+import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/resilience_interceptor.dart';
 import 'package:flutter_bloc_advance/core/feature_flags/feature_flag_service.dart';
 import 'package:flutter_bloc_advance/features/users/domain/repositories/user_repository.dart';
@@ -53,17 +54,29 @@ class AppScope extends StatelessWidget {
         else
           RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
         RepositoryProvider<AppConfig>.value(value: dependencies.appConfig),
-        RepositoryProvider<IAccountRepository>(create: (_) => dependencies.createAccountRepository()),
-        RepositoryProvider<IAuthorityRepository>(create: (_) => dependencies.createAuthorityRepository()),
+        RepositoryProvider<ApiClient>(
+          create: (context) => dependencies.createApiClient(context.read<ISecureStorage>()),
+        ),
+        RepositoryProvider<IAccountRepository>(
+          create: (context) => dependencies.createAccountRepository(context.read<ApiClient>()),
+        ),
+        RepositoryProvider<IAuthorityRepository>(
+          create: (context) => dependencies.createAuthorityRepository(context.read<ApiClient>()),
+        ),
         RepositoryProvider<IAuthRepository>(
-          create: (context) => dependencies.createAuthRepository(context.read<ISecureStorage>()),
+          create: (context) =>
+              dependencies.createAuthRepository(context.read<ISecureStorage>(), context.read<ApiClient>()),
         ),
         RepositoryProvider<IAuthSessionRepository>(
           create: (context) => dependencies.createAuthSessionRepository(context.read<ISecureStorage>()),
         ),
-        RepositoryProvider<IDynamicFormRepository>(create: (_) => dependencies.createDynamicFormRepository()),
+        RepositoryProvider<IDynamicFormRepository>(
+          create: (context) => dependencies.createDynamicFormRepository(context.read<ApiClient>()),
+        ),
         RepositoryProvider<MenuRepository>(create: (_) => dependencies.createMenuRepository()),
-        RepositoryProvider<IUserRepository>(create: (_) => dependencies.createUserRepository()),
+        RepositoryProvider<IUserRepository>(
+          create: (context) => dependencies.createUserRepository(context.read<ApiClient>()),
+        ),
       ],
       child: MultiBlocProvider(
         providers: [
@@ -101,11 +114,12 @@ class AppScope extends StatelessWidget {
           ),
           BlocProvider<SidebarBloc>(create: (_) => SidebarBloc()),
           BlocProvider<SystemDashboardCubit>(
-            create: (_) => SystemDashboardCubit(
+            create: (context) => SystemDashboardCubit(
               connectivityService: ConnectivityService.instance,
               featureFlagService: FeatureFlagService.instance,
               resilienceInterceptor: ResilienceInterceptor.instance,
               cacheStorage: SharedPrefsCacheStorage.instance,
+              apiClient: context.read<ApiClient>(),
             ),
           ),
         ],

--- a/lib/app/di/app_scope.dart
+++ b/lib/app/di/app_scope.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/app/connectivity/connectivity_cubit.dart';
 import 'package:flutter_bloc_advance/app/di/app_dependencies.dart';
+import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/app/shell/menu_bloc/menu_bloc.dart';
 import 'package:flutter_bloc_advance/app/shell/sidebar/sidebar_bloc.dart';
 import 'package:flutter_bloc_advance/app/session/session_cubit.dart';
@@ -51,6 +52,7 @@ class AppScope extends StatelessWidget {
           RepositoryProvider<ISecureStorage>.value(value: secure)
         else
           RepositoryProvider<ISecureStorage>(create: (_) => dependencies.createSecureStorage()),
+        RepositoryProvider<AppConfig>.value(value: dependencies.appConfig),
         RepositoryProvider<IAccountRepository>(create: (_) => dependencies.createAccountRepository()),
         RepositoryProvider<IAuthorityRepository>(create: (_) => dependencies.createAuthorityRepository()),
         RepositoryProvider<IAuthRepository>(
@@ -67,7 +69,9 @@ class AppScope extends StatelessWidget {
         providers: [
           BlocProvider<ConnectivityCubit>(create: (_) => ConnectivityCubit()..monitor()),
           BlocProvider<SessionCubit>(
-            create: (context) => SessionCubit(secureStorage: context.read<ISecureStorage>())..restore(),
+            create: (context) =>
+                SessionCubit(secureStorage: context.read<ISecureStorage>(), appConfig: context.read<AppConfig>())
+                  ..restore(),
           ),
           BlocProvider<LoginBloc>(
             create: (context) => LoginBloc(

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -95,14 +95,14 @@ enum SessionExpiredReason {
 /// Consumers (router redirect, UI guards) pattern-match on [state];
 /// callers that want to re-evaluate trigger [refresh].
 class SessionCubit extends Cubit<SessionState> {
-  SessionCubit({ISecureStorage? secureStorage, this.appConfig = const AppConfig.dev()})
+  SessionCubit({ISecureStorage? secureStorage, this._appConfig = const AppConfig.dev()})
     : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
       super(const SessionUnknown());
 
   static final _log = AppLogger.getLogger('SessionCubit');
 
   final ISecureStorage _secureStorage;
-  final AppConfig appConfig;
+  final AppConfig _appConfig;
 
   Future<void> restore() async {
     // ISecureStorage.read can throw on platform / decryption failure.
@@ -122,7 +122,7 @@ class SessionCubit extends Cubit<SessionState> {
       // In production we additionally reject expired tokens. In non-prod
       // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
       // `exp` claim does not log the user out on every restart.
-      if (appConfig.isProduction) {
+      if (_appConfig.isProduction) {
         final expired = SecurityUtils.isTokenExpired(token);
         _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
         if (expired) {

--- a/lib/app/session/session_cubit.dart
+++ b/lib/app/session/session_cubit.dart
@@ -95,13 +95,14 @@ enum SessionExpiredReason {
 /// Consumers (router redirect, UI guards) pattern-match on [state];
 /// callers that want to re-evaluate trigger [refresh].
 class SessionCubit extends Cubit<SessionState> {
-  SessionCubit({ISecureStorage? secureStorage})
+  SessionCubit({ISecureStorage? secureStorage, this.appConfig = const AppConfig.dev()})
     : _secureStorage = secureStorage ?? FlutterSecureStorageAdapter(),
       super(const SessionUnknown());
 
   static final _log = AppLogger.getLogger('SessionCubit');
 
   final ISecureStorage _secureStorage;
+  final AppConfig appConfig;
 
   Future<void> restore() async {
     // ISecureStorage.read can throw on platform / decryption failure.
@@ -121,7 +122,7 @@ class SessionCubit extends Cubit<SessionState> {
       // In production we additionally reject expired tokens. In non-prod
       // (mocks/dev) we stay lenient so a static MOCK_TOKEN without an
       // `exp` claim does not log the user out on every restart.
-      if (ProfileConstants.isProduction) {
+      if (appConfig.isProduction) {
         final expired = SecurityUtils.isTokenExpired(token);
         _log.info('restore: token found, expired={} → authenticated={}', [expired, !expired]);
         if (expired) {

--- a/lib/features/account/data/repositories/account_repository.dart
+++ b/lib/features/account/data/repositories/account_repository.dart
@@ -9,6 +9,10 @@ import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
 
 class AccountRepository implements IAccountRepository {
+  AccountRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
   static final _log = AppLogger.getLogger('AccountRepository');
 
   static const _resource = 'account';
@@ -29,7 +33,7 @@ class AccountRepository implements IAccountRepository {
         user = user.copyWith(langKey: 'en');
       }
       user = user.copyWith(authorities: ['ROLE_USER']);
-      final response = await ApiClient.post<User>('/register', User.fromEntity(user));
+      final response = await _apiClient.post<User>('/register', User.fromEntity(user));
       final decoded = ApiClient.decodeUTF8(response.data!);
       final result = User.fromJsonString(decoded);
       if (result == null) {
@@ -59,7 +63,7 @@ class AccountRepository implements IAccountRepository {
           passwordChangeDTO.newPassword!.isEmpty) {
         return const Failure(ValidationError('Current password and new password are required'));
       }
-      final response = await ApiClient.post<PasswordChangeDTO>('/$_resource/change-password', passwordChangeDTO);
+      final response = await _apiClient.post<PasswordChangeDTO>('/$_resource/change-password', passwordChangeDTO);
       if ((response.statusCode ?? 0) < 400) {
         _log.debug('END:changePassword successful');
         return const Success(null);
@@ -87,7 +91,7 @@ class AccountRepository implements IAccountRepository {
       if (!mailAddress.contains('@') || !mailAddress.contains('.')) {
         return const Failure(ValidationError('Mail address is invalid'));
       }
-      final response = await ApiClient.post<String>(
+      final response = await _apiClient.post<String>(
         '/$_resource/reset-password/init',
         mailAddress,
         headers: {'Accept': 'application/json, text/plain, */*'},
@@ -114,7 +118,7 @@ class AccountRepository implements IAccountRepository {
   Future<Result<UserEntity>> getAccount() async {
     _log.debug('BEGIN:getAccount repository start');
     try {
-      final response = await ApiClient.get('/$_resource');
+      final response = await _apiClient.get('/$_resource');
       final decoded = ApiClient.decodeUTF8(response.data!);
       final parsed = User.fromJsonString(decoded);
       if (parsed == null) {
@@ -141,7 +145,7 @@ class AccountRepository implements IAccountRepository {
         return const Failure(ValidationError(userIdNotNull));
       }
       final updatedUser = user.copyWith(langKey: user.langKey ?? 'en');
-      final response = await ApiClient.post<User>('/$_resource', User.fromEntity(updatedUser));
+      final response = await _apiClient.post<User>('/$_resource', User.fromEntity(updatedUser));
       final decoded = ApiClient.decodeUTF8(response.data!);
       final parsed = User.fromJsonString(decoded);
       if (parsed == null) {
@@ -169,7 +173,7 @@ class AccountRepository implements IAccountRepository {
       if (id.isEmpty) {
         return const Failure(ValidationError(userIdNotNull));
       }
-      final response = await ApiClient.delete('/$_resource/$id');
+      final response = await _apiClient.delete('/$_resource/$id');
       _log.debug('END:deleteAccount successful - response.status: {}', [response.statusCode]);
       if (response.statusCode == 204) {
         return const Success(null);

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -14,9 +14,11 @@ import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart'
 class LoginRepository implements IAuthRepository {
   static final _log = AppLogger.getLogger("LoginRepository");
 
-  LoginRepository({ISecureStorage? secureStorage, IAuthSessionRepository? sessionRepository})
+  LoginRepository({required this._apiClient, ISecureStorage? secureStorage, IAuthSessionRepository? sessionRepository})
     : _sessionRepository =
           sessionRepository ?? AuthSessionRepository(secureStorage: secureStorage ?? FlutterSecureStorageAdapter());
+
+  final ApiClient _apiClient;
 
   final IAuthSessionRepository _sessionRepository;
 
@@ -29,7 +31,7 @@ class LoginRepository implements IAuthRepository {
       }
 
       final request = AuthMapper.toUserJwt(userJWT);
-      final response = await ApiClient.post("/authenticate", request);
+      final response = await _apiClient.post("/authenticate", request);
       final result = JWTToken.fromJsonString(response.data!);
       _log.debug("END:authenticate successful - response.body: {}", [result.toString()]);
       final entity = AuthMapper.toTokenEntity(result);
@@ -77,7 +79,7 @@ class LoginRepository implements IAuthRepository {
       if (request.email.isEmpty) {
         return const Failure(ValidationError("Invalid email"));
       }
-      final response = await ApiClient.post(
+      final response = await _apiClient.post(
         "/authenticate/send-otp",
         AuthMapper.toSendOtpRequest(request),
         headers: {"Content-Type": "application/json"},
@@ -115,7 +117,7 @@ class LoginRepository implements IAuthRepository {
         return const Failure(ValidationError("Invalid OTP"));
       }
 
-      final response = await ApiClient.post(
+      final response = await _apiClient.post(
         "/authenticate/verify-otp",
         AuthMapper.toVerifyOtpRequest(request),
         headers: {"Content-Type": "application/json"},

--- a/lib/features/dashboard/application/dashboard_cubit.dart
+++ b/lib/features/dashboard/application/dashboard_cubit.dart
@@ -22,6 +22,7 @@ class SystemDashboardCubit extends Cubit<SystemDashboardState> {
     required this._featureFlagService,
     required this._resilienceInterceptor,
     required this._cacheStorage,
+    required this._apiClient,
   }) : super(const SystemDashboardState()) {
     _connectivitySubscription = _connectivityService.statusStream.listen(_onConnectivityChanged);
     _featureFlagService.addListener(_onFeatureFlagsChanged);
@@ -33,6 +34,7 @@ class SystemDashboardCubit extends Cubit<SystemDashboardState> {
   final FeatureFlagService _featureFlagService;
   final ResilienceInterceptor _resilienceInterceptor;
   final SharedPrefsCacheStorage _cacheStorage;
+  final ApiClient _apiClient;
 
   StreamSubscription<ConnectivityStatus>? _connectivitySubscription;
 
@@ -152,11 +154,11 @@ class SystemDashboardCubit extends Cubit<SystemDashboardState> {
   // ---------------------------------------------------------------------------
 
   /// Snapshot of the live interceptor chain. Pulled from
-  /// [ApiClient.interceptorChainSnapshot] so the dashboard cannot drift
-  /// out of sync when interceptors are added, removed, or conditionally
-  /// included (fixes #64).
+  /// [ApiClient.interceptorChainSnapshot] (instance getter) so the
+  /// dashboard cannot drift out of sync when interceptors are added,
+  /// removed, or conditionally included (fixes #64).
   List<InterceptorInfo> _buildInterceptorList() {
-    final snapshot = ApiClient.interceptorChainSnapshot;
+    final snapshot = _apiClient.interceptorChainSnapshot;
     return [
       for (var i = 0; i < snapshot.length; i++)
         InterceptorInfo(name: snapshot[i].name, order: i + 1, active: snapshot[i].active, detail: snapshot[i].detail),

--- a/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
@@ -59,10 +59,16 @@ class _DashboardHomePageState extends State<DashboardHomePage> {
       _ => null,
     };
 
-    final environment = switch (context.read<AppConfig>().environment) {
+    AppConfig? appConfig;
+    try {
+      appConfig = context.read<AppConfig>();
+    } catch (_) {
+      // AppConfig not provided (standalone/partial-DI pump) — fall back to dev label.
+    }
+    final environment = switch (appConfig?.environment) {
       Environment.prod => 'prod',
-      Environment.dev => 'dev',
       Environment.test => 'test',
+      Environment.dev || null => 'dev',
     };
 
     context.read<SystemDashboardCubit>().updateAppConfig(

--- a/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
@@ -62,7 +62,7 @@ class _DashboardHomePageState extends State<DashboardHomePage> {
     AppConfig? appConfig;
     try {
       appConfig = context.read<AppConfig>();
-    } catch (_) {
+    } on ProviderNotFoundException {
       // AppConfig not provided (standalone/partial-DI pump) — fall back to dev label.
     }
     final environment = switch (appConfig?.environment) {

--- a/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_home_page.dart
@@ -59,11 +59,11 @@ class _DashboardHomePageState extends State<DashboardHomePage> {
       _ => null,
     };
 
-    final environment = ProfileConstants.isProduction
-        ? 'prod'
-        : ProfileConstants.isDevelopment
-        ? 'dev'
-        : 'test';
+    final environment = switch (context.read<AppConfig>().environment) {
+      Environment.prod => 'prod',
+      Environment.dev => 'dev',
+      Environment.test => 'test',
+    };
 
     context.read<SystemDashboardCubit>().updateAppConfig(
       AppConfigSummary(

--- a/lib/features/lifecycle/data/repositories/lifecycle_repository.dart
+++ b/lib/features/lifecycle/data/repositories/lifecycle_repository.dart
@@ -8,13 +8,17 @@ import 'package:flutter_bloc_advance/features/lifecycle/domain/repositories/life
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 
 class LifecycleRepository implements ILifecycleRepository {
+  LifecycleRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
   static final _log = AppLogger.getLogger('LifecycleRepository');
 
   @override
   Future<Result<AppConfigEntity>> fetchAppConfig() async {
     _log.debug('Fetching app config');
     try {
-      final response = await ApiClient.get('/app/config');
+      final response = await _apiClient.get('/app/config');
       final model = AppConfigModel.fromJsonString(response.data!);
       return Success(model);
     } on UnauthorizedException catch (e) {

--- a/lib/features/users/data/repositories/authority_repository.dart
+++ b/lib/features/users/data/repositories/authority_repository.dart
@@ -7,9 +7,11 @@ import 'package:flutter_bloc_advance/features/users/domain/repositories/authorit
 import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 
 class AuthorityRepositoryImpl implements IAuthorityRepository {
-  static final _log = AppLogger.getLogger('AuthorityRepository');
+  AuthorityRepositoryImpl(this._apiClient);
 
-  AuthorityRepositoryImpl();
+  final ApiClient _apiClient;
+
+  static final _log = AppLogger.getLogger('AuthorityRepository');
 
   final String _resource = 'authorities';
 
@@ -20,7 +22,7 @@ class AuthorityRepositoryImpl implements IAuthorityRepository {
       return const Failure(ValidationError('Authority name null'));
     }
     try {
-      final response = await ApiClient.post<Authority>('/$_resource', authority);
+      final response = await _apiClient.post<Authority>('/$_resource', authority);
       final result = Authority.fromJsonString(response.data!);
       _log.debug('END:createAuthority successful');
       if (result == null) {
@@ -47,7 +49,7 @@ class AuthorityRepositoryImpl implements IAuthorityRepository {
     _log.debug('BEGIN:getAuthorities repository start');
     try {
       final queryParams = {'sort': 'name'};
-      final response = await ApiClient.get('/$_resource', queryParams: queryParams);
+      final response = await _apiClient.get('/$_resource', queryParams: queryParams);
       final result = Authority.fromJsonStringList(response.data!);
       final nonNullList = result.whereType<String>().toList();
       _log.debug('END:getAuthorities successful - response list size: {}', [nonNullList.length]);
@@ -74,7 +76,7 @@ class AuthorityRepositoryImpl implements IAuthorityRepository {
       return const Failure(ValidationError('Authority id null'));
     }
     try {
-      final response = await ApiClient.get('/$_resource', pathParams: id);
+      final response = await _apiClient.get('/$_resource', pathParams: id);
       final result = Authority.fromJsonString(response.data!);
       _log.debug('END:getAuthority successful - response.body: {}', [result.toString()]);
       if (result == null) {
@@ -103,7 +105,7 @@ class AuthorityRepositoryImpl implements IAuthorityRepository {
       return const Failure(ValidationError('Authority id null'));
     }
     try {
-      final response = await ApiClient.delete('/$_resource', pathParams: id);
+      final response = await _apiClient.delete('/$_resource', pathParams: id);
       _log.debug('END:deleteAuthority successful - response status code: {}', [response.statusCode]);
       return const Success(null);
     } on UnauthorizedException catch (e) {

--- a/lib/features/users/data/repositories/user_repository.dart
+++ b/lib/features/users/data/repositories/user_repository.dart
@@ -8,6 +8,10 @@ import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/shared/models/user_entity.dart';
 
 class UserRepository implements IUserRepository {
+  UserRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
   static final _log = AppLogger.getLogger('UserRepository');
   static const String _resource = 'users';
   static const String userIdRequired = 'User id is required';
@@ -19,7 +23,7 @@ class UserRepository implements IUserRepository {
       return const Failure(ValidationError(userIdRequired));
     }
     try {
-      final response = await ApiClient.get('/admin/$_resource', pathParams: id);
+      final response = await _apiClient.get('/admin/$_resource', pathParams: id);
       final result = User.fromJsonString(response.data!)!;
       _log.debug('END:getUser successful - response.body: {}', [result.toString()]);
       return Success(result);
@@ -45,7 +49,7 @@ class UserRepository implements IUserRepository {
       return const Failure(ValidationError('User login is required'));
     }
     try {
-      final response = await ApiClient.get('/admin/$_resource', pathParams: login);
+      final response = await _apiClient.get('/admin/$_resource', pathParams: login);
       final result = User.fromJsonString(response.data!)!;
       _log.debug('END:getUserByLogin successful - response.body: {}', [result.toString()]);
       return Success(result);
@@ -74,7 +78,7 @@ class UserRepository implements IUserRepository {
       return const Failure(ValidationError('User email is required'));
     }
     try {
-      final response = await ApiClient.post<User>('/admin/$_resource', User.fromEntity(user), idempotent: true);
+      final response = await _apiClient.post<User>('/admin/$_resource', User.fromEntity(user), idempotent: true);
       final result = User.fromJsonString(response.data!);
       _log.debug('END:createUser successful');
       if (result == null) {
@@ -103,7 +107,7 @@ class UserRepository implements IUserRepository {
       return const Failure(ValidationError(userIdRequired));
     }
     try {
-      final response = await ApiClient.put<User>('/admin/$_resource', User.fromEntity(user));
+      final response = await _apiClient.put<User>('/admin/$_resource', User.fromEntity(user));
       final result = User.fromJsonString(response.data!);
       _log.debug('END:updateUser successful');
       if (result == null) {
@@ -130,7 +134,7 @@ class UserRepository implements IUserRepository {
     _log.debug('BEGIN:getUsers repository start - page: {}, size: {}, sort: {}', [page, size, sort]);
     try {
       final queryParams = {'page': page.toString(), 'size': size.toString(), 'sort': sort.join('&sort=')};
-      final response = await ApiClient.get('/admin/$_resource', queryParams: queryParams);
+      final response = await _apiClient.get('/admin/$_resource', queryParams: queryParams);
       final result = User.fromJsonStringList(response.data!);
       _log.debug('END:getUsers successful - response list size: {}', [result.length]);
       return Success(result);
@@ -158,7 +162,7 @@ class UserRepository implements IUserRepository {
     ]);
     try {
       final queryParams = {'page': page.toString(), 'size': size.toString()};
-      final response = await ApiClient.get(
+      final response = await _apiClient.get(
         '/admin/$_resource/authorities',
         pathParams: authority,
         queryParams: queryParams,
@@ -191,7 +195,7 @@ class UserRepository implements IUserRepository {
     ]);
     try {
       final queryParams = {'page': page.toString(), 'size': size.toString(), 'name': name, 'authority': authority};
-      final response = await ApiClient.get('/admin/$_resource/filter', queryParams: queryParams);
+      final response = await _apiClient.get('/admin/$_resource/filter', queryParams: queryParams);
       final result = User.fromJsonStringList(response.data!);
       _log.debug('END:findUserByName successful - response list size: {}', [result.length]);
       return Success(result);
@@ -217,7 +221,7 @@ class UserRepository implements IUserRepository {
       return const Failure(ValidationError(userIdRequired));
     }
     try {
-      final response = await ApiClient.delete('/admin/$_resource', pathParams: id);
+      final response = await _apiClient.delete('/admin/$_resource', pathParams: id);
       _log.debug('END:deleteUser successful - response status code: {}', [response.statusCode]);
       return const Success(null);
     } on UnauthorizedException catch (e) {

--- a/lib/infrastructure/analytics/sentry_analytics_service.dart
+++ b/lib/infrastructure/analytics/sentry_analytics_service.dart
@@ -6,7 +6,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 ///
 /// Pre-condition: `SentryFlutter.init(...)` has already run with a
 /// configured DSN. The bootstrap layer gates that on
-/// `AppConfig.sentryDsn != null` and only swaps this service
+/// `appConfig.sentryDsn != null` and only swaps this service
 /// in when the SDK is live; tests + non-prod builds keep
 /// `LogAnalyticsService` so this file is not even constructed
 /// without a DSN.

--- a/lib/infrastructure/analytics/sentry_analytics_service.dart
+++ b/lib/infrastructure/analytics/sentry_analytics_service.dart
@@ -6,7 +6,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 ///
 /// Pre-condition: `SentryFlutter.init(...)` has already run with a
 /// configured DSN. The bootstrap layer gates that on
-/// `ProfileConstants.sentryDsn != null` and only swaps this service
+/// `AppConfig.sentryDsn != null` and only swaps this service
 /// in when the SDK is live; tests + non-prod builds keep
 /// `LogAnalyticsService` so this file is not even constructed
 /// without a DSN.

--- a/lib/infrastructure/config/environment.dart
+++ b/lib/infrastructure/config/environment.dart
@@ -3,100 +3,53 @@ import 'package:flutter_bloc_advance/infrastructure/config/template_config.dart'
 /// This file is used to set the environment
 enum Environment { dev, prod, test }
 
-/// This class is used to store all environment variables
-///
-/// It is used in the main_local.dart file to set the environment
-class ProfileConstants {
-  static Map<String, dynamic>? _config;
+final class AppConfig {
+  const AppConfig({
+    required this.environment,
+    required this.apiBaseUrl,
+    required this.certificatePins,
+    required this.idleTimeout,
+  });
 
-  static void setEnvironment(Environment env) {
-    switch (env) {
-      case Environment.dev:
-        _config = _Config.devConstants;
-        break;
-      case Environment.test:
-        _config = _Config.testConstants;
-        break;
-      case Environment.prod:
-        _config = _Config.prodConstants;
-        break;
-    }
-  }
+  const AppConfig.dev()
+    : environment = Environment.dev,
+      apiBaseUrl = null,
+      certificatePins = const <String>[],
+      idleTimeout = null;
 
-  static bool get isProduction {
-    return _config == _Config.prodConstants;
-  }
+  const AppConfig.test()
+    : environment = Environment.test,
+      apiBaseUrl = null,
+      certificatePins = const <String>[],
+      idleTimeout = null;
 
-  static bool get isDevelopment {
-    return _config == _Config.devConstants;
-  }
+  const AppConfig.prod()
+    : environment = Environment.prod,
+      apiBaseUrl = TemplateConfig.prodApiUrl,
+      certificatePins = const <String>[],
+      idleTimeout = const Duration(minutes: 15);
 
-  static bool get isTest {
-    return _config == _Config.testConstants;
-  }
+  factory AppConfig.fromEnvironment(Environment environment) => switch (environment) {
+    Environment.dev => const AppConfig.dev(),
+    Environment.prod => const AppConfig.prod(),
+    Environment.test => const AppConfig.test(),
+  };
 
-  static dynamic get api {
-    return _config![_Config.api];
-  }
+  final Environment environment;
+  final String? apiBaseUrl;
+  final List<String> certificatePins;
+  final Duration? idleTimeout;
+
+  bool get isProduction => environment == Environment.prod;
+  bool get isDevelopment => environment == Environment.dev;
+  bool get isTest => environment == Environment.test;
 
   /// Production-only DSN passed via `--dart-define=SENTRY_DSN=...`.
-  /// Returns null in non-prod, or when the define is absent / empty
-  /// so the bootstrap falls back to [LogAnalyticsService] without
-  /// touching the Sentry SDK.
-  ///
-  /// **Never** commit a DSN to source. The repo is a public template;
-  /// a checked-in DSN means anyone running the fork ships events into
-  /// the original project's Sentry quota.
-  static String? get sentryDsn {
+  /// Returns null in non-prod, or when the define is absent / empty.
+  /// **Never** commit a DSN to source (public template).
+  String? get sentryDsn {
     if (!isProduction) return null;
     const dsn = String.fromEnvironment('SENTRY_DSN');
     return dsn.isEmpty ? null : dsn;
   }
-
-  /// Pinned certificate SHA-256 hashes (base64, e.g. produced by
-  /// `openssl dgst -sha256 -binary | openssl enc -base64`).
-  /// Empty list = pinning disabled (default).
-  ///
-  /// See `lib/infrastructure/http/certificate_pinning_adapter.dart` for
-  /// the live validation behaviour, and the README "Certificate Pinning"
-  /// section for the extraction one-liner + key-rotation procedure.
-  static List<String> get certificatePins {
-    final raw = _config?[_Config.certificatePins];
-    if (raw is! List) return const [];
-    return raw.whereType<String>().toList(growable: false);
-  }
-
-  /// Inactivity threshold for auto-logout. `null` disables the
-  /// [IdleTimeoutObserver]; downstream forks override by editing
-  /// [_Config.prodConstants] (or any env map). Stored as an int (seconds)
-  /// in the map so the config can stay a plain `Map<String, dynamic>`.
-  static Duration? get idleTimeout {
-    final raw = _config?[_Config.idleTimeoutSeconds];
-    if (raw is! int || raw <= 0) return null;
-    return Duration(seconds: raw);
-  }
-}
-
-class _Config {
-  static const api = "API";
-  static const certificatePins = "CERTIFICATE_PINS";
-  static const idleTimeoutSeconds = "IDLE_TIMEOUT_SECONDS";
-
-  /// Dev / test default: pinning disabled (empty list) and idle timeout off.
-  /// Mocked sessions and rapid hot-reload flows would be hostile if the
-  /// observer logged the user out mid-edit.
-  static Map<String, dynamic> devConstants = {api: "mock", certificatePins: <String>[], idleTimeoutSeconds: null};
-
-  static Map<String, dynamic> testConstants = {api: "mock", certificatePins: <String>[], idleTimeoutSeconds: null};
-
-  /// Production defaults: pinning ships disabled (empty list) — add base64
-  /// SHA-256 pins extracted from your live backend's certificate to enable
-  /// (backup pin support is automatic; list two and rotate per the README).
-  /// Idle timeout defaults to 15 minutes (industry baseline for non-financial
-  /// apps; financial-grade forks should lower to 5 minutes).
-  static Map<String, dynamic> prodConstants = {
-    api: TemplateConfig.prodApiUrl,
-    certificatePins: <String>[],
-    idleTimeoutSeconds: 15 * 60,
-  };
 }

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -57,6 +57,18 @@ class ApiClient {
   static Dio? _testDio;
   static List<InterceptorChainEntry> _interceptorChainSnapshot = const [];
 
+  /// Temporary static config (migration scaffolding — removed once ApiClient
+  /// becomes instance-injected in a later task).
+  static AppConfig _appConfig = const AppConfig.dev();
+
+  static AppConfig get appConfig => _appConfig;
+  static set appConfig(AppConfig value) {
+    _appConfig = value;
+    _dio?.close();
+    _dio = null;
+    _interceptorChainSnapshot = const [];
+  }
+
   /// Snapshot of the active interceptor chain, in order. Populated the
   /// first time [instance] is read (i.e. when Dio is built).
   ///
@@ -102,6 +114,7 @@ class ApiClient {
     _testDio = null;
     secureStorage = null;
     onSessionExpired = null;
+    appConfig = const AppConfig.dev();
   }
 
   /// The active Dio instance.
@@ -111,7 +124,7 @@ class ApiClient {
   }
 
   static Dio _createDio() {
-    _log.debug('Creating Dio instance (production: {})', [ProfileConstants.isProduction]);
+    _log.debug('Creating Dio instance (production: {})', [_appConfig.isProduction]);
     if (secureStorage == null) {
       // Loud warning when Dio is built without a shared secureStorage.
       // Production code paths through AppBootstrap always set this
@@ -129,7 +142,7 @@ class ApiClient {
 
     final dio = Dio(
       BaseOptions(
-        baseUrl: ProfileConstants.isProduction ? (ProfileConstants.api as String) : '',
+        baseUrl: _appConfig.apiBaseUrl ?? '',
         connectTimeout: const Duration(seconds: _timeoutSeconds),
         receiveTimeout: const Duration(seconds: _timeoutSeconds),
         responseType: ResponseType.plain,
@@ -138,10 +151,10 @@ class ApiClient {
     );
 
     // Certificate pinning. Empty pin list (default) keeps the system
-    // adapter; populating ProfileConstants.certificatePins swaps in a
+    // adapter; populating appConfig.certificatePins swaps in a
     // pinning adapter that fails closed on any non-matching cert. Web
     // is a hard no-op — see buildPinnedAdapter docs.
-    final pins = ProfileConstants.certificatePins;
+    final pins = _appConfig.certificatePins;
     if (pins.isNotEmpty) {
       _log.info('Installing certificate pinning adapter ({} pin(s))', [pins.length]);
       dio.httpClientAdapter = buildPinnedAdapter(pins);
@@ -203,9 +216,9 @@ class ApiClient {
       // must travel back up through the observability interceptors above
       // (DevConsole capture + verbose logging). It resolves with
       // callFollowing:true to make that happen.
-      if (!ProfileConstants.isProduction)
+      if (!_appConfig.isProduction)
         (
-          interceptor: MockInterceptor(),
+          interceptor: MockInterceptor(appConfig: _appConfig),
           meta: const InterceptorChainEntry(
             name: 'MockInterceptor',
             active: false,

--- a/lib/infrastructure/http/api_client.dart
+++ b/lib/infrastructure/http/api_client.dart
@@ -49,25 +49,17 @@ class InterceptorChainEntry {
 /// which catch [DioException] and rethrow as [AppException] types so that
 /// repository catch blocks work without Dio coupling.
 class ApiClient {
+  ApiClient({required this._appConfig, this._secureStorage, this._onSessionExpired, this._dio});
+
   static final _log = AppLogger.getLogger('ApiClient');
 
   static const int _timeoutSeconds = 30;
 
-  static Dio? _dio;
-  static Dio? _testDio;
-  static List<InterceptorChainEntry> _interceptorChainSnapshot = const [];
-
-  /// Temporary static config (migration scaffolding — removed once ApiClient
-  /// becomes instance-injected in a later task).
-  static AppConfig _appConfig = const AppConfig.dev();
-
-  static AppConfig get appConfig => _appConfig;
-  static set appConfig(AppConfig value) {
-    _appConfig = value;
-    _dio?.close();
-    _dio = null;
-    _interceptorChainSnapshot = const [];
-  }
+  final AppConfig _appConfig;
+  final ISecureStorage? _secureStorage;
+  final OnSessionExpired? _onSessionExpired;
+  Dio? _dio;
+  List<InterceptorChainEntry> _chainSnapshot = const [];
 
   /// Snapshot of the active interceptor chain, in order. Populated the
   /// first time [instance] is read (i.e. when Dio is built).
@@ -76,66 +68,22 @@ class ApiClient {
   /// hard-coding names — keeps the dashboard in sync with the chain
   /// even when interceptors are added, removed, or conditionally
   /// included (e.g. [MockInterceptor] outside production).
-  static List<InterceptorChainEntry> get interceptorChainSnapshot => List.unmodifiable(_interceptorChainSnapshot);
-
-  /// Callback invoked when the session has expired (token refresh failed).
-  ///
-  /// Set this before the first API call (typically in app initialization) so
-  /// that the [TokenRefreshInterceptor] can notify the app layer to log out.
-  static OnSessionExpired? onSessionExpired;
-
-  /// Secure storage instance threaded into [AuthInterceptor] and
-  /// [TokenRefreshInterceptor] when Dio is built. Bootstrap sets this
-  /// to the same [ISecureStorage] adapter it uses for migration and
-  /// the widget tree, so the HTTP interceptors and the repository
-  /// layer share one source of truth. Falls back to a default
-  /// [FlutterSecureStorageAdapter] when unset (tests that don't go
-  /// through bootstrap).
-  static ISecureStorage? secureStorage;
-
-  /// Inject a custom Dio instance for testing.
-  static void setTestInstance(Dio dio) => _testDio = dio;
-
-  /// Reset the test instance.
-  static void resetTestInstance() => _testDio = null;
-
-  /// Reset the production singleton (useful in tests).
-  ///
-  /// Clears every static hook the class owns so a re-init path
-  /// (hot reload, test tearDown, multi-test runs in one process)
-  /// cannot leak a previous adapter/callback into the next Dio
-  /// construction. Without resetting [secureStorage] / [onSessionExpired]
-  /// here, a test that sets them and a later test that builds a fresh
-  /// Dio would inherit those — silently re-binding the new interceptors
-  /// to the previous run's instances.
-  static void reset() {
-    _dio?.close();
-    _dio = null;
-    _testDio = null;
-    secureStorage = null;
-    onSessionExpired = null;
-    appConfig = const AppConfig.dev();
-  }
+  List<InterceptorChainEntry> get interceptorChainSnapshot => List.unmodifiable(_chainSnapshot);
 
   /// The active Dio instance.
-  static Dio get instance {
-    if (_testDio != null) return _testDio!;
-    return _dio ??= _createDio();
-  }
+  Dio get instance => _dio ??= _createDio();
 
-  static Dio _createDio() {
+  Dio _createDio() {
     _log.debug('Creating Dio instance (production: {})', [_appConfig.isProduction]);
-    if (secureStorage == null) {
-      // Loud warning when Dio is built without a shared secureStorage.
-      // Production code paths through AppBootstrap always set this
-      // before the first HTTP call; if you see this in test or app
-      // logs it means HTTP interceptors are about to construct their
-      // own FlutterSecureStorageAdapter instance, which will diverge
-      // from whatever the repository layer / SessionCubit are using.
-      // Set ApiClient.secureStorage before touching ApiClient.instance
-      // (test setup helpers do this — see test/test_utils.dart).
+    if (_secureStorage == null) {
+      // Loud warning when this ApiClient was built without an injected
+      // secureStorage. Production wiring (AppDependencies.createApiClient)
+      // always supplies the shared adapter; if you see this in test or app
+      // logs it means the interceptors are about to construct their own
+      // FlutterSecureStorageAdapter instance, which will diverge from
+      // whatever the repository layer / SessionCubit are using.
       _log.warn(
-        'ApiClient.secureStorage is null at Dio creation — interceptors will fall back '
+        'ApiClient was constructed without a secureStorage — interceptors will fall back '
         'to a private FlutterSecureStorageAdapter and diverge from the repository layer.',
       );
     }
@@ -170,14 +118,14 @@ class ApiClient {
         meta: const InterceptorChainEntry(name: 'ConnectivityInterceptor', detail: 'Rejects requests when offline'),
       ),
       (
-        interceptor: AuthInterceptor(secureStorage: secureStorage),
+        interceptor: AuthInterceptor(secureStorage: _secureStorage),
         meta: const InterceptorChainEntry(name: 'AuthInterceptor', detail: 'Attaches JWT token to requests'),
       ),
       (
         interceptor: TokenRefreshInterceptor(
           dio: dio,
-          onSessionExpired: onSessionExpired,
-          secureStorage: secureStorage,
+          onSessionExpired: _onSessionExpired,
+          secureStorage: _secureStorage,
         ),
         meta: const InterceptorChainEntry(name: 'TokenRefreshInterceptor', detail: 'Refreshes expired access tokens'),
       ),
@@ -228,7 +176,7 @@ class ApiClient {
     ];
 
     dio.interceptors.addAll(chain.map((e) => e.interceptor));
-    _interceptorChainSnapshot = chain.map((e) => e.meta).toList(growable: false);
+    _chainSnapshot = chain.map((e) => e.meta).toList(growable: false);
 
     return dio;
   }
@@ -237,7 +185,7 @@ class ApiClient {
   // Convenience methods matching the old HttpUtils API surface
   // ---------------------------------------------------------------------------
 
-  static Future<Response<String>> get(String path, {String? pathParams, Map<String, dynamic>? queryParams}) async {
+  Future<Response<String>> get(String path, {String? pathParams, Map<String, dynamic>? queryParams}) async {
     final fullPath = pathParams != null ? '$path/$pathParams' : path;
     try {
       return await instance.get<String>(
@@ -250,7 +198,7 @@ class ApiClient {
     }
   }
 
-  static Future<Response<String>> post<T>(
+  Future<Response<String>> post<T>(
     String path,
     T data, {
     Map<String, String>? headers,
@@ -272,7 +220,7 @@ class ApiClient {
     }
   }
 
-  static Future<Response<String>> put<T>(String path, T data, {String? pathParams, bool idempotent = false}) async {
+  Future<Response<String>> put<T>(String path, T data, {String? pathParams, bool idempotent = false}) async {
     final fullPath = pathParams != null ? '$path/$pathParams' : path;
     final serialized = _serializeData(data);
     try {
@@ -292,7 +240,7 @@ class ApiClient {
     }
   }
 
-  static Future<Response<String>> patch<T>(String path, T data, {String? pathParams, bool idempotent = false}) async {
+  Future<Response<String>> patch<T>(String path, T data, {String? pathParams, bool idempotent = false}) async {
     final fullPath = pathParams != null ? '$path/$pathParams' : path;
     final serialized = _serializeData(data);
     try {
@@ -312,7 +260,7 @@ class ApiClient {
     }
   }
 
-  static Future<Response<String>> delete(String path, {String? pathParams, Map<String, dynamic>? queryParams}) async {
+  Future<Response<String>> delete(String path, {String? pathParams, Map<String, dynamic>? queryParams}) async {
     final fullPath = pathParams != null ? '$path/$pathParams' : path;
     try {
       return await instance.delete<String>(

--- a/lib/infrastructure/http/interceptors/mock_interceptor.dart
+++ b/lib/infrastructure/http/interceptors/mock_interceptor.dart
@@ -17,6 +17,10 @@ import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 /// that flag the response short-circuits and those handlers never fire,
 /// leaving the dev console Network tab empty in mock mode.
 class MockInterceptor extends Interceptor {
+  MockInterceptor({this.appConfig = const AppConfig.dev()});
+
+  final AppConfig appConfig;
+
   static final _log = AppLogger.getLogger('MockInterceptor');
 
   @override
@@ -24,7 +28,7 @@ class MockInterceptor extends Interceptor {
     _log.debug('Mock request: {} {}', [options.method, options.path]);
 
     // Simulate network latency in dev (not in tests)
-    if (!ProfileConstants.isTest) {
+    if (!appConfig.isTest) {
       await Future.delayed(const Duration(milliseconds: 500));
     }
 

--- a/lib/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart
+++ b/lib/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart
@@ -15,6 +15,10 @@ import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 /// pattern that the rest of the codebase uses, removing the
 /// `try/catch` dialect from the application layer.
 class DynamicFormRepository implements IDynamicFormRepository {
+  DynamicFormRepository(this._apiClient);
+
+  final ApiClient _apiClient;
+
   static final _log = AppLogger.getLogger('DynamicFormRepository');
   static const String _resource = '/dynamic_forms';
   static const String formIdRequired = 'Form id is required';
@@ -29,7 +33,7 @@ class DynamicFormRepository implements IDynamicFormRepository {
       return const Failure(ValidationError(formIdRequired));
     }
     try {
-      final response = await ApiClient.get(_resource, pathParams: formId);
+      final response = await _apiClient.get(_resource, pathParams: formId);
       final schema = FormSchemaModel.fromJsonString(response.data!);
       _log.debug('END:fetchSchema successful: {}', [schema.id]);
       return Success(schema);
@@ -55,7 +59,7 @@ class DynamicFormRepository implements IDynamicFormRepository {
       return const Failure(ValidationError(endpointRequired));
     }
     try {
-      final response = await ApiClient.get(basePath, pathParams: pathParams);
+      final response = await _apiClient.get(basePath, pathParams: pathParams);
       final bundle = FormBundleModel.fromJsonString(response.data!);
       _log.debug('END:fetchBundle successful: {}', [bundle.schema.id]);
       return Success(bundle);
@@ -85,10 +89,10 @@ class DynamicFormRepository implements IDynamicFormRepository {
     }
     try {
       final response = switch (action.method.toUpperCase()) {
-        'POST' => await ApiClient.post(action.endpoint, data, pathParams: pathParams),
-        'PUT' => await ApiClient.put(action.endpoint, data, pathParams: pathParams),
-        'PATCH' => await ApiClient.patch(action.endpoint, data, pathParams: pathParams),
-        'DELETE' => await ApiClient.delete(action.endpoint, pathParams: pathParams),
+        'POST' => await _apiClient.post(action.endpoint, data, pathParams: pathParams),
+        'PUT' => await _apiClient.put(action.endpoint, data, pathParams: pathParams),
+        'PATCH' => await _apiClient.patch(action.endpoint, data, pathParams: pathParams),
+        'DELETE' => await _apiClient.delete(action.endpoint, pathParams: pathParams),
         _ => throw UnsupportedError('Unsupported HTTP method: ${action.method}'),
       };
       _log.debug('END:submit successful', []);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.38+1
+version: 0.21.39+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.0 • channel stable • https://github.com/flutter/flutter.git

--- a/test/app/dev_console/tabs/environment_tab_test.dart
+++ b/test/app/dev_console/tabs/environment_tab_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/app/dev_console/tabs/environment_tab.dart';
 import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
 import 'package:flutter_bloc_advance/shared/design_system/theme/app_theme.dart';
@@ -11,10 +12,6 @@ import 'package:go_router/go_router.dart';
 /// builder — so [GoRouterState.of] has no scope to resolve. The fix reads
 /// the current location from the router itself (`GoRouter.of(c).state`).
 void main() {
-  setUp(() {
-    ProfileConstants.setEnvironment(Environment.test);
-  });
-
   GoRouter buildRouter() {
     return GoRouter(
       routes: [
@@ -39,7 +36,12 @@ void main() {
   }
 
   testWidgets('EnvironmentTab renders inside a modal bottom sheet without a GoRouterState error', (tester) async {
-    await tester.pumpWidget(MaterialApp.router(theme: AppTheme.light(), routerConfig: buildRouter()));
+    await tester.pumpWidget(
+      RepositoryProvider<AppConfig>.value(
+        value: const AppConfig.test(),
+        child: MaterialApp.router(theme: AppTheme.light(), routerConfig: buildRouter()),
+      ),
+    );
 
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();

--- a/test/app/di/repository_contracts_test.dart
+++ b/test/app/di/repository_contracts_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_bloc_advance/features/users/domain/repositories/user_rep
 import 'package:flutter_bloc_advance/infrastructure/storage/secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../test_utils.dart';
+
 class _StubSecureStorage implements ISecureStorage {
   @override
   Future<String?> read(String key) async => null;
@@ -25,14 +27,14 @@ void main() {
   const dependencies = AppDependencies();
 
   test('app dependencies expose account repository contract', () {
-    expect(dependencies.createAccountRepository(), isA<IAccountRepository>());
+    expect(dependencies.createAccountRepository(TestUtils.apiClient()), isA<IAccountRepository>());
   });
 
   test('app dependencies expose auth repository contract', () {
-    expect(dependencies.createAuthRepository(_StubSecureStorage()), isA<IAuthRepository>());
+    expect(dependencies.createAuthRepository(_StubSecureStorage(), TestUtils.apiClient()), isA<IAuthRepository>());
   });
 
   test('app dependencies expose user repository contract', () {
-    expect(dependencies.createUserRepository(), isA<IUserRepository>());
+    expect(dependencies.createUserRepository(TestUtils.apiClient()), isA<IUserRepository>());
   });
 }

--- a/test/app/session/session_cubit_test.dart
+++ b/test/app/session/session_cubit_test.dart
@@ -122,15 +122,13 @@ void main() {
 
     blocTest<SessionCubit, SessionState>(
       'restore emits SessionUnauthenticated(expired) for an expired token in prod',
-      setUp: () => ProfileConstants.setEnvironment(Environment.prod),
       build: () {
         final secure = _MemorySecureStorage();
         secure._store[SecureStorageKeys.jwtToken.key] = _expiredJwt;
-        return SessionCubit(secureStorage: secure);
+        return SessionCubit(secureStorage: secure, appConfig: const AppConfig.prod());
       },
       act: (cubit) => cubit.restore(),
       expect: () => [const SessionUnauthenticated(reason: SessionExpiredReason.expired)],
-      tearDown: () => ProfileConstants.setEnvironment(Environment.test),
     );
 
     blocTest<SessionCubit, SessionState>(

--- a/test/features/account/data/repositories/account_repository_test.dart
+++ b/test/features/account/data/repositories/account_repository_test.dart
@@ -10,9 +10,14 @@ import '../../../../mocks/fake_data.dart';
 import '../../../../test_utils.dart';
 
 void main() {
+  late AccountRepository repository;
+
   //region setup
   setUpAll(() async {
     await TestUtils().setupUnitTest();
+  });
+  setUp(() {
+    repository = AccountRepository(TestUtils.apiClient());
   });
   tearDown(() async {
     await TestUtils().tearDownUnitTest();
@@ -23,7 +28,7 @@ void main() {
   group("AccountRepository Register success", () {
     test("Given valid user when register then return user successfully", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
+      final result = await repository.register(entity);
 
       //check assets/mock/POST_register.json
       expect(result, isA<Success<UserEntity>>());
@@ -44,7 +49,7 @@ void main() {
     test("Given valid without langKey user when register then return user successfully", () async {
       var entity = mockUserFullPayload;
       entity = entity.copyWith(langKey: "");
-      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
+      final result = await repository.register(entity);
 
       //check assets/mock/POST_register.json
       expect(result, isA<Success<UserEntity>>());
@@ -64,21 +69,21 @@ void main() {
 
     test("Given user with empty email when register then return Failure with ValidationError", () async {
       final entity = mockUserFullPayload.copyWith(email: "");
-      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
+      final result = await repository.register(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
 
     test("Given user with null login when register then return Success", () async {
       const entity = User(firstName: "test", lastName: "test", email: "test@test.com");
-      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
+      final result = await repository.register(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     /// Register endpoint does not require AccessToken, this endpoint added to the allowed endpoints in the HttpUtils class
     test("Given valid user without token when register then return user successfully", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
+      final result = await repository.register(entity);
       expect(result, isA<Success<UserEntity>>());
     });
   });
@@ -88,20 +93,20 @@ void main() {
     test("Given valid passwordChangeDTO when changePassword then return Success", () async {
       TestUtils().setupAuthentication();
       const passwordChangeDTO = mockPasswordChangePayload;
-      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
+      final result = await repository.changePassword(passwordChangeDTO);
       expect(result, isA<Success<void>>());
     });
 
     test("Given empty value passwordChangeDTO when changePassword then return Failure", () async {
       const passwordChangeDTO = PasswordChangeDTO();
-      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
+      final result = await repository.changePassword(passwordChangeDTO);
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
 
     test("Given empty passwords passwordChangeDTO when changePassword then return Failure", () async {
       final passwordChangeDTO = mockPasswordChangePayload.copyWith(currentPassword: "", newPassword: "");
-      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
+      final result = await repository.changePassword(passwordChangeDTO);
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
@@ -112,18 +117,18 @@ void main() {
     test("Given valid mailAddress when resetPassword then return Success", () async {
       TestUtils().setupAuthentication();
       const mailAddress = "admin@sample.tech";
-      final result = await AccountRepository(TestUtils.apiClient()).resetPassword(mailAddress);
+      final result = await repository.resetPassword(mailAddress);
       expect(result, isA<Success<void>>());
     });
 
     test("Given empty mailAddress when resetPassword then return Failure with ValidationError", () async {
-      final result = await AccountRepository(TestUtils.apiClient()).resetPassword("");
+      final result = await repository.resetPassword("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
 
     test("Given invalid mailAddress when resetPassword then return Failure with ValidationError", () async {
-      final result = await AccountRepository(TestUtils.apiClient()).resetPassword("test");
+      final result = await repository.resetPassword("test");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
@@ -134,13 +139,13 @@ void main() {
     //success
     test("Given valid user when getAccount then return Success", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository(TestUtils.apiClient()).getAccount();
+      final result = await repository.getAccount();
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given getAccount without AccessToken then return Failure with AuthError", () async {
-      final result = await AccountRepository(TestUtils.apiClient()).getAccount();
+      final result = await repository.getAccount();
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -152,14 +157,14 @@ void main() {
     test("Given valid user when saveAccount then return Success", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given valid user when saveAccount without AccessToken then return Failure with AuthError", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -167,7 +172,7 @@ void main() {
     test("Given user with empty id when saveAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       const entity = User();
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -175,7 +180,7 @@ void main() {
     test("Given user with blank id when saveAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -187,14 +192,14 @@ void main() {
     test("Given valid user when updateAccount then return Success", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given valid user when updateAccount without AccessToken then return Failure with AuthError", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -202,7 +207,7 @@ void main() {
     test("Given user with null id when updateAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       const entity = User();
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -210,7 +215,7 @@ void main() {
     test("Given user with blank id when updateAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
-      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -221,20 +226,20 @@ void main() {
     //success
     test("Given valid id when deleteAccount then return Success", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository(TestUtils.apiClient()).delete("id");
+      final result = await repository.delete("id");
       expect(result, isA<Success<void>>());
     });
 
     //fail: without AccessToken
     test("Given valid id when deleteAccount without AccessToken then return Failure with AuthError", () async {
-      final result = await AccountRepository(TestUtils.apiClient()).delete("id");
+      final result = await repository.delete("id");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<AuthError>());
     });
 
     test("Given empty id when deleteAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository(TestUtils.apiClient()).delete("");
+      final result = await repository.delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/features/account/data/repositories/account_repository_test.dart
+++ b/test/features/account/data/repositories/account_repository_test.dart
@@ -23,7 +23,7 @@ void main() {
   group("AccountRepository Register success", () {
     test("Given valid user when register then return user successfully", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().register(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
 
       //check assets/mock/POST_register.json
       expect(result, isA<Success<UserEntity>>());
@@ -44,7 +44,7 @@ void main() {
     test("Given valid without langKey user when register then return user successfully", () async {
       var entity = mockUserFullPayload;
       entity = entity.copyWith(langKey: "");
-      final result = await AccountRepository().register(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
 
       //check assets/mock/POST_register.json
       expect(result, isA<Success<UserEntity>>());
@@ -64,21 +64,21 @@ void main() {
 
     test("Given user with empty email when register then return Failure with ValidationError", () async {
       final entity = mockUserFullPayload.copyWith(email: "");
-      final result = await AccountRepository().register(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
 
     test("Given user with null login when register then return Success", () async {
       const entity = User(firstName: "test", lastName: "test", email: "test@test.com");
-      final result = await AccountRepository().register(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     /// Register endpoint does not require AccessToken, this endpoint added to the allowed endpoints in the HttpUtils class
     test("Given valid user without token when register then return user successfully", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().register(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).register(entity);
       expect(result, isA<Success<UserEntity>>());
     });
   });
@@ -88,20 +88,20 @@ void main() {
     test("Given valid passwordChangeDTO when changePassword then return Success", () async {
       TestUtils().setupAuthentication();
       const passwordChangeDTO = mockPasswordChangePayload;
-      final result = await AccountRepository().changePassword(passwordChangeDTO);
+      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
       expect(result, isA<Success<void>>());
     });
 
     test("Given empty value passwordChangeDTO when changePassword then return Failure", () async {
       const passwordChangeDTO = PasswordChangeDTO();
-      final result = await AccountRepository().changePassword(passwordChangeDTO);
+      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
 
     test("Given empty passwords passwordChangeDTO when changePassword then return Failure", () async {
       final passwordChangeDTO = mockPasswordChangePayload.copyWith(currentPassword: "", newPassword: "");
-      final result = await AccountRepository().changePassword(passwordChangeDTO);
+      final result = await AccountRepository(TestUtils.apiClient()).changePassword(passwordChangeDTO);
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
@@ -112,18 +112,18 @@ void main() {
     test("Given valid mailAddress when resetPassword then return Success", () async {
       TestUtils().setupAuthentication();
       const mailAddress = "admin@sample.tech";
-      final result = await AccountRepository().resetPassword(mailAddress);
+      final result = await AccountRepository(TestUtils.apiClient()).resetPassword(mailAddress);
       expect(result, isA<Success<void>>());
     });
 
     test("Given empty mailAddress when resetPassword then return Failure with ValidationError", () async {
-      final result = await AccountRepository().resetPassword("");
+      final result = await AccountRepository(TestUtils.apiClient()).resetPassword("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
 
     test("Given invalid mailAddress when resetPassword then return Failure with ValidationError", () async {
-      final result = await AccountRepository().resetPassword("test");
+      final result = await AccountRepository(TestUtils.apiClient()).resetPassword("test");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });
@@ -134,13 +134,13 @@ void main() {
     //success
     test("Given valid user when getAccount then return Success", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository().getAccount();
+      final result = await AccountRepository(TestUtils.apiClient()).getAccount();
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given getAccount without AccessToken then return Failure with AuthError", () async {
-      final result = await AccountRepository().getAccount();
+      final result = await AccountRepository(TestUtils.apiClient()).getAccount();
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -152,14 +152,14 @@ void main() {
     test("Given valid user when saveAccount then return Success", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given valid user when saveAccount without AccessToken then return Failure with AuthError", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -167,7 +167,7 @@ void main() {
     test("Given user with empty id when saveAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       const entity = User();
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -175,7 +175,7 @@ void main() {
     test("Given user with blank id when saveAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -187,14 +187,14 @@ void main() {
     test("Given valid user when updateAccount then return Success", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Success<UserEntity>>());
     });
 
     //fail: without AccessToken
     test("Given valid user when updateAccount without AccessToken then return Failure with AuthError", () async {
       final entity = mockUserFullPayload;
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<AuthError>());
     });
@@ -202,7 +202,7 @@ void main() {
     test("Given user with null id when updateAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       const entity = User();
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -210,7 +210,7 @@ void main() {
     test("Given user with blank id when updateAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload.copyWith(id: "");
-      final result = await AccountRepository().update(entity);
+      final result = await AccountRepository(TestUtils.apiClient()).update(entity);
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -221,20 +221,20 @@ void main() {
     //success
     test("Given valid id when deleteAccount then return Success", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository().delete("id");
+      final result = await AccountRepository(TestUtils.apiClient()).delete("id");
       expect(result, isA<Success<void>>());
     });
 
     //fail: without AccessToken
     test("Given valid id when deleteAccount without AccessToken then return Failure with AuthError", () async {
-      final result = await AccountRepository().delete("id");
+      final result = await AccountRepository(TestUtils.apiClient()).delete("id");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<AuthError>());
     });
 
     test("Given empty id when deleteAccount then return Failure with ValidationError", () async {
       TestUtils().setupAuthentication();
-      final result = await AccountRepository().delete("");
+      final result = await AccountRepository(TestUtils.apiClient()).delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/features/auth/data/repositories/login_repository_test.dart
+++ b/test/features/auth/data/repositories/login_repository_test.dart
@@ -40,7 +40,7 @@ void main() {
     test("Given valid entity when authenticate then return Success with AuthTokenEntity", () async {
       TestUtils().setupAuthentication();
       const entity = AuthCredentialsEntity(username: 'username', password: 'password');
-      final result = await LoginRepository().authenticate(entity);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).authenticate(entity);
 
       expect(result, isA<Success<AuthTokenEntity>>());
       expect(result.dataOrNull?.idToken, "MOCK_TOKEN");
@@ -49,14 +49,16 @@ void main() {
     // authenticate method can use without accessToken
     test("Given valid entity without AccessToken when authenticate then return Success with AuthTokenEntity", () async {
       const entity = AuthCredentialsEntity(username: 'username', password: 'password');
-      final result = await LoginRepository().authenticate(entity);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).authenticate(entity);
 
       expect(result, isA<Success<AuthTokenEntity>>());
       expect(result.dataOrNull?.idToken, "MOCK_TOKEN");
     });
 
     test("Given empty entity when authenticate then return Failure", () async {
-      final result = await LoginRepository().authenticate(const AuthCredentialsEntity(username: "", password: ""));
+      final result = await LoginRepository(
+        apiClient: TestUtils.apiClient(),
+      ).authenticate(const AuthCredentialsEntity(username: "", password: ""));
       expect(result, isA<Failure<AuthTokenEntity>>());
     });
 
@@ -65,7 +67,7 @@ void main() {
       await secure.write(SecureStorageKeys.jwtToken.key, 'MOCK_TOKEN');
       expect(await secure.read(SecureStorageKeys.jwtToken.key), 'MOCK_TOKEN');
 
-      final result = await LoginRepository().logout();
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).logout();
       expect(result, isA<Success<void>>());
       // Both backends are wiped after logout — secure store no longer
       // holds the JWT, so AuthInterceptor cannot re-attach it.
@@ -81,7 +83,7 @@ void main() {
       final secure = _FlakyDeleteSecureStorage(failOn: SecureStorageKeys.jwtToken.key);
       await secure.write(SecureStorageKeys.refreshToken.key, 'REFRESH');
 
-      final result = await LoginRepository(secureStorage: secure).logout();
+      final result = await LoginRepository(secureStorage: secure, apiClient: TestUtils.apiClient()).logout();
 
       expect(result, isA<Failure<void>>(), reason: 'partial failure surfaced as Failure');
       expect(
@@ -98,7 +100,7 @@ void main() {
       await secure.write(SecureStorageKeys.refreshToken.key, 'REFRESH_VALUE');
       expect(await secure.read(SecureStorageKeys.jwtToken.key), 'JWT_VALUE');
 
-      final result = await LoginRepository().logout();
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).logout();
 
       expect(result, isA<Success<void>>());
       expect(await secure.read(SecureStorageKeys.jwtToken.key), isNull, reason: 'secure JWT must not survive logout');
@@ -115,7 +117,7 @@ void main() {
       TestUtils().setupAuthentication();
       const request = SendOtpEntity(email: "test@example.com");
 
-      final result = await LoginRepository().sendOtp(request);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).sendOtp(request);
       expect(result, isA<Success<void>>());
     });
 
@@ -123,7 +125,7 @@ void main() {
       TestUtils().setupAuthentication();
       const request = SendOtpEntity(email: "");
 
-      final result = await LoginRepository().sendOtp(request);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).sendOtp(request);
       expect(result, isA<Failure<void>>());
     });
   });
@@ -133,7 +135,7 @@ void main() {
       TestUtils().setupAuthentication();
       const request = VerifyOtpEntity(email: "test@example.com", otp: "123456");
 
-      final result = await LoginRepository().verifyOtp(request);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).verifyOtp(request);
       expect(result, isA<Success<AuthTokenEntity>>());
       expect(result.dataOrNull?.idToken, "MOCK_TOKEN");
     });
@@ -142,7 +144,7 @@ void main() {
       TestUtils().setupAuthentication();
       const request = VerifyOtpEntity(email: "test@example.com", otp: "1234567");
 
-      final result = await LoginRepository().verifyOtp(request);
+      final result = await LoginRepository(apiClient: TestUtils.apiClient()).verifyOtp(request);
       expect(result, isA<Failure<AuthTokenEntity>>());
     });
   });

--- a/test/features/dashboard/application/dashboard_cubit_test.dart
+++ b/test/features/dashboard/application/dashboard_cubit_test.dart
@@ -62,6 +62,7 @@ void main() {
       featureFlagService: featureFlagService,
       resilienceInterceptor: resilienceInterceptor,
       cacheStorage: cacheStorage,
+      apiClient: TestUtils.apiClient(),
     );
   }
 

--- a/test/features/users/data/repositories/authority_reporitory_test.dart
+++ b/test/features/users/data/repositories/authority_reporitory_test.dart
@@ -23,24 +23,24 @@ void main() {
     test("Given valid authority when create then return authority successfully", () async {
       TestUtils().setupAuthentication();
       const entity = mockAuthorityPayload;
-      final result = await AuthorityRepositoryImpl().create(entity);
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(entity);
 
       expect(result, isA<Success<Authority>>());
       expect((result as Success<Authority>).data.name, "ROLE_USER");
     });
     test("Given valid authority without AccessToken when create then return failure", () async {
       const entity = mockAuthorityPayload;
-      final result = await AuthorityRepositoryImpl().create(entity);
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(entity);
       expect(result, isA<Failure<Authority>>());
     });
 
     test("Given null authority when create then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl().create(const Authority());
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(const Authority());
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
     test("Given empty authority when create then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl().create(const Authority(name: ""));
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(const Authority(name: ""));
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
@@ -50,7 +50,7 @@ void main() {
   group("AuthorityRepository Get success", () {
     test("Given valid when getAuthorities then return authorities successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl().list();
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).list();
 
       expect(result, isA<Success<List<String>>>());
       final data = (result as Success<List<String>>).data;
@@ -59,7 +59,7 @@ void main() {
       expect(data[1], "ROLE_ADMIN");
     });
     test("Given valid without AccessToken when getAuthorities then return failure", () async {
-      final result = await AuthorityRepositoryImpl().list();
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).list();
       expect(result, isA<Failure<List<String>>>());
     });
   });
@@ -68,18 +68,18 @@ void main() {
   group("AuthorityRepository Get success", () {
     test("Given valid id when getAuthority then return authority successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl().retrieve("1");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("1");
 
       expect(result, isA<Success<Authority>>());
       expect((result as Success<Authority>).data.name, "ROLE_USER");
     });
     test("Given valid id without AccessToken when getAuthority then return failure", () async {
-      final result = await AuthorityRepositoryImpl().retrieve("1");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("1");
       expect(result, isA<Failure<Authority>>());
     });
 
     test("Given null id when getAuthority then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl().retrieve("");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("");
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
@@ -89,16 +89,16 @@ void main() {
   group("AuthorityRepository Delete success", () {
     test("Given valid id when deleteAuthority then return successful", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl().delete("1");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("1");
       expect(result, isA<Success<void>>());
     });
     test("Given valid id without AccessToken when deleteAuthority then return failure", () async {
-      final result = await AuthorityRepositoryImpl().delete("1");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("1");
       expect(result, isA<Failure<void>>());
     });
 
     test("Given null id when deleteAuthority then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl().delete("");
+      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/features/users/data/repositories/authority_reporitory_test.dart
+++ b/test/features/users/data/repositories/authority_reporitory_test.dart
@@ -8,9 +8,15 @@ import '../../../../mocks/fake_data.dart';
 import '../../../../test_utils.dart';
 
 void main() {
+  late AuthorityRepositoryImpl repository;
+
   //region setup
   setUpAll(() async {
     await TestUtils().setupUnitTest();
+  });
+
+  setUp(() {
+    repository = AuthorityRepositoryImpl(TestUtils.apiClient());
   });
 
   tearDown(() async {
@@ -23,24 +29,24 @@ void main() {
     test("Given valid authority when create then return authority successfully", () async {
       TestUtils().setupAuthentication();
       const entity = mockAuthorityPayload;
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(entity);
+      final result = await repository.create(entity);
 
       expect(result, isA<Success<Authority>>());
       expect((result as Success<Authority>).data.name, "ROLE_USER");
     });
     test("Given valid authority without AccessToken when create then return failure", () async {
       const entity = mockAuthorityPayload;
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(entity);
+      final result = await repository.create(entity);
       expect(result, isA<Failure<Authority>>());
     });
 
     test("Given null authority when create then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(const Authority());
+      final result = await repository.create(const Authority());
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
     test("Given empty authority when create then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).create(const Authority(name: ""));
+      final result = await repository.create(const Authority(name: ""));
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
@@ -50,7 +56,7 @@ void main() {
   group("AuthorityRepository Get success", () {
     test("Given valid when getAuthorities then return authorities successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).list();
+      final result = await repository.list();
 
       expect(result, isA<Success<List<String>>>());
       final data = (result as Success<List<String>>).data;
@@ -59,7 +65,7 @@ void main() {
       expect(data[1], "ROLE_ADMIN");
     });
     test("Given valid without AccessToken when getAuthorities then return failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).list();
+      final result = await repository.list();
       expect(result, isA<Failure<List<String>>>());
     });
   });
@@ -68,18 +74,18 @@ void main() {
   group("AuthorityRepository Get success", () {
     test("Given valid id when getAuthority then return authority successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("1");
+      final result = await repository.retrieve("1");
 
       expect(result, isA<Success<Authority>>());
       expect((result as Success<Authority>).data.name, "ROLE_USER");
     });
     test("Given valid id without AccessToken when getAuthority then return failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("1");
+      final result = await repository.retrieve("1");
       expect(result, isA<Failure<Authority>>());
     });
 
     test("Given null id when getAuthority then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).retrieve("");
+      final result = await repository.retrieve("");
       expect(result, isA<Failure<Authority>>());
       expect((result as Failure<Authority>).error, isA<ValidationError>());
     });
@@ -89,16 +95,16 @@ void main() {
   group("AuthorityRepository Delete success", () {
     test("Given valid id when deleteAuthority then return successful", () async {
       TestUtils().setupAuthentication();
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("1");
+      final result = await repository.delete("1");
       expect(result, isA<Success<void>>());
     });
     test("Given valid id without AccessToken when deleteAuthority then return failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("1");
+      final result = await repository.delete("1");
       expect(result, isA<Failure<void>>());
     });
 
     test("Given null id when deleteAuthority then return validation failure", () async {
-      final result = await AuthorityRepositoryImpl(TestUtils.apiClient()).delete("");
+      final result = await repository.delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/features/users/data/repositories/user_repository_test.dart
+++ b/test/features/users/data/repositories/user_repository_test.dart
@@ -20,13 +20,13 @@ void main() {
   group("User Repository getUsers", () {
     test("Given valid user when getUsers then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().list();
+      final result = await UserRepository(TestUtils.apiClient()).list();
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid user without accessToken when getUsers then return failure", () async {
-      final result = await UserRepository().list();
+      final result = await UserRepository(TestUtils.apiClient()).list();
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -34,7 +34,7 @@ void main() {
   group("User Repository getUser", () {
     test("Given valid userId when getUser then return user successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().retrieve("user-1");
+      final result = await UserRepository(TestUtils.apiClient()).retrieve("user-1");
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -53,13 +53,13 @@ void main() {
     });
 
     test("Given valid userId without accessToken when getUser then return failure", () async {
-      final result = await UserRepository().retrieve("1");
+      final result = await UserRepository(TestUtils.apiClient()).retrieve("1");
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null userId when getUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().retrieve("");
+      final result = await UserRepository(TestUtils.apiClient()).retrieve("");
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -68,7 +68,7 @@ void main() {
   group("User Repository getUserByLogin", () {
     test("Given valid login when getUserByLogin then return user successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().retrieveByLogin("username");
+      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("username");
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -87,13 +87,13 @@ void main() {
     });
 
     test("Given valid login without accessToken when getUserByLogin then return failure", () async {
-      final result = await UserRepository().retrieveByLogin("admin");
+      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("admin");
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null login when getUserByLogin then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().retrieveByLogin("");
+      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("");
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -103,7 +103,7 @@ void main() {
     test("Given valid user when createUser then return user successfully", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await UserRepository().create(entity);
+      final result = await UserRepository(TestUtils.apiClient()).create(entity);
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -122,20 +122,20 @@ void main() {
     });
 
     test("Given valid user without accessToken when createUser then return failure", () async {
-      final result = await UserRepository().create(mockUserFullPayload);
+      final result = await UserRepository(TestUtils.apiClient()).create(mockUserFullPayload);
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null user when createUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().create(const User());
+      final result = await UserRepository(TestUtils.apiClient()).create(const User());
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
 
     test("Given null username when createUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().create(const User(login: "admin"));
+      final result = await UserRepository(TestUtils.apiClient()).create(const User(login: "admin"));
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -144,14 +144,14 @@ void main() {
   group("User Repository listUser", () {
     test("Given valid range when listUser then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().list(page: 0, size: 10);
+      final result = await UserRepository(TestUtils.apiClient()).list(page: 0, size: 10);
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range without accessToken when listUser then return failure", () async {
-      final result = await UserRepository().list(page: 0, size: 10);
+      final result = await UserRepository(TestUtils.apiClient()).list(page: 0, size: 10);
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -159,14 +159,14 @@ void main() {
   group("User Repository findUserByAuthority", () {
     test("Given valid range and authority when findUserByAuthority then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().listByAuthority(0, 10, "ROLE_ADMIN");
+      final result = await UserRepository(TestUtils.apiClient()).listByAuthority(0, 10, "ROLE_ADMIN");
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range and authority without accessToken when findUserByAuthority then return failure", () async {
-      final result = await UserRepository().listByAuthority(0, 10, "ROLE_ADMIN");
+      final result = await UserRepository(TestUtils.apiClient()).listByAuthority(0, 10, "ROLE_ADMIN");
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -174,14 +174,14 @@ void main() {
   group("User Repository findUserByName", () {
     test("Given valid range, name and authority when findUserByName then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
+      final result = await UserRepository(TestUtils.apiClient()).listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range, name and authority without accessToken when findUserByName then return failure", () async {
-      final result = await UserRepository().listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
+      final result = await UserRepository(TestUtils.apiClient()).listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -190,7 +190,7 @@ void main() {
     test("Given valid user when updateUser then return user successfully", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await UserRepository().update(entity);
+      final result = await UserRepository(TestUtils.apiClient()).update(entity);
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -209,13 +209,13 @@ void main() {
     });
 
     test("Given valid user without accessToken when updateUser then return failure", () async {
-      final result = await UserRepository().update(mockUserFullPayload);
+      final result = await UserRepository(TestUtils.apiClient()).update(mockUserFullPayload);
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null user when updateUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().update(const User());
+      final result = await UserRepository(TestUtils.apiClient()).update(const User());
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -224,18 +224,18 @@ void main() {
   group("User Repository deleteUser", () {
     test("Given valid userId when deleteUser then return success", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().delete("user-1");
+      final result = await UserRepository(TestUtils.apiClient()).delete("user-1");
       expect(result, isA<Success<void>>());
     });
 
     test("Given valid userId without accessToken when deleteUser then return failure", () async {
-      final result = await UserRepository().delete("1");
+      final result = await UserRepository(TestUtils.apiClient()).delete("1");
       expect(result, isA<Failure<void>>());
     });
 
     test("Given null userId when deleteUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository().delete("");
+      final result = await UserRepository(TestUtils.apiClient()).delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/features/users/data/repositories/user_repository_test.dart
+++ b/test/features/users/data/repositories/user_repository_test.dart
@@ -9,8 +9,14 @@ import '../../../../mocks/fake_data.dart';
 import '../../../../test_utils.dart';
 
 void main() {
+  late UserRepository repository;
+
   setUpAll(() async {
     await TestUtils().setupUnitTest();
+  });
+
+  setUp(() {
+    repository = UserRepository(TestUtils.apiClient());
   });
 
   tearDown(() async {
@@ -20,13 +26,13 @@ void main() {
   group("User Repository getUsers", () {
     test("Given valid user when getUsers then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).list();
+      final result = await repository.list();
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid user without accessToken when getUsers then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).list();
+      final result = await repository.list();
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -34,7 +40,7 @@ void main() {
   group("User Repository getUser", () {
     test("Given valid userId when getUser then return user successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).retrieve("user-1");
+      final result = await repository.retrieve("user-1");
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -53,13 +59,13 @@ void main() {
     });
 
     test("Given valid userId without accessToken when getUser then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).retrieve("1");
+      final result = await repository.retrieve("1");
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null userId when getUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).retrieve("");
+      final result = await repository.retrieve("");
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -68,7 +74,7 @@ void main() {
   group("User Repository getUserByLogin", () {
     test("Given valid login when getUserByLogin then return user successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("username");
+      final result = await repository.retrieveByLogin("username");
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -87,13 +93,13 @@ void main() {
     });
 
     test("Given valid login without accessToken when getUserByLogin then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("admin");
+      final result = await repository.retrieveByLogin("admin");
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null login when getUserByLogin then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).retrieveByLogin("");
+      final result = await repository.retrieveByLogin("");
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -103,7 +109,7 @@ void main() {
     test("Given valid user when createUser then return user successfully", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await UserRepository(TestUtils.apiClient()).create(entity);
+      final result = await repository.create(entity);
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -122,20 +128,20 @@ void main() {
     });
 
     test("Given valid user without accessToken when createUser then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).create(mockUserFullPayload);
+      final result = await repository.create(mockUserFullPayload);
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null user when createUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).create(const User());
+      final result = await repository.create(const User());
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
 
     test("Given null username when createUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).create(const User(login: "admin"));
+      final result = await repository.create(const User(login: "admin"));
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -144,14 +150,14 @@ void main() {
   group("User Repository listUser", () {
     test("Given valid range when listUser then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).list(page: 0, size: 10);
+      final result = await repository.list(page: 0, size: 10);
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range without accessToken when listUser then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).list(page: 0, size: 10);
+      final result = await repository.list(page: 0, size: 10);
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -159,14 +165,14 @@ void main() {
   group("User Repository findUserByAuthority", () {
     test("Given valid range and authority when findUserByAuthority then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).listByAuthority(0, 10, "ROLE_ADMIN");
+      final result = await repository.listByAuthority(0, 10, "ROLE_ADMIN");
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range and authority without accessToken when findUserByAuthority then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).listByAuthority(0, 10, "ROLE_ADMIN");
+      final result = await repository.listByAuthority(0, 10, "ROLE_ADMIN");
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -174,14 +180,14 @@ void main() {
   group("User Repository findUserByName", () {
     test("Given valid range, name and authority when findUserByName then return user list successfully", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
+      final result = await repository.listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
 
       expect(result, isA<Success<List<UserEntity>>>());
       expect((result as Success<List<UserEntity>>).data.length, 4);
     });
 
     test("Given valid range, name and authority without accessToken when findUserByName then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
+      final result = await repository.listByNameAndRole(0, 10, "admin", "ROLE_ADMIN");
       expect(result, isA<Failure<List<UserEntity>>>());
     });
   });
@@ -190,7 +196,7 @@ void main() {
     test("Given valid user when updateUser then return user successfully", () async {
       TestUtils().setupAuthentication();
       final entity = mockUserFullPayload;
-      final result = await UserRepository(TestUtils.apiClient()).update(entity);
+      final result = await repository.update(entity);
 
       expect(result, isA<Success<UserEntity>>());
       final data = (result as Success<UserEntity>).data;
@@ -209,13 +215,13 @@ void main() {
     });
 
     test("Given valid user without accessToken when updateUser then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).update(mockUserFullPayload);
+      final result = await repository.update(mockUserFullPayload);
       expect(result, isA<Failure<UserEntity>>());
     });
 
     test("Given null user when updateUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).update(const User());
+      final result = await repository.update(const User());
       expect(result, isA<Failure<UserEntity>>());
       expect((result as Failure<UserEntity>).error, isA<ValidationError>());
     });
@@ -224,18 +230,18 @@ void main() {
   group("User Repository deleteUser", () {
     test("Given valid userId when deleteUser then return success", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).delete("user-1");
+      final result = await repository.delete("user-1");
       expect(result, isA<Success<void>>());
     });
 
     test("Given valid userId without accessToken when deleteUser then return failure", () async {
-      final result = await UserRepository(TestUtils.apiClient()).delete("1");
+      final result = await repository.delete("1");
       expect(result, isA<Failure<void>>());
     });
 
     test("Given null userId when deleteUser then return validation failure", () async {
       TestUtils().setupAuthentication();
-      final result = await UserRepository(TestUtils.apiClient()).delete("");
+      final result = await repository.delete("");
       expect(result, isA<Failure<void>>());
       expect((result as Failure<void>).error, isA<ValidationError>());
     });

--- a/test/infrastructure/config/environment_test.dart
+++ b/test/infrastructure/config/environment_test.dart
@@ -4,24 +4,27 @@ import 'package:flutter_bloc_advance/infrastructure/config/template_config.dart'
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('ProfileConstants', () {
-    test('setEnvironment sets dev environment', () {
-      ProfileConstants.setEnvironment(Environment.dev);
-      expect(ProfileConstants.isDevelopment, true);
-      expect(ProfileConstants.api, "mock");
+  group('AppConfig', () {
+    test('dev config sets development environment', () {
+      const config = AppConfig.dev();
+      expect(config.isDevelopment, true);
+      expect(config.apiBaseUrl, isNull);
     });
-
-    test('setEnvironment sets test environment', () {
-      ProfileConstants.setEnvironment(Environment.test);
-      expect(ProfileConstants.isDevelopment, false);
-      expect(ProfileConstants.isProduction, false);
-      expect(ProfileConstants.api, "mock");
+    test('test config sets test environment', () {
+      const config = AppConfig.test();
+      expect(config.isDevelopment, false);
+      expect(config.isProduction, false);
+      expect(config.apiBaseUrl, isNull);
     });
-
-    test('setEnvironment sets prod environment', () {
-      ProfileConstants.setEnvironment(Environment.prod);
-      expect(ProfileConstants.isProduction, true);
-      expect(ProfileConstants.api, TemplateConfig.prodApiUrl);
+    test('prod config sets production environment', () {
+      const config = AppConfig.prod();
+      expect(config.isProduction, true);
+      expect(config.apiBaseUrl, TemplateConfig.prodApiUrl);
+    });
+    test('fromEnvironment maps each enum value', () {
+      expect(AppConfig.fromEnvironment(Environment.dev).isDevelopment, true);
+      expect(AppConfig.fromEnvironment(Environment.test).isTest, true);
+      expect(AppConfig.fromEnvironment(Environment.prod).isProduction, true);
     });
   });
   test("allowed paths", () {

--- a/test/infrastructure/config/environment_test.dart
+++ b/test/infrastructure/config/environment_test.dart
@@ -14,12 +14,15 @@ void main() {
       const config = AppConfig.test();
       expect(config.isDevelopment, false);
       expect(config.isProduction, false);
+      expect(config.isTest, true);
       expect(config.apiBaseUrl, isNull);
     });
     test('prod config sets production environment', () {
       const config = AppConfig.prod();
       expect(config.isProduction, true);
       expect(config.apiBaseUrl, TemplateConfig.prodApiUrl);
+      expect(config.idleTimeout, const Duration(minutes: 15));
+      expect(config.certificatePins, isEmpty);
     });
     test('fromEnvironment maps each enum value', () {
       expect(AppConfig.fromEnvironment(Environment.dev).isDevelopment, true);

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -65,7 +65,6 @@ void main() {
   });
 
   tearDown(() async {
-    ApiClient.reset();
     await TestUtils().tearDownUnitTest();
   });
 
@@ -94,30 +93,26 @@ void main() {
 
   group('ApiClient Tests', () {
     late _StubInterceptor stub;
+    late ApiClient client;
 
     setUp(() {
-      ApiClient.appConfig = const AppConfig.prod();
       stub = _StubInterceptor();
       final testDio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
       testDio.interceptors.add(stub);
-      ApiClient.setTestInstance(testDio);
-    });
-
-    tearDown(() {
-      ApiClient.reset();
+      client = ApiClient(appConfig: const AppConfig.prod(), dio: testDio);
     });
 
     group('HTTP Requests', () {
       test('given valid data when post request is made then should return success response', () async {
         stub.stubSuccess(data: '{"success": true}', statusCode: 200);
-        final response = await ApiClient.post('/test', {'data': 'test'});
+        final response = await client.post('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
 
       test('given socket exception when post request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed');
         await expectLater(
-          ApiClient.post('/test', {'data': 'test'}),
+          client.post('/test', {'data': 'test'}),
           throwsA(
             allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('No Internet connection'))]),
           ),
@@ -127,21 +122,21 @@ void main() {
       test('given timeout when post request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.connectionTimeout, message: 'Timeout');
         await expectLater(
-          ApiClient.post('/test', {'data': 'test'}),
+          client.post('/test', {'data': 'test'}),
           throwsA(allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('TimeoutException'))])),
         );
       });
 
       test('given valid data when get request is made then should return success 200', () async {
         stub.stubSuccess(data: '{"success": true}', statusCode: 200);
-        final response = await ApiClient.get('/test');
+        final response = await client.get('/test');
         expect(response.statusCode, lessThan(300));
       });
 
       test('given connection error when get request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed');
         await expectLater(
-          ApiClient.get('/test'),
+          client.get('/test'),
           throwsA(
             allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('No Internet connection'))]),
           ),
@@ -151,7 +146,7 @@ void main() {
       test('given 401 response when get request is made then should throw UnauthorizedException', () async {
         stub.stubDioError(DioExceptionType.badResponse, statusCode: 401, data: 'Unauthorized');
         await expectLater(
-          ApiClient.get('/test'),
+          client.get('/test'),
           throwsA(allOf([isA<UnauthorizedException>(), predicate((e) => e.toString().contains('Unauthorized'))])),
         );
       });
@@ -159,26 +154,26 @@ void main() {
       test('given timeout when get request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.receiveTimeout, message: 'Timeout');
         await expectLater(
-          ApiClient.get('/test'),
+          client.get('/test'),
           throwsA(allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('TimeoutException'))])),
         );
       });
 
       test('given valid data when put request is made then should return success 200', () async {
         stub.stubSuccess(data: '{"success": true}', statusCode: 200);
-        final response = await ApiClient.put('/test', {'data': 'test'});
+        final response = await client.put('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
 
       test('given connection error when put request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed');
-        await expectLater(ApiClient.put('/test', {'data': 'test'}), throwsA(isA<FetchDataException>()));
+        await expectLater(client.put('/test', {'data': 'test'}), throwsA(isA<FetchDataException>()));
       });
 
       test('given timeout when put request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.sendTimeout, message: 'Timeout');
         await expectLater(
-          ApiClient.put('/test', {'data': 'test'}),
+          client.put('/test', {'data': 'test'}),
           throwsA(allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('TimeoutException'))])),
         );
       });
@@ -186,19 +181,19 @@ void main() {
       group('PATCH', () {
         test('given valid data when patch request is made then should return success 200', () async {
           stub.stubSuccess(data: '{"success": true}', statusCode: 200);
-          final response = await ApiClient.patch('/test', {'data': 'test'});
+          final response = await client.patch('/test', {'data': 'test'});
           expect(response.statusCode, lessThan(300));
         });
 
         test('given connection error when patch request is made then should throw FetchDataException', () async {
           stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed');
-          await expectLater(ApiClient.patch('/test', {'data': 'test'}), throwsA(isA<FetchDataException>()));
+          await expectLater(client.patch('/test', {'data': 'test'}), throwsA(isA<FetchDataException>()));
         });
 
         test('given timeout when patch request is made then should throw FetchDataException', () async {
           stub.stubDioError(DioExceptionType.receiveTimeout, message: 'Timeout');
           await expectLater(
-            ApiClient.patch('/test', {'data': 'test'}),
+            client.patch('/test', {'data': 'test'}),
             throwsA(allOf([isA<FetchDataException>(), predicate((e) => e.toString().contains('TimeoutException'))])),
           );
         });
@@ -206,81 +201,83 @@ void main() {
 
       test('given valid data when delete request is made then should return success 204', () async {
         stub.stubSuccess(data: '{"success": true}', statusCode: 204);
-        final response = await ApiClient.delete('/test');
+        final response = await client.delete('/test');
         expect(response.statusCode, lessThan(300));
       });
 
       test('given 401 when delete request is made then should throw UnauthorizedException', () async {
         stub.stubDioError(DioExceptionType.badResponse, statusCode: 401, data: 'Unauthorized');
         await expectLater(
-          ApiClient.delete('/test'),
+          client.delete('/test'),
           throwsA(allOf([isA<UnauthorizedException>(), predicate((e) => e.toString().contains('Unauthorized'))])),
         );
       });
 
       test('given connection error when delete request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed');
-        await expectLater(ApiClient.delete('/test'), throwsA(isA<FetchDataException>()));
+        await expectLater(client.delete('/test'), throwsA(isA<FetchDataException>()));
       });
 
       test('given timeout when delete request is made then should throw FetchDataException', () async {
         stub.stubDioError(DioExceptionType.receiveTimeout, message: 'Timeout');
-        await expectLater(ApiClient.delete('/test'), throwsA(isA<FetchDataException>()));
+        await expectLater(client.delete('/test'), throwsA(isA<FetchDataException>()));
       });
 
       test('given 400 when request is made then should throw BadRequestException', () async {
         stub.stubDioError(DioExceptionType.badResponse, statusCode: 400, data: 'Bad Request');
         await expectLater(
-          ApiClient.post('/test', {'data': 'test'}),
+          client.post('/test', {'data': 'test'}),
           throwsA(allOf([isA<BadRequestException>(), predicate((e) => e.toString().contains('Bad Request'))])),
         );
       });
     });
 
     group('Mock Requests', () {
+      late ApiClient mockClient;
+
       setUp(() {
-        ApiClient.reset();
-        ApiClient.appConfig = const AppConfig.test();
+        // Build a fresh test-env client so the MockInterceptor is in the chain.
+        mockClient = TestUtils.apiClient();
       });
 
       test('given test environment when GET request is made then should return mock data', () async {
         TestUtils().setupAuthentication();
-        final response = await ApiClient.get('/test');
+        final response = await mockClient.get('/test');
         expect(response.statusCode, lessThan(300));
       });
 
       test('given test environment without token when GET request is made then should throw', () async {
-        expect(() => ApiClient.get('/test'), throwsA(isA<UnauthorizedException>()));
+        expect(() => mockClient.get('/test'), throwsA(isA<UnauthorizedException>()));
       });
 
       test('given test environment when POST request is made then should return mock data', () async {
         TestUtils().setupAuthentication();
-        final response = await ApiClient.post('/test', {'data': 'test'});
+        final response = await mockClient.post('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
 
       test('given test environment without token when POST request is made then should throw', () async {
-        expect(() => ApiClient.post('/test', {'data': 'test'}), throwsA(isA<UnauthorizedException>()));
+        expect(() => mockClient.post('/test', {'data': 'test'}), throwsA(isA<UnauthorizedException>()));
       });
 
       test('given test environment when PUT request is made then should return mock data', () async {
         TestUtils().setupAuthentication();
-        final response = await ApiClient.put('/test', {'data': 'test'});
+        final response = await mockClient.put('/test', {'data': 'test'});
         expect(response.statusCode, lessThan(300));
       });
 
       test('given test environment without token when PUT request is made then should throw', () async {
-        expect(() => ApiClient.put('/test', {'data': 'test'}), throwsA(isA<UnauthorizedException>()));
+        expect(() => mockClient.put('/test', {'data': 'test'}), throwsA(isA<UnauthorizedException>()));
       });
 
       test('given test environment when DELETE request is made then should return 204', () async {
         TestUtils().setupAuthentication();
-        final response = await ApiClient.delete('/test');
+        final response = await mockClient.delete('/test');
         expect(response.statusCode, lessThan(300));
       });
 
       test('given test environment without token when DELETE request is made then should throw', () async {
-        expect(() => ApiClient.delete('/test'), throwsA(isA<UnauthorizedException>()));
+        expect(() => mockClient.delete('/test'), throwsA(isA<UnauthorizedException>()));
       });
     });
   });
@@ -304,19 +301,17 @@ void main() {
   // what gets registered with Dio. Pin the order + names so future
   // chain edits surface as a deliberate test update.
   group('ApiClient.interceptorChainSnapshot (#63, #64)', () {
-    setUp(() {
-      ApiClient.reset();
-    });
-
     test('is populated after the Dio instance is built', () {
-      // Force lazy build.
-      ApiClient.instance;
-      expect(ApiClient.interceptorChainSnapshot, isNotEmpty);
+      // Build a test-env client and force lazy Dio construction.
+      final client = TestUtils.apiClient();
+      client.instance;
+      expect(client.interceptorChainSnapshot, isNotEmpty);
     });
 
     test('lists every interceptor in declared order (non-production includes MockInterceptor)', () {
-      ApiClient.instance;
-      final names = ApiClient.interceptorChainSnapshot.map((e) => e.name).toList();
+      final client = TestUtils.apiClient();
+      client.instance;
+      final names = client.interceptorChainSnapshot.map((e) => e.name).toList();
 
       expect(names, [
         'ConnectivityInterceptor',
@@ -335,36 +330,37 @@ void main() {
     });
 
     test('MockInterceptor entry is flagged active=false (dev/test fallback)', () {
-      ApiClient.instance;
-      final mock = ApiClient.interceptorChainSnapshot.firstWhere((e) => e.name == 'MockInterceptor');
+      final client = TestUtils.apiClient();
+      client.instance;
+      final mock = client.interceptorChainSnapshot.firstWhere((e) => e.name == 'MockInterceptor');
       expect(mock.active, isFalse);
     });
 
     test('snapshot is returned as an unmodifiable view', () {
-      ApiClient.instance;
+      final client = TestUtils.apiClient();
+      client.instance;
       expect(
-        () => ApiClient.interceptorChainSnapshot..add(const InterceptorChainEntry(name: 'X', detail: 'X')),
+        () => client.interceptorChainSnapshot..add(const InterceptorChainEntry(name: 'X', detail: 'X')),
         throwsUnsupportedError,
       );
     });
 
-    // Guard for the test-ordering hazard called out in the independent
-    // review (I3): when ApiClient.secureStorage is null at Dio creation
-    // time, the interceptors fall back to a private adapter instance
-    // that diverges from the repository layer's adapter. test_utils
-    // wires the shared adapter in setupUnitTest. Drives a fresh
-    // setupUnitTest inside the test so this assertion survives the
-    // group's pre-test ApiClient.reset() (which deliberately clears
-    // the static — see C-C / [ApiClient.reset]).
-    test('ApiClient.secureStorage is wired by setupUnitTest — no silent divergence', () async {
-      await TestUtils().setupUnitTest();
-      expect(
-        ApiClient.secureStorage,
-        isNotNull,
-        reason:
-            'If this fires, setupUnitTest is being bypassed or someone reset the static. '
-            'See ApiClient._createDio warn log and lib/infrastructure/http/api_client.dart:76.',
-      );
+    // The old static-divergence hazard (review I3) is eliminated by the
+    // instance/DI model: secureStorage is a constructor dependency of the
+    // single shared ApiClient, so the interceptors and the repository layer
+    // can no longer use different adapters. This test pins the remaining
+    // observable contract — even when built WITHOUT a secureStorage (the
+    // documented `_secureStorage == null` fallback branch), the client still
+    // assembles its full interceptor chain. The secureStorage → Authorization
+    // header wiring itself is covered by auth_interceptor_test.dart.
+    test('assembles the full interceptor chain even without an injected secureStorage', () {
+      // No secureStorage passed → exercises the documented `_secureStorage == null`
+      // fallback branch in _createDio. AppConfig.test() keeps baseUrl empty (valid)
+      // and forces the real chain (no injected Dio).
+      final client = ApiClient(appConfig: const AppConfig.test());
+      client.instance; // force Dio + chain construction
+      final names = client.interceptorChainSnapshot.map((e) => e.name);
+      expect(names, containsAll(<String>['AuthInterceptor', 'TokenRefreshInterceptor']));
     });
   });
 }

--- a/test/infrastructure/http/api_client_test.dart
+++ b/test/infrastructure/http/api_client_test.dart
@@ -96,7 +96,7 @@ void main() {
     late _StubInterceptor stub;
 
     setUp(() {
-      ProfileConstants.setEnvironment(Environment.prod);
+      ApiClient.appConfig = const AppConfig.prod();
       stub = _StubInterceptor();
       final testDio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
       testDio.interceptors.add(stub);
@@ -239,8 +239,8 @@ void main() {
 
     group('Mock Requests', () {
       setUp(() {
-        ProfileConstants.setEnvironment(Environment.test);
         ApiClient.reset();
+        ApiClient.appConfig = const AppConfig.test();
       });
 
       test('given test environment when GET request is made then should return mock data', () async {

--- a/test/infrastructure/http/dev_console_capture_in_mock_mode_test.dart
+++ b/test/infrastructure/http/dev_console_capture_in_mock_mode_test.dart
@@ -1,6 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_bloc_advance/infrastructure/config/environment.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/dev_console_store.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/interceptors/mock_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -25,8 +23,6 @@ void main() {
   });
 
   setUp(() {
-    ApiClient.reset();
-    ApiClient.appConfig = const AppConfig.test();
     DevConsoleStore.instance.clearNetwork();
   });
 
@@ -53,7 +49,7 @@ void main() {
     test('a mock-served GET appears in DevConsoleStore AND is marked complete', () async {
       TestUtils().setupAuthentication();
 
-      await ApiClient.get('/test');
+      await TestUtils.apiClient().get('/test');
 
       final entries = DevConsoleStore.instance.networkEntries;
       expect(entries, isNotEmpty, reason: 'DevConsoleInterceptor.onRequest must run before the mock short-circuits');

--- a/test/infrastructure/http/dev_console_capture_in_mock_mode_test.dart
+++ b/test/infrastructure/http/dev_console_capture_in_mock_mode_test.dart
@@ -25,8 +25,8 @@ void main() {
   });
 
   setUp(() {
-    ProfileConstants.setEnvironment(Environment.test);
     ApiClient.reset();
+    ApiClient.appConfig = const AppConfig.test();
     DevConsoleStore.instance.clearNetwork();
   });
 

--- a/test/main/app_test.dart
+++ b/test/main/app_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_bloc_advance/main/app.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -19,7 +18,6 @@ void main() {
     });
 
     tearDown(() async {
-      ApiClient.reset();
       await TestUtils().tearDownUnitTest();
     });
 

--- a/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
+++ b/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_bloc_advance/shared/dynamic_forms/application/usecases/l
 import 'package:flutter_bloc_advance/shared/dynamic_forms/application/usecases/load_form_schema_usecase.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/application/usecases/submit_form_usecase.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../test_utils.dart';
@@ -120,18 +119,16 @@ void main() {
 
   setUp(() {
     stub = _StubInterceptor();
-    final testDio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
-    testDio.interceptors.add(stub);
-    ApiClient.setTestInstance(testDio);
   });
 
   tearDown(() async {
-    ApiClient.reset();
     await TestUtils().tearDownUnitTest();
   });
 
   DynamicFormBloc buildBloc() {
-    final repo = DynamicFormRepository();
+    final testDio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
+    testDio.interceptors.add(stub);
+    final repo = DynamicFormRepository(TestUtils.apiClient(dio: testDio));
     return DynamicFormBloc(
       loadFormSchemaUseCase: LoadFormSchemaUseCase(repo),
       submitFormUseCase: SubmitFormUseCase(repo),

--- a/test/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl_test.dart
+++ b/test/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/data/repositories/dynamic_form_repository_impl.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/domain/entities/form_bundle_entity.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/domain/entities/form_schema_entity.dart';
-import 'package:flutter_bloc_advance/infrastructure/http/api_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
@@ -83,21 +82,20 @@ void main() {
     await TestUtils().setupUnitTest();
   });
 
+  late DynamicFormRepository repo;
+
   setUp(() {
     stub = _StubInterceptor();
     final testDio = Dio(BaseOptions(baseUrl: 'https://test.api', responseType: ResponseType.plain));
     testDio.interceptors.add(stub);
-    ApiClient.setTestInstance(testDio);
+    repo = DynamicFormRepository(TestUtils.apiClient(dio: testDio));
   });
 
   tearDown(() async {
-    ApiClient.reset();
     await TestUtils().tearDownUnitTest();
   });
 
   group('DynamicFormRepository input validation', () {
-    final repo = DynamicFormRepository();
-
     test('fetchSchema returns ValidationError when formId is empty', () async {
       final result = await repo.fetchSchema('');
 
@@ -127,8 +125,6 @@ void main() {
   });
 
   group('fetchBundle', () {
-    final repo = DynamicFormRepository();
-
     test('returns Failure<FormBundleEntity> with ValidationError when endpoint is empty', () async {
       final result = await repo.fetchBundle('');
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -66,7 +66,7 @@ class TestUtils {
 
   Future<void> setupUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
-    ProfileConstants.setEnvironment(Environment.test);
+    ApiClient.appConfig = const AppConfig.test();
     TestWidgetsFlutterBinding.ensureInitialized();
     EquatableConfig.stringify = true;
     _installSecureStorageMock();
@@ -85,7 +85,7 @@ class TestUtils {
 
   Future<void> setupRepositoryUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
-    ProfileConstants.setEnvironment(Environment.test);
+    ApiClient.appConfig = const AppConfig.test();
     // Binding must be initialized BEFORE installing the MethodChannel
     // mock — `TestDefaultBinaryMessengerBinding.instance` throws
     // otherwise. setupUnitTest does the same.

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc_advance/core/logging/app_logger.dart';
@@ -26,6 +27,12 @@ class TestUtils {
   static final Map<String, String> _secureStore = {};
 
   static const _secureChannel = MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+
+  /// Mock-backed client for tests: test AppConfig → MockInterceptor serves
+  /// assets/mock/*.json; shared secure adapter → same MethodChannel mock the
+  /// repo layer reads. Pass [dio] to inject a stub.
+  static ApiClient apiClient({Dio? dio}) =>
+      ApiClient(appConfig: const AppConfig.test(), secureStorage: FlutterSecureStorageAdapter(), dio: dio);
 
   /// Always re-installs the handler. Previously short-circuited via
   /// a `_secureMockInstalled` flag, but `secure_storage_test.dart`
@@ -66,18 +73,9 @@ class TestUtils {
 
   Future<void> setupUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
-    ApiClient.appConfig = const AppConfig.test();
     TestWidgetsFlutterBinding.ensureInitialized();
     EquatableConfig.stringify = true;
     _installSecureStorageMock();
-    // Wire ApiClient to a shared FlutterSecureStorageAdapter so the
-    // HTTP interceptors read from the same MethodChannel-mocked store
-    // as the repository layer. Without this, tests touching both
-    // ApiClient.instance and a repository would silently use two
-    // different adapter instances — both backed by the same mock so
-    // tests pass, but the test harness would not catch a future
-    // production refactor that breaks SoT.
-    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);
@@ -85,29 +83,18 @@ class TestUtils {
 
   Future<void> setupRepositoryUnitTest() async {
     AppLogger.configure(isProduction: false, logFormat: LogFormat.simple);
-    ApiClient.appConfig = const AppConfig.test();
     // Binding must be initialized BEFORE installing the MethodChannel
     // mock — `TestDefaultBinaryMessengerBinding.instance` throws
     // otherwise. setupUnitTest does the same.
     TestWidgetsFlutterBinding.ensureInitialized();
     _installSecureStorageMock();
-    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     await _clearStorage();
     await AppLocalStorage().save(StorageKeys.language.key, "en");
     AppRouter().setRouter(RouterType.goRouter);
   }
 
   Future<void> tearDownUnitTest() async {
-    ApiClient.reset();
-    // [ApiClient.reset] now also clears `secureStorage` and
-    // `onSessionExpired` (Copilot finding: hot-reload / multi-test
-    // leakage). Test files that rely on `setUpAll` + per-test
-    // `tearDown` (instead of per-test `setUp`) would otherwise see a
-    // null `secureStorage` after the first teardown. Re-wire the
-    // shared adapter here so the next test in the same file starts
-    // with the same SoT invariants `setupUnitTest` established.
     _installSecureStorageMock();
-    ApiClient.secureStorage = FlutterSecureStorageAdapter();
     return await _clearStorage();
   }
 


### PR DESCRIPTION
Closes #144. Supersedes #145.

## What

Replaces the global mutable `ProfileConstants` map **and** the fully-static `ApiClient` with typed, immutable, dependency-injected equivalents — eliminating **all mutable global state** in the config + HTTP layer.

- **`ProfileConstants` map → `final class AppConfig`** (kept from #145's design): first-class `Environment`, typed `apiBaseUrl`/`certificatePins`/`idleTimeout`, `const` `.dev()/.test()/.prod()` + `fromEnvironment`, prod-only `sentryDsn`. No more `null!`, `dynamic`, magic-string keys, or map-identity environment checks.
- **Static `ApiClient` → DI-injected instance.** The 6 HTTP repositories (`User`, `Account`, `Authority`, `DynamicForm`, `Lifecycle`, `Login`) now receive `ApiClient` via constructor. `AppDependencies` builds **one** instance; `AppScope` provides it via `RepositoryProvider<ApiClient>` and threads it into the repos and `SystemDashboardCubit`. Bootstrap no longer mutates any `ApiClient` statics. `ApiClient.reset()`/`setTestInstance` are gone — test isolation is now **structural** (each test owns its client).
- Pure stateless helpers (`decodeUTF8`, error mappers) remain `static` (no global state).
- `AuthSessionRepository`/`MenuRepository` are untouched (they make no HTTP calls).

## Scope note (honest)

Issue #144 asked for the config to move to DI. A review of #145 found that `ApiClient` still held the env config as a **mutable global static** — reproducing the very anti-pattern #144 targets. This PR therefore also converts `ApiClient` to an instance so the *last* global is removed. That's broader than #144's literal text but fulfils its stated goal ("stops files from depending on hidden global state", "no global mutation", testability).

## Review findings from #145, folded in

- **Dual source of truth** (DI `AppConfig` vs `ApiClient.appConfig`): eliminated — one `AppConfig`, one `ApiClient`, one DI spine.
- **Unguarded `context.read<AppConfig>()` in the dashboard**: now guarded (consistent with the sibling `LifecycleBloc` read).

## Verification

- `fvm flutter test` → **1564 passed, 0 failures**
- `fvm dart analyze` → clean
- `fvm dart format . --line-length=120 --set-exit-if-changed` → 0 changed

Design and step-by-step plan (incl. a documented mid-flight correction) live in `docs/superpowers/specs/` and `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)