### PR TITLE
ci(test): exclude generated/bootstrap code from coverage gate (closes #149)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,19 +66,8 @@ jobs:
         run: flutter test --coverage --timeout=30s --concurrency=4 --reporter=compact
 
       - name: Check coverage threshold
-        run: |
-          if [ -f coverage/lcov.info ]; then
-            total_lines=$(grep -c "DA:" coverage/lcov.info || echo "0")
-            hit_lines=$(grep "DA:" coverage/lcov.info | grep -cv ",0$" || echo "0")
-            if [ "$total_lines" -gt 0 ]; then
-              coverage=$((hit_lines * 100 / total_lines))
-              echo "Coverage: ${coverage}%"
-              if [ "$coverage" -lt 65 ]; then
-                echo "::error::Coverage ${coverage}% is below 65% threshold"
-                exit 1
-              fi
-            fi
-          fi
+        # Excludes generated/bootstrap code from the metric (see scripts/check_coverage.sh, issue #149).
+        run: scripts/check_coverage.sh coverage/lcov.info 65
 
   build:
     name: Build Android

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.40+1
+version: 0.21.41+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.0 • channel stable • https://github.com/flutter/flutter.git

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Computes line coverage from an lcov file, EXCLUDING generated and bootstrap
+# code, and fails if it is below a threshold.
+#
+# Why filter: `flutter test --coverage` instruments every executed lib/ file,
+# including generated localization (lib/generated/**), codegen output
+# (*.g.dart / *.freezed.dart), and app entry points (lib/main/main_*.dart).
+# None of those carry hand-written, test-worthy logic, so counting them makes
+# the headline number an unreliable quality signal (see issue #149).
+#
+# Usage:
+#   scripts/check_coverage.sh [LCOV_FILE] [THRESHOLD]
+# Defaults: coverage/lcov.info, 65
+#
+# Portable: pure bash + awk, no `lcov` binary required (avoids version-skew
+# pain on CI runners). Reusable locally and in CI.
+
+set -euo pipefail
+
+LCOV_FILE="${1:-coverage/lcov.info}"
+THRESHOLD="${2:-65}"
+
+if [ ! -f "$LCOV_FILE" ]; then
+  echo "::warning::No coverage file at '$LCOV_FILE'; skipping coverage check"
+  exit 0
+fi
+
+# Extended-regex of SF: paths excluded from the coverage metric.
+EXCLUDE_RE='(^|/)lib/generated/|\.g\.dart$|\.freezed\.dart$|(^|/)lib/main/main_[^/]*\.dart$|\.config\.dart$'
+
+read -r total hit excluded < <(awk -v ex="$EXCLUDE_RE" '
+  /^SF:/ {
+    path = substr($0, 4)
+    skip = (path ~ ex) ? 1 : 0
+    if (skip) excluded++
+    next
+  }
+  skip { next }
+  /^DA:/ { total++; if ($0 !~ /,0$/) hit++ }
+  END   { printf "%d %d %d\n", total, hit, excluded }
+' "$LCOV_FILE")
+
+if [ "${total:-0}" -eq 0 ]; then
+  echo "::warning::No instrumented lines after filtering; skipping coverage check"
+  exit 0
+fi
+
+coverage=$(( hit * 100 / total ))
+echo "Coverage (filtered): ${coverage}% — ${hit}/${total} lines (${excluded} generated/bootstrap files excluded)"
+
+if [ "$coverage" -lt "$THRESHOLD" ]; then
+  echo "::error::Coverage ${coverage}% is below ${THRESHOLD}% threshold"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #149. The CI coverage gate computed line coverage from the **raw** `lcov.info` with no filtering. `flutter test --coverage` instruments every executed `lib/` file — including generated localization (`lib/generated/**`) and, when present, `*.g.dart` / `*.freezed.dart` / `lib/main/main_*.dart`. Counting those made the headline number mix authored and generated code, so it was an unreliable quality signal.

## Changes
- **Add `scripts/check_coverage.sh`** — pure bash + awk (no `lcov` binary, avoids CI version-skew pain), filters generated/bootstrap files by `SF:` path, computes line coverage, and fails below a threshold. Reusable locally too (fits the `run_fvm_build.sh` local-checks philosophy).
- **Replace** the brittle inline `grep`/arithmetic in `build_and_test.yml` with a single call: `scripts/check_coverage.sh coverage/lcov.info 65`.

## Excluded patterns
`lib/generated/**`, `*.g.dart`, `*.freezed.dart`, `lib/main/main_*.dart`, `*.config.dart`

## Verification
- `shellcheck scripts/check_coverage.sh` → clean
- Local run: `Coverage (filtered): 71% — 5433/7611 lines (4 generated/bootstrap files excluded)` → passes 65% floor
- Tested pass / fail (threshold 99) / missing-file (skips gracefully) paths
- `dart format` clean

## Note
Threshold kept at **65** (authored coverage is 71%, ~6 pts headroom). Raising the floor is a separate decision left to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)