### PR TITLE
refactor(test): deterministic time — fakeAsync + no real-time waits (closes #148)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-deterministic-test-time.md
+++ b/docs/superpowers/plans/2026-06-03-deterministic-test-time.md
@@ -1,0 +1,366 @@
+# Deterministic Test Time Implementation Plan (#148)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove wall-clock dependence from the test suite — drive time-based logic with `fakeAsync`, stop using real-time `blocTest(wait:)` for mocked async, and use a fixed instant for arbitrary-value fixtures.
+
+**Architecture:** `event_transformers_test` moves to `fakeAsync` (virtual time). `dynamic_form_bloc_test` drops the `wait:`/`Future.delayed` real waits (the mocked Dio responses resolve on microtasks; ordering is made explicit with `bloc.stream.firstWhere`). Arbitrary fixture timestamps use a shared `kTestInstant`. Legitimately relative/time-bracket tests are left untouched.
+
+**Tech Stack:** Flutter 3.44.0, `flutter_test`, `bloc_test`, `fake_async` 1.3.3 (dev dep), `mocktail`, FVM. Run tests with `fvm flutter test`.
+
+---
+
+## Key facts
+
+- The bloc's `stream` is a broadcast stream, so a `firstWhere` listener inside an
+  `act` callback coexists with `blocTest`'s own collector.
+- `dynamic_form_bloc` uses `restart()` / `dropConcurrent()` transformers — **no
+  debounce**. Its test `wait:`s only cover mocked async settling.
+- `fakeAsync`'s `async.elapse(d)` advances virtual time, running all timers and
+  microtasks scheduled within `d` in order — instantly in real time.
+- Baseline: full suite 1565 tests green (~31–36s wall, high variance).
+
+## File structure
+
+- Modify `test/shared/utils/event_transformers_test.dart` — Task 1 (fakeAsync).
+- Modify `test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart` — Task 2 (drop waits).
+- Modify `test/mocks/fake_data.dart` + `test/features/users/presentation/pages/list_user_screen_test.dart` — Task 3 (fixed instant).
+- Modify `docs/testing-architecture.md` — Task 4 (docs).
+
+---
+
+## Task 1: `event_transformers_test.dart` → fakeAsync
+
+**Files:**
+- Modify: `test/shared/utils/event_transformers_test.dart` (replace the 4 `blocTest` cases; keep the `_Event`/`_Run`/`_CounterBloc` scaffold)
+
+- [ ] **Step 1: Replace the imports + `main()` body**
+
+Keep the top scaffold (`_Event`, `_Run`, `_CounterBloc`) exactly as-is. Change the
+`bloc_test` import to `fake_async`, and replace the whole `void main() { ... }`
+with the version below. Resulting import block:
+
+```dart
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_bloc_advance/shared/utils/event_transformers.dart';
+import 'package:flutter_test/flutter_test.dart';
+```
+
+(Remove `import 'package:bloc_test/bloc_test.dart';` — no longer used.)
+
+New `main()`:
+
+```dart
+void main() {
+  group('EventTransformers.dropConcurrent', () {
+    test('a second event added while the first handler is running is dropped', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.dropConcurrent());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run()); // dropped: previous handler is still running.
+
+        async.elapse(const Duration(seconds: 1)); // past handlerDelay; instant in virtual time
+
+        expect(states, [1]);
+        expect(bloc.runs, 1);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
+  });
+
+  group('EventTransformers.debounceRestartable', () {
+    test('rapid bursts collapse to a single handler invocation after debounce', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(
+          transformer: EventTransformers.debounceRestartable(const Duration(milliseconds: 50)),
+        );
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run())
+          ..add(_Run());
+
+        async.elapse(const Duration(seconds: 1)); // past debounce window + handlerDelay
+
+        expect(states, [1]);
+        expect(bloc.runs, 1);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
+  });
+
+  group('EventTransformers.restart', () {
+    test('a new event cancels the in-flight handler so only the latest emits', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.restart());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run()); // cancels the prior handler before it emits.
+
+        async.elapse(const Duration(seconds: 1));
+
+        // Two handler invocations start, but only the latest reaches emit(): 1.
+        expect(states, [1]);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
+  });
+
+  group('EventTransformers.queue', () {
+    test('events are processed strictly one-at-a-time in arrival order', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.queue());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run())
+          ..add(_Run());
+
+        async.elapse(const Duration(seconds: 1)); // 3 × handlerDelay, sequential
+
+        // None dropped, none cancelled — three emissions in order.
+        expect(states, [1, 2, 3]);
+        expect(bloc.runs, 3);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `fvm flutter test test/shared/utils/event_transformers_test.dart -r compact 2>&1 | tail -4`
+Expected: `All tests passed!` (4 tests).
+
+If a test does not see the expected emissions, the bloc's event ingestion needs a
+microtask turn before/after elapsing: add `async.flushMicrotasks();` immediately
+after the `bloc.add(...)` calls and again after `async.elapse(...)`. Do NOT
+re-introduce real-time waits. The assertions above are correct (they match the
+current passing tests), so tune only the elapse/flush sequence until green.
+
+- [ ] **Step 3: Confirm no wall-clock dependence**
+
+Run: `fvm flutter test test/shared/utils/event_transformers_test.dart` and confirm
+it completes in well under a second of test time (no `wait:` remains).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/shared/utils/event_transformers_test.dart
+git commit -m "test: drive event transformer tests with fakeAsync (deterministic) (#148)"
+```
+
+---
+
+## Task 2: `dynamic_form_bloc_test.dart` → drop real-time waits
+
+**Files:**
+- Modify: `test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart`
+
+The file has 13 `wait: const Duration(milliseconds: 300)` lines and 6
+`await Future<void>.delayed(const Duration(milliseconds: 100|150))` sequencing
+delays (around lines 363, 383, 405, 424, 445, 522 — line numbers drift as edits
+are made, so locate by content).
+
+- [ ] **Step 1: Remove every `wait:` that only covers mocked async**
+
+Delete each `wait: const Duration(milliseconds: 300),` line in the `blocTest`
+cases. (These wait for a mocked Dio response that resolves on a microtask;
+`blocTest` already awaits the bloc's state stream.)
+
+- [ ] **Step 2: Replace each sequencing `Future.delayed` with a state wait**
+
+Every sequencing delay is "wait for the Load/LoadBundle to finish before adding
+the next event." Replace the delay with a wait on the loaded state. Pattern
+(applies to all 6 sites — both `DynamicFormLoadEvent` and `DynamicFormLoadBundleEvent`
+emit `DynamicFormLoaded`):
+
+Before:
+```dart
+act: (bloc) async {
+  bloc.add(const DynamicFormLoadEvent('no_action_form'));
+  await Future<void>.delayed(const Duration(milliseconds: 100));
+  bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
+},
+```
+After:
+```dart
+act: (bloc) async {
+  bloc.add(const DynamicFormLoadEvent('no_action_form'));
+  await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
+  bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
+},
+```
+
+For sites that re-stub between load and the next event (lines ~383, ~405, ~424,
+~522), keep the `stub.stub...` call in the same position (after the `firstWhere`,
+before the next `add`). For the LoadBundle site (~522), the predicate is the same
+`(s) => s is DynamicFormLoaded`.
+
+- [ ] **Step 3: Run the file**
+
+Run: `fvm flutter test test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart -r compact 2>&1 | tail -5`
+Expected: `All tests passed!` (same test count as before).
+
+If any test now misses a trailing emission (e.g. a Submit state emitted after
+`act` returns), add a single `await bloc.stream.firstWhere((s) => s is <ExpectedFinalState>);`
+at the end of that `act` rather than a timed `wait:`. If a transformer needs one
+event-loop turn, use `await Future<void>.delayed(Duration.zero)` (a microtask hop,
+not wall-clock). Never restore a millisecond `wait:`.
+
+- [ ] **Step 4: Confirm no real-time waits remain**
+
+Run: `grep -nE "wait: const Duration\(milliseconds: [1-9]|Future<void>.delayed\(const Duration\(milliseconds: [1-9]" test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart`
+Expected: no output (only `Duration.zero` delays, if any, are acceptable).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
+git commit -m "test: drop real-time waits in dynamic form bloc tests; sequence on state (#148)"
+```
+
+---
+
+## Task 3: fixed instant for arbitrary-value fixtures
+
+**Files:**
+- Modify: `test/mocks/fake_data.dart`
+- Modify: `test/features/users/presentation/pages/list_user_screen_test.dart`
+
+- [ ] **Step 1: Add the shared constant to `fake_data.dart`**
+
+Add near the top of `test/mocks/fake_data.dart` (after the existing
+`final DateTime createdDate = DateTime(2024, 1, 1);`):
+
+```dart
+/// Fixed instant for fixtures whose timestamp value is arbitrary. Use this
+/// instead of DateTime.now() so a fixture never depends on wall-clock time.
+final DateTime kTestInstant = DateTime.utc(2024, 1, 1, 12);
+```
+
+- [ ] **Step 2: Replace `DateTime.now()` in the list-user fixture**
+
+In `test/features/users/presentation/pages/list_user_screen_test.dart`, replace
+`createdDate: DateTime.now()` and `lastModifiedDate: DateTime.now()` (around lines
+134/136) with `createdDate: kTestInstant` and `lastModifiedDate: kTestInstant`.
+Ensure the file imports `kTestInstant` — add `import '../../../../mocks/fake_data.dart';`
+if not already present (verify the relative depth: the file is at
+`test/features/users/presentation/pages/`, so `../../../../mocks/fake_data.dart`).
+
+- [ ] **Step 3: Audit the remaining `DateTime.now()` sites (no code change)**
+
+Run: `grep -rn "DateTime.now()" test/ --include='*.dart'`
+Confirm each remaining site is one of: relative expiry (`.add`/`.subtract`),
+a `before`/`after` range-bracket assertion, or `idle_timeout_observer_test`
+(fakeAsync). These are correct — leave them. The only conversions are the
+list-user fixtures from Step 2.
+
+- [ ] **Step 4: Run affected file**
+
+Run: `fvm flutter test test/features/users/presentation/pages/list_user_screen_test.dart -r compact 2>&1 | tail -3`
+Expected: `All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/mocks/fake_data.dart test/features/users/presentation/pages/list_user_screen_test.dart
+git commit -m "test: use a fixed instant for arbitrary-value fixtures (#148)"
+```
+
+---
+
+## Task 4: document the determinism conventions
+
+**Files:**
+- Modify: `docs/testing-architecture.md` (the "Determinism & known gaps" section)
+
+- [ ] **Step 1: Update the section**
+
+Replace the existing "Determinism & known gaps" bullet list content with:
+
+```markdown
+- **Time:** use `fakeAsync` for time-based logic (timers, debounce, timeouts).
+  `event_transformers_test.dart` is the reference — it drives the bloc inside
+  `fakeAsync` and advances virtual time with `async.elapse(...)`, with no
+  wall-clock dependency. `idle_timeout_observer_test.dart` uses the same approach.
+- **Mocked async:** do not use real-time `blocTest(wait:)` to "let a mock settle"
+  — `blocTest` already awaits the bloc's state stream. Sequence dependent events
+  with `await bloc.stream.firstWhere((s) => s is <State>)`, not a millisecond delay.
+- **Fixtures:** use the fixed `kTestInstant` (`test/mocks/fake_data.dart`) for any
+  fixture timestamp whose exact value no assertion depends on — never `DateTime.now()`.
+- **Goldens:** there are no golden/visual-regression tests yet (issue #135). The
+  bootstrap is where font loading will be wired when they land.
+- **Tags/presets:** there is no `dart_test.yaml` tagging scheme yet (issue #154).
+```
+
+(This removes the prior #148 "still uses real-time `blocTest(wait:)`" item.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/testing-architecture.md
+git commit -m "docs: document fakeAsync + no-real-wait + fixed-instant conventions (#148)"
+```
+
+---
+
+## Task 5: full verification + measurement
+
+- [ ] **Step 1: Full suite**
+
+Run: `fvm flutter test --concurrency=4 --reporter=compact 2>&1 | tail -3`
+Expected: `All tests passed!` (1565, unchanged count).
+
+- [ ] **Step 2: Analyze + format**
+
+Run: `fvm dart analyze` → `No issues found!`
+Run: `fvm dart format . --line-length=120 --set-exit-if-changed` → exit 0 (if it reformats, `git add -A`).
+
+- [ ] **Step 3: Measure the targeted files before/after (sanity)**
+
+Run: `/usr/bin/time -v fvm flutter test test/shared/utils/event_transformers_test.dart test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart -r compact 2>&1 | grep -E "Elapsed|All tests"`
+Expected: noticeably lower than the ~7.3s baseline for these two files.
+
+- [ ] **Step 4: Commit any formatting**
+
+```bash
+git add -A && git commit -m "test: deterministic time finalize (#148)" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Part A → Task 1; Part B → Task 2; Part C → Task 3; Part D →
+  Task 4; verification → Task 5. All covered.
+- **No real-wait regressions:** Tasks 1 & 2 each end with a grep/behavioral check
+  forbidding millisecond waits; fallback guidance uses `Duration.zero`/state
+  waits, never timed waits.
+- **Type consistency:** `DynamicFormLoaded`, `DynamicFormSubmitEvent`,
+  `DynamicFormLoadEvent`, `DynamicFormLoadBundleEvent`, `_CounterBloc`,
+  `EventTransformers.{dropConcurrent,debounceRestartable,restart,queue}`,
+  `kTestInstant` used consistently.
+- **No placeholders:** full converted source for Task 1; concrete before/after for
+  Task 2; exact constant + edits for Task 3.

--- a/docs/superpowers/specs/2026-06-03-deterministic-test-time-design.md
+++ b/docs/superpowers/specs/2026-06-03-deterministic-test-time-design.md
@@ -1,0 +1,143 @@
+# Deterministic Test Time — Design (#148)
+
+**Date:** 2026-06-03
+**Issue:** #148 (test-infrastructure audit follow-up)
+**Status:** Approved (design)
+
+## Problem & re-scoping
+
+The audit issue (#148) flagged "20 real-time `blocTest(wait:)` + 51 `DateTime.now()`"
+as flakiness/slowness debt. Investigation refined the picture:
+
+- **`event_transformers_test.dart` (4 tests)** genuinely depend on real time: a
+  debounce window (Timer) plus an 80 ms `Future.delayed` handler, asserted via
+  `blocTest(wait: 250–350ms)`. These are the legitimate `fakeAsync` candidates.
+- **`dynamic_form_bloc_test.dart` (13 `wait:` + 6 `Future.delayed`)** do NOT
+  debounce — the bloc uses `restart()` / `dropConcurrent()` transformers, which
+  add no delay. The waits exist to let a **mocked** Dio response (resolving on a
+  microtask, i.e. effectively instantly) settle. `blocTest` already awaits the
+  bloc's state stream, so these real-time waits are wasted (~10 × 300 ms ≈ 3 s of
+  pure idle, plus 6 × 100–150 ms sequencing delays).
+- **`DateTime.now()` (≈40 sites)** are mostly legitimate: relative expiry
+  (`.add` / `.subtract`), `before`/`after` range-bracket assertions, and
+  `idle_timeout_observer_test` (already `fakeAsync`). Only a couple of fixtures
+  use `DateTime.now()` for a value no assertion depends on
+  (`list_user_screen_test`), introducing pointless non-determinism.
+
+## Goals
+
+- Time-dependent logic asserts on **virtual** time (`fakeAsync`), not wall-clock.
+- Tests that wait only for **mocked async** rely on `blocTest`'s stream awaiting,
+  not arbitrary real-time `wait:`.
+- Arbitrary-value fixtures use a **fixed instant**, not `DateTime.now()`.
+- No assertion behavior changes; full suite stays green; suite gets faster and
+  deterministic.
+
+## Non-goals (YAGNI)
+
+- No `package:clock` seam in **production** code — this is a test-only change.
+- Do **not** touch correct relative-time / range-bracket tests (cache expiry,
+  `before`/`after`, `idle_timeout`). Converting them adds risk for no value.
+
+## Part A — `event_transformers_test.dart` → `fakeAsync`
+
+Convert the 4 `blocTest(wait:)` cases to plain `test()` wrapped in `fakeAsync`,
+driving the existing `_CounterBloc` manually. Pattern:
+
+```dart
+test('rapid bursts collapse to a single handler invocation after debounce', () {
+  fakeAsync((async) {
+    final bloc = _CounterBloc(
+      transformer: EventTransformers.debounceRestartable(const Duration(milliseconds: 50)),
+    );
+    final states = <int>[];
+    final sub = bloc.stream.listen(states.add);
+
+    bloc..add(_Run())..add(_Run())..add(_Run());
+
+    async.elapse(const Duration(milliseconds: 50)); // debounce window fires
+    async.elapse(_CounterBloc.handlerDelay);         // 80ms handler completes
+    async.flushMicrotasks();
+
+    expect(states, [1]);
+    expect(bloc.runs, 1);
+
+    sub.cancel();
+    bloc.close();
+  });
+});
+```
+
+- Keep the `_CounterBloc` scaffold and `handlerDelay` as-is.
+- Each of the 4 groups (`dropConcurrent`, `debounceRestartable`, `restart`,
+  `queue`) gets the same treatment with its own elapse amounts (e.g. `queue`
+  elapses `3 × handlerDelay`).
+- `async.elapse` advances both Timers (debounce) and `Future.delayed` (handler);
+  interleave with `flushMicrotasks()` so bloc emissions settle.
+
+This is the Flutter-standard way to test time-based stream logic and removes the
+real-time `wait:`.
+
+## Part B — `dynamic_form_bloc_test.dart` → drop wasted waits
+
+For each `blocTest` whose `wait:` only covers a mocked async response:
+
+1. Remove the `wait: const Duration(milliseconds: 300)` line.
+2. For act callbacks that sequence Load → Submit via
+   `await Future<void>.delayed(const Duration(milliseconds: 100/150))`, replace
+   the delay with a deterministic wait on state:
+   ```dart
+   act: (bloc) async {
+     bloc.add(const DynamicFormLoadEvent('no_action_form'));
+     await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
+     bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
+   },
+   ```
+3. **Verification gate:** run the file after each change. If `blocTest` misses a
+   late emission without `wait:`, do NOT restore a guessed duration — instead use
+   the smallest deterministic mechanism (an explicit `await bloc.stream.firstWhere(...)`
+   in `act`, or `bloc_test`'s built-in stream settling). Only if a transformer
+   genuinely needs an event-loop turn, use `await Future<void>.delayed(Duration.zero)`
+   (a microtask hop, not wall-clock time).
+
+Net effect: removes ~3 s of idle waiting and makes ordering explicit rather than
+timing-dependent.
+
+## Part C — fixed instant for arbitrary fixtures
+
+- Add a shared constant to `test/mocks/fake_data.dart`:
+  ```dart
+  /// Fixed instant for fixtures whose timestamp value is arbitrary — keeps
+  /// tests deterministic (never use DateTime.now() for a value no assertion
+  /// depends on).
+  final DateTime kTestInstant = DateTime.utc(2024, 1, 1, 12);
+  ```
+- Replace `DateTime.now()` with `kTestInstant` in fixtures where the value is
+  arbitrary: `test/features/users/presentation/pages/list_user_screen_test.dart`
+  (`createdDate`, `lastModifiedDate`).
+- Audit the remaining `DateTime.now()` sites; leave the legitimately relative /
+  range-bracket ones untouched. Where a relative-time test reads as ambiguous,
+  add a one-line `// intentionally relative to now` comment instead of changing it.
+
+## Part D — documentation
+
+Update the "Determinism & known gaps" section of `docs/testing-architecture.md`:
+- `fakeAsync` for time-based logic (link `event_transformers_test` as the example).
+- No real-time `wait:` for mocked async — rely on `blocTest` stream awaiting.
+- Fixed instants (`kTestInstant`) for arbitrary-value fixtures.
+- Remove #148 from the "not-yet-done" list once complete.
+
+## Verification
+
+- `dart format --set-exit-if-changed` clean; `dart analyze` clean.
+- Full `flutter test` green (1565), no count change.
+- Record wall-clock before/after for `event_transformers_test` +
+  `dynamic_form_bloc_test` (expect a measurable drop).
+
+## Acceptance
+
+- No `blocTest(wait:)` with real durations remain for debounce or mocked-async
+  settling (or each remaining one has a documented justification).
+- `event_transformers_test` runs under `fakeAsync` with no wall-clock dependency.
+- No `DateTime.now()` in arbitrary-value fixtures.
+- Determinism conventions documented; suite green and faster.

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -265,13 +265,18 @@ All shared doubles live in `test/mocks/`:
 
 ## Determinism & known gaps
 
-- **Time:** prefer `fake_async` for timer/timeout logic (see
-  `idle_timeout_observer_test.dart`). Some debounce tests still use real-time
-  `blocTest(wait:)` — tracked for migration in issue #148.
+- **Time:** use `fakeAsync` for time-based logic (timers, debounce, timeouts).
+  `event_transformers_test.dart` is the reference — it drives the bloc inside
+  `fakeAsync` and advances virtual time with `async.elapse(...)`, with no
+  wall-clock dependency. `idle_timeout_observer_test.dart` uses the same approach.
+- **Mocked async:** do not use real-time `blocTest(wait:)` to "let a mock settle"
+  — `blocTest` already awaits the bloc's state stream. Sequence dependent events
+  with `await bloc.stream.firstWhere((s) => s is <State>)`, not a millisecond delay.
+- **Fixtures:** use the fixed `kTestInstant` (`test/mocks/fake_data.dart`) for any
+  fixture timestamp whose exact value no assertion depends on — never `DateTime.now()`.
 - **Goldens:** there are no golden/visual-regression tests yet (issue #135). The
-  bootstrap is the place font loading will be wired when they land.
-- **Tags/presets:** there is no `dart_test.yaml` tagging scheme yet (issue
-  #154).
+  bootstrap is where font loading will be wired when they land.
+- **Tags/presets:** there is no `dart_test.yaml` tagging scheme yet (issue #154).
 
 These are documented so newcomers know what is intentional vs. not-yet-done.
 

--- a/test/features/users/application/user_list_bloc_test.dart
+++ b/test/features/users/application/user_list_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_bloc_advance/core/errors/app_error.dart';
 import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/users/application/usecases/delete_user_usecase.dart';
@@ -65,9 +66,6 @@ void main() {
     bloc.close();
   });
 
-  // UserListBloc applies a 300ms debounce to UserListSearch.
-  const debounceWait = Duration(milliseconds: 400);
-
   group('UserListState', () {
     test('UserListInitial equality and props', () {
       expect(const UserListInitial(), const UserListInitial());
@@ -117,36 +115,67 @@ void main() {
         UserEntity(id: '2', firstName: 'Test2', lastName: 'User2'),
       ];
 
-      blocTest<UserListBloc, UserListState>(
-        'emits [loading, loaded] when search succeeds',
-        setUp: () => repository.listResult = users,
-        build: () => bloc,
-        act: (b) => b.add(const UserListSearch(authorities: 'ROLE_USER')),
-        wait: debounceWait,
-        expect: () => [const UserListLoading(), const UserListLoaded(users: users)],
-      );
+      test('emits [loading, loaded] when search succeeds', () {
+        fakeAsync((async) {
+          repository.listResult = users;
+          final searchBloc = UserListBloc(
+            searchUsersUseCase: SearchUsersUseCase(repository),
+            deleteUserUseCase: DeleteUserUseCase(repository),
+          );
+          final states = <UserListState>[];
+          final sub = searchBloc.stream.listen(states.add);
 
-      blocTest<UserListBloc, UserListState>(
-        'emits [loading, failure] when search fails',
-        setUp: () => repository.failure = const UnknownError('Search failed'),
-        build: () => bloc,
-        act: (b) => b.add(const UserListSearch(authorities: 'ROLE_USER')),
-        wait: debounceWait,
-        expect: () => [const UserListLoading(), const UserListFailure(error: 'Search failed')],
-      );
+          searchBloc.add(const UserListSearch(authorities: 'ROLE_USER'));
+          async.elapse(const Duration(seconds: 1));
 
-      blocTest<UserListBloc, UserListState>(
-        'rapid bursts collapse to a single emission pair (debounceRestartable)',
-        setUp: () => repository.listResult = users,
-        build: () => bloc,
-        act: (b) {
-          b.add(const UserListSearch(authorities: 'ROLE_A'));
-          b.add(const UserListSearch(authorities: 'ROLE_B'));
-          b.add(const UserListSearch(authorities: 'ROLE_USER'));
-        },
-        wait: debounceWait,
-        expect: () => [const UserListLoading(), const UserListLoaded(users: users)],
-      );
+          expect(states, [const UserListLoading(), const UserListLoaded(users: users)]);
+
+          sub.cancel();
+          searchBloc.close();
+        });
+      });
+
+      test('emits [loading, failure] when search fails', () {
+        fakeAsync((async) {
+          repository.failure = const UnknownError('Search failed');
+          final searchBloc = UserListBloc(
+            searchUsersUseCase: SearchUsersUseCase(repository),
+            deleteUserUseCase: DeleteUserUseCase(repository),
+          );
+          final states = <UserListState>[];
+          final sub = searchBloc.stream.listen(states.add);
+
+          searchBloc.add(const UserListSearch(authorities: 'ROLE_USER'));
+          async.elapse(const Duration(seconds: 1));
+
+          expect(states, [const UserListLoading(), const UserListFailure(error: 'Search failed')]);
+
+          sub.cancel();
+          searchBloc.close();
+        });
+      });
+
+      test('rapid bursts collapse to a single emission pair (debounceRestartable)', () {
+        fakeAsync((async) {
+          repository.listResult = users;
+          final searchBloc = UserListBloc(
+            searchUsersUseCase: SearchUsersUseCase(repository),
+            deleteUserUseCase: DeleteUserUseCase(repository),
+          );
+          final states = <UserListState>[];
+          final sub = searchBloc.stream.listen(states.add);
+
+          searchBloc.add(const UserListSearch(authorities: 'ROLE_A'));
+          searchBloc.add(const UserListSearch(authorities: 'ROLE_B'));
+          searchBloc.add(const UserListSearch(authorities: 'ROLE_USER'));
+          async.elapse(const Duration(seconds: 1));
+
+          expect(states, [const UserListLoading(), const UserListLoaded(users: users)]);
+
+          sub.cancel();
+          searchBloc.close();
+        });
+      });
     });
 
     group('UserListDelete', () {

--- a/test/features/users/presentation/pages/list_user_screen_test.dart
+++ b/test/features/users/presentation/pages/list_user_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../../../../mocks/fake_data.dart';
 import '../../../../mocks/mock_classes.dart';
 
 void main() {
@@ -131,9 +132,9 @@ void main() {
           activated: true,
           langKey: 'en',
           createdBy: 'system',
-          createdDate: DateTime.now(),
+          createdDate: kTestInstant,
           lastModifiedBy: "system",
-          lastModifiedDate: DateTime.now(),
+          lastModifiedDate: kTestInstant,
           authorities: const ['ROLE_ADMIN'],
         ),
       ];

--- a/test/features/users/presentation/pages/user_editor_screen_test.dart
+++ b/test/features/users/presentation/pages/user_editor_screen_test.dart
@@ -139,7 +139,7 @@ void main() {
       when(() => mockUserBloc.add(any())).thenAnswer((invocation) async {
         if (invocation.positionalArguments[0] is UserEditorFetch) {
           userStateController.add(const UserEditorLoading());
-          await Future.delayed(const Duration(milliseconds: 100));
+          await Future<void>.delayed(Duration.zero);
           userStateController.add(UserEditorLoaded(data: mockUser));
         }
       });

--- a/test/mocks/fake_data.dart
+++ b/test/mocks/fake_data.dart
@@ -7,6 +7,10 @@ import 'package:flutter_bloc_advance/features/auth/data/models/user_jwt.dart';
 
 final DateTime createdDate = DateTime(2024, 1, 1);
 
+/// Fixed instant for fixtures whose timestamp value is arbitrary. Use this
+/// instead of DateTime.now() so a fixture never depends on wall-clock time.
+final DateTime kTestInstant = DateTime.utc(2024, 1, 1, 12);
+
 /// User fake data with full payload
 final mockUserFullPayload = User(
   id: '1',

--- a/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
+++ b/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
@@ -370,6 +370,7 @@ void main() {
           bloc.add(const DynamicFormLoadEvent('no_action_form'));
           await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
+          await bloc.stream.firstWhere((s) => s is DynamicFormSubmitted);
         },
         expect: () => [
           // Load events
@@ -451,6 +452,7 @@ void main() {
           bloc.add(const DynamicFormLoadEvent('test_form'));
           await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           bloc.add(const DynamicFormResetEvent());
+          await bloc.stream.firstWhere((s) => s is DynamicFormInitial);
         },
         expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormLoaded>(), isA<DynamicFormInitial>()],
       );

--- a/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
+++ b/test/shared/dynamic_forms/application/dynamic_form_bloc_test.dart
@@ -304,8 +304,10 @@ void main() {
         'emits [loading, loaded] when API returns valid form schema',
         setUp: () => stub.stubSuccess(data: _validFormSchemaJson),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadEvent('test_form'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
+        },
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>()
@@ -319,8 +321,10 @@ void main() {
         'emits [loading, failure] when API returns connection error',
         setUp: () => stub.stubDioError(DioExceptionType.connectionError, message: 'Connection failed'),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadEvent('test_form'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
+        },
         expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormFailure>().having((s) => s.error, 'error', isNotNull)],
       );
 
@@ -328,8 +332,10 @@ void main() {
         'emits [loading, failure] when API returns 404',
         setUp: () => stub.stubDioError(DioExceptionType.badResponse, statusCode: 404, data: 'Not found'),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadEvent('unknown')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadEvent('unknown'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
+        },
         expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormFailure>().having((s) => s.error, 'error', isNotNull)],
       );
 
@@ -337,8 +343,10 @@ void main() {
         'emits [loading, failure] when API returns timeout',
         setUp: () => stub.stubDioError(DioExceptionType.connectionTimeout, message: 'Timeout'),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadEvent('test_form')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadEvent('test_form'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
+        },
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormFailure>().having((s) => s.error, 'error', contains('Timeout')),
@@ -360,10 +368,9 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadEvent('no_action_form'));
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
         },
-        wait: const Duration(milliseconds: 300),
         expect: () => [
           // Load events
           isA<DynamicFormLoading>(),
@@ -380,12 +387,12 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadEvent('test_form'));
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           // After loading, stub the submit response
           stub.stubSuccess(data: '{"id": "lead_1"}');
           bloc.add(const DynamicFormSubmitEvent({'name': 'John', 'email': 'john@test.com'}));
+          await bloc.stream.firstWhere((s) => s is DynamicFormSubmitted);
         },
-        wait: const Duration(milliseconds: 300),
         expect: () => [
           // Load events
           isA<DynamicFormLoading>(),
@@ -402,11 +409,11 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadEvent('put_form'));
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           stub.stubSuccess(data: '{"updated": true}');
           bloc.add(const DynamicFormSubmitEvent({'name': 'Jane'}));
+          await bloc.stream.firstWhere((s) => s is DynamicFormSubmitted);
         },
-        wait: const Duration(milliseconds: 300),
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>(),
@@ -421,11 +428,11 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadEvent('test_form'));
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           stub.stubDioError(DioExceptionType.badResponse, statusCode: 500, data: 'Internal Server Error');
           bloc.add(const DynamicFormSubmitEvent({'name': 'John'}));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
         },
-        wait: const Duration(milliseconds: 300),
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>(),
@@ -442,10 +449,9 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadEvent('test_form'));
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           bloc.add(const DynamicFormResetEvent());
         },
-        wait: const Duration(milliseconds: 300),
         expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormLoaded>(), isA<DynamicFormInitial>()],
       );
 
@@ -467,8 +473,10 @@ void main() {
           }),
         ),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadBundleEvent('/admin/users/1/extended')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadBundleEvent('/admin/users/1/extended'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
+        },
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>().having((s) => s.schema.id, 'schema.id', 'test_form').having(
@@ -483,8 +491,10 @@ void main() {
         'emits [loading, failure] when API returns connection timeout',
         setUp: () => stub.stubDioError(DioExceptionType.connectionTimeout, message: 'Timeout'),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadBundleEvent('/admin/users/1/extended')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadBundleEvent('/admin/users/1/extended'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
+        },
         expect: () => [isA<DynamicFormLoading>(), isA<DynamicFormFailure>()],
       );
 
@@ -497,8 +507,10 @@ void main() {
           }),
         ),
         build: () => buildBloc(),
-        act: (bloc) => bloc.add(const DynamicFormLoadBundleEvent('/admin/users/extended', pathParams: 'user-1')),
-        wait: const Duration(milliseconds: 300),
+        act: (bloc) async {
+          bloc.add(const DynamicFormLoadBundleEvent('/admin/users/extended', pathParams: 'user-1'));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
+        },
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>().having((s) => s.submitPathParams, 'submitPathParams', 'user-1'),
@@ -519,12 +531,12 @@ void main() {
         build: () => buildBloc(),
         act: (bloc) async {
           bloc.add(const DynamicFormLoadBundleEvent('/admin/users/extended', pathParams: 'user-1'));
-          await Future<void>.delayed(const Duration(milliseconds: 150));
+          await bloc.stream.firstWhere((s) => s is DynamicFormLoaded);
           // 2) First submit fails — bloc must emit Failure(submitPathParams: 'user-1').
           stub.stubDioError(DioExceptionType.connectionTimeout, message: 'Timeout');
           bloc.add(const DynamicFormSubmitEvent({'name': 'Alice'}));
+          await bloc.stream.firstWhere((s) => s is DynamicFormFailure);
         },
-        wait: const Duration(milliseconds: 500),
         expect: () => [
           isA<DynamicFormLoading>(),
           isA<DynamicFormLoaded>().having((s) => s.submitPathParams, 'submitPathParams', 'user-1'),

--- a/test/shared/utils/event_transformers_test.dart
+++ b/test/shared/utils/event_transformers_test.dart
@@ -1,4 +1,4 @@
-import 'package:bloc_test/bloc_test.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/shared/utils/event_transformers.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -27,62 +27,91 @@ class _CounterBloc extends Bloc<_Event, int> {
 
 void main() {
   group('EventTransformers.dropConcurrent', () {
-    blocTest<_CounterBloc, int>(
-      'a second event added while the first handler is running is dropped',
-      build: () => _CounterBloc(transformer: EventTransformers.dropConcurrent()),
-      act: (bloc) {
-        bloc.add(_Run());
-        bloc.add(_Run()); // dropped: previous handler is still running.
-      },
-      wait: const Duration(milliseconds: 250),
-      expect: () => [1],
-      verify: (bloc) => expect(bloc.runs, 1),
-    );
+    test('a second event added while the first handler is running is dropped', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.dropConcurrent());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run()); // dropped: previous handler is still running.
+
+        async.elapse(const Duration(seconds: 1));
+
+        expect(states, [1]);
+        expect(bloc.runs, 1);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
   });
 
   group('EventTransformers.debounceRestartable', () {
-    blocTest<_CounterBloc, int>(
-      'rapid bursts collapse to a single handler invocation after debounce',
-      build: () => _CounterBloc(transformer: EventTransformers.debounceRestartable(const Duration(milliseconds: 50))),
-      act: (bloc) {
-        bloc.add(_Run());
-        bloc.add(_Run());
-        bloc.add(_Run());
-      },
-      wait: const Duration(milliseconds: 300),
-      expect: () => [1],
-      verify: (bloc) => expect(bloc.runs, 1),
-    );
+    test('rapid bursts collapse to a single handler invocation after debounce', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.debounceRestartable(const Duration(milliseconds: 50)));
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run())
+          ..add(_Run());
+
+        async.elapse(const Duration(seconds: 1));
+
+        expect(states, [1]);
+        expect(bloc.runs, 1);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
   });
 
   group('EventTransformers.restart', () {
-    blocTest<_CounterBloc, int>(
-      'a new event cancels the in-flight handler so only the latest emits',
-      build: () => _CounterBloc(transformer: EventTransformers.restart()),
-      act: (bloc) {
-        bloc.add(_Run());
-        bloc.add(_Run()); // cancels the prior handler before it emits.
-      },
-      wait: const Duration(milliseconds: 250),
-      // Two handler invocations start, but only the latest reaches emit(): 1.
-      expect: () => [1],
-    );
+    test('a new event cancels the in-flight handler so only the latest emits', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.restart());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run()); // cancels the prior handler before it emits.
+
+        async.elapse(const Duration(seconds: 1));
+
+        expect(states, [1]);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
   });
 
   group('EventTransformers.queue', () {
-    blocTest<_CounterBloc, int>(
-      'events are processed strictly one-at-a-time in arrival order',
-      build: () => _CounterBloc(transformer: EventTransformers.queue()),
-      act: (bloc) {
-        bloc.add(_Run());
-        bloc.add(_Run());
-        bloc.add(_Run());
-      },
-      // 3 handlers × 80ms each, run sequentially, so wait > 240ms.
-      wait: const Duration(milliseconds: 350),
-      // None dropped, none cancelled — three emissions in order.
-      expect: () => [1, 2, 3],
-      verify: (bloc) => expect(bloc.runs, 3),
-    );
+    test('events are processed strictly one-at-a-time in arrival order', () {
+      fakeAsync((async) {
+        final bloc = _CounterBloc(transformer: EventTransformers.queue());
+        final states = <int>[];
+        final sub = bloc.stream.listen(states.add);
+
+        bloc
+          ..add(_Run())
+          ..add(_Run())
+          ..add(_Run());
+
+        async.elapse(const Duration(seconds: 1));
+
+        expect(states, [1, 2, 3]);
+        expect(bloc.runs, 3);
+
+        sub.cancel();
+        bloc.close();
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Closes #148. Removes wall-clock dependence from the test suite.

Investigation refined the issue's framing (documented in the design spec): `dynamic_form_bloc` uses `restart()`/`dropConcurrent()` — **no debounce** — so its `wait:`s only covered mocked async settling, and most `DateTime.now()` sites are legitimately relative/range-bracket. The change is surgical.

### Changes
- **`event_transformers_test.dart`** — 4 `blocTest(wait:)` → plain `test()` inside `fakeAsync`, driving `_CounterBloc` and advancing virtual time with `async.elapse(...)`. No wall-clock dependency.
- **`dynamic_form_bloc_test.dart`** — removed **13** real-time `wait: 300ms` + **6** `Future.delayed` sequencing delays; ordering is now explicit via `await bloc.stream.firstWhere((s) => s is <State>)`. Assertion lists unchanged.
- **`fake_data.dart`** — added `kTestInstant`; `list_user_screen_test.dart` uses it instead of `DateTime.now()`. Legitimately relative/time-bracket tests left untouched (audited).
- **`docs/testing-architecture.md`** — determinism conventions updated; #148 removed from "known gaps".

### Results
- Target files **7.3s → 2.2s** (real waiting removed; remainder is fixed startup).
- Full suite **1565 green** (count unchanged), ~31.6s.
- Zero real-time `wait:`/`Future.delayed(ms)` remain in the two files (grep-verified).
- `dart analyze` clean, `dart format` clean.
- Final code review passed (one minor "await the terminal state" follow-up applied).

### Process
Brainstorm → spec (`docs/superpowers/specs/2026-06-03-deterministic-test-time-design.md`) → plan (`docs/superpowers/plans/2026-06-03-deterministic-test-time.md`) → subagent-driven execution (5 tasks) → final review.

## Test Plan
- [x] `flutter test` → 1565 passed
- [x] `dart analyze` / `dart format` clean
- [x] no real-time waits remain (grep)
- [x] assertion lists preserved (review-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)