### PR TITLE
test: dart_test.yaml + test tags (closes #154)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 15
-        run: flutter test --coverage --timeout=30s --concurrency=4 --reporter=compact
+        run: flutter test --coverage --concurrency=4 --reporter=compact
 
       - name: Check coverage threshold
         # Excludes generated/bootstrap code from the metric (see scripts/check_coverage.sh, issue #149).

--- a/README.md
+++ b/README.md
@@ -384,7 +384,14 @@ fvm flutter test --coverage
 
 # Useful for debugging order-dependent issues
 fvm flutter test --concurrency=1 --test-randomize-ordering-seed=random
+
+# Run only widget tests / everything except widget tests (fast unit loop)
+fvm flutter test --tags widget
+fvm flutter test --exclude-tags widget
 ```
+
+Tags are declared in `dart_test.yaml` (`widget`, plus `golden`/`integration`
+reserved for upcoming visual-regression and end-to-end suites).
 
 See [`docs/testing-architecture.md`](docs/testing-architecture.md) for the test
 structure, global bootstrap, and how to write tests for each layer.

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,19 @@
+# Test configuration (package:test / flutter test).
+#
+# All tags used with `flutter test --tags` / `--exclude-tags` must be declared
+# here, otherwise the runner warns about unrecognized tags. Declaring a tag
+# needs no body.
+tags:
+  # Widget tests (use `testWidgets`) — need a binding + pump; heavier than pure
+  # unit tests. Applied via a file-level `@Tags(['widget'])` annotation.
+  widget:
+  # Golden / visual-regression tests — platform-sensitive, run in isolation.
+  # Reserved for #135 (the alchemist golden package auto-applies this tag).
+  golden:
+  # On-device end-to-end tests. Reserved for #152.
+  integration:
+    timeout: 2x
+
+# Per-test timeout. package:test's default is 30s; this mirrors the previous CI
+# `--timeout=30s` flag so behavior is unchanged. Slow categories override via tag.
+timeout: 30s

--- a/docs/superpowers/plans/2026-06-03-dart-test-tags.md
+++ b/docs/superpowers/plans/2026-06-03-dart-test-tags.md
@@ -1,0 +1,265 @@
+# dart_test.yaml + Test Tags Implementation Plan (#154)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `dart_test.yaml` declaring a `widget`/`golden`/`integration` tag vocabulary (+ timeouts), tag the 29 widget-test files with `@Tags(['widget'])`, centralize the CI timeout, and document the run commands.
+
+**Architecture:** A single root `dart_test.yaml` declares tags so `flutter test --tags`/`--exclude-tags` work warning-free; the 29 `testWidgets` files get a file-level `@Tags(['widget'])` library annotation. `golden`/`integration` are declared but unused (reserved for #135/#152). Untagged files remain the default fast set.
+
+**Tech Stack:** Flutter 3.44.0, `flutter_test`, `dart_test.yaml` (package:test config), FVM. Run with `fvm flutter test`.
+
+---
+
+## Key facts
+
+- All tags used with `--tags`/`--exclude-tags` must be declared in `dart_test.yaml` or `flutter test` warns. Declaring needs no body.
+- `@Tags(['widget'])` is a **library annotation** — must be at the very top of the file, before imports, followed by `library;`.
+- All 29 target files confirmed to have no existing `library;`/`@Tags`/`part` directive, so placement is uniform.
+- `flutter test` honors `dart_test.yaml` `tags:`/`timeout:`, `--tags`, `--exclude-tags`.
+
+## File structure
+
+- Create `dart_test.yaml` (repo root) — Task 1.
+- Modify 29 `*_test.dart` files (add `@Tags(['widget']) library;`) — Task 2.
+- Modify `.github/workflows/build_and_test.yml` — Task 3.
+- Modify `README.md` + `docs/testing-architecture.md` — Task 4.
+
+---
+
+## Task 1: Create `dart_test.yaml`
+
+**Files:**
+- Create: `dart_test.yaml` (repo root)
+
+- [ ] **Step 1: Write `dart_test.yaml`**
+
+```yaml
+# Test configuration (package:test / flutter test).
+#
+# All tags used with `flutter test --tags` / `--exclude-tags` must be declared
+# here, otherwise the runner warns about unrecognized tags. Declaring a tag
+# needs no body.
+tags:
+  # Widget tests (use `testWidgets`) — need a binding + pump; heavier than pure
+  # unit tests. Applied via a file-level `@Tags(['widget'])` annotation.
+  widget:
+  # Golden / visual-regression tests — platform-sensitive, run in isolation.
+  # Reserved for #135 (the alchemist golden package auto-applies this tag).
+  golden:
+  # On-device end-to-end tests. Reserved for #152.
+  integration:
+    timeout: 2x
+
+# Per-test timeout. package:test's default is 30s; this mirrors the previous CI
+# `--timeout=30s` flag so behavior is unchanged. Slow categories override via tag.
+timeout: 30s
+```
+
+- [ ] **Step 2: Verify the runner accepts it (no unrecognized-tag warnings)**
+
+Run: `fvm flutter test test/core/result/result_test.dart -r compact 2>&1 | tail -5`
+Expected: `All tests passed!` with NO line containing "Unknown tag" / "unrecognized". (Running one tiny file is enough to prove the config parses.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dart_test.yaml
+git commit -m "test: add dart_test.yaml declaring widget/golden/integration tags (#154)"
+```
+
+---
+
+## Task 2: Tag the 29 widget-test files
+
+**Files (add `@Tags(['widget'])` + `library;` at the very top of each):**
+- test/app/connectivity/connectivity_banner_test.dart
+- test/app/dev_console/tabs/environment_tab_test.dart
+- test/app/dev_console/tabs/network_tab_test.dart
+- test/app/localization/localization_test.dart
+- test/app/router/app_router_factory_test.dart
+- test/app/router/app_router_strategy_test.dart
+- test/app/router/router_test.dart
+- test/app/shell/top_bar/breadcrumb_widget_test.dart
+- test/features/account/presentation/pages/account_screen_test.dart
+- test/features/auth/presentation/pages/change_password_screen_test.dart
+- test/features/auth/presentation/pages/forgot_password_screen_test.dart
+- test/features/auth/presentation/pages/register_screen_go_router_test.dart
+- test/features/auth/presentation/widgets/community_section_widget_test.dart
+- test/features/auth/presentation/widgets/login_otp_email_widget_test.dart
+- test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+- test/features/dashboard/presentation/pages/dashboard_page_test.dart
+- test/features/dashboard/presentation/pages/home_screen_test.dart
+- test/features/settings/presentation/pages/settings_screen_test.dart
+- test/features/users/presentation/pages/list_user_screen_test.dart
+- test/features/users/presentation/pages/user_editor_screen_test.dart
+- test/features/users/presentation/pages/user_extended_info_page_test.dart
+- test/main/app_test.dart
+- test/shared/design_system/theme/semantic_colors_test.dart
+- test/shared/design_system/tokens/padding_spacing_test.dart
+- test/shared/dynamic_forms/presentation/pages/dynamic_form_page_test.dart
+- test/shared/dynamic_forms/presentation/widgets/dynamic_form_renderer_test.dart
+- test/shared/widgets/responsive_form_widget_test.dart
+- test/shared/widgets/submit_button_widget_test.dart
+- test/shared/widgets/web_back_button_disabler_test.dart
+
+- [ ] **Step 1: Prepend the annotation to every file in the list**
+
+At the very top of each file (before the first `import`), insert these two lines followed by a blank line:
+
+```dart
+@Tags(['widget'])
+library;
+```
+
+So a file that currently starts with:
+```dart
+import 'package:flutter/material.dart';
+```
+becomes:
+```dart
+@Tags(['widget'])
+library;
+
+import 'package:flutter/material.dart';
+```
+
+Do not change anything else in the files.
+
+- [ ] **Step 2: Analyze (catches malformed annotation/library placement)**
+
+Run: `fvm dart analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: Verify the tag selects exactly these files**
+
+Run: `fvm flutter test --tags widget -r compact 2>&1 | tail -3`
+Expected: `All tests passed!` — and the run includes only widget files.
+
+Run: `fvm flutter test --tags widget -r expanded 2>&1 | grep -c "loading "` (optional sanity) — the number of suites loaded should be 29.
+
+- [ ] **Step 4: Verify exclusion works**
+
+Run: `fvm flutter test --exclude-tags widget -r compact 2>&1 | tail -3`
+Expected: `All tests passed!` (the ~108 unit/bloc files; no widget files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test: tag widget-test files with @Tags(['widget']) (#154)"
+```
+
+---
+
+## Task 3: Centralize the CI timeout
+
+**Files:**
+- Modify: `.github/workflows/build_and_test.yml`
+
+- [ ] **Step 1: Drop `--timeout=30s` from the test step**
+
+The timeout now lives in `dart_test.yaml`. Change the test command line:
+
+From:
+```yaml
+        run: flutter test --coverage --timeout=30s --concurrency=4 --reporter=compact
+```
+To:
+```yaml
+        run: flutter test --coverage --concurrency=4 --reporter=compact
+```
+
+(Leave the rest of the job — `timeout-minutes: 15`, coverage step — unchanged. `sonar_scanner.yml` is unchanged.)
+
+- [ ] **Step 2: Validate YAML structure**
+
+Run: `grep -n "flutter test --coverage" .github/workflows/build_and_test.yml`
+Expected: shows the line WITHOUT `--timeout=30s`, with `--concurrency=4 --reporter=compact` intact.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/build_and_test.yml
+git commit -m "ci: move per-test timeout into dart_test.yaml (#154)"
+```
+
+---
+
+## Task 4: Document the tags
+
+**Files:**
+- Modify: `README.md` (Test section)
+- Modify: `docs/testing-architecture.md` (Tags/presets bullet under Determinism & known gaps)
+
+- [ ] **Step 1: Add tag commands to README Test section**
+
+In `README.md`, find the `### Test` fenced block (the one with `fvm flutter test` commands) and add these lines inside the code block, after the existing commands:
+
+```shell
+# Run only widget tests / everything except widget tests (fast unit loop)
+fvm flutter test --tags widget
+fvm flutter test --exclude-tags widget
+```
+
+And add a sentence after the block:
+
+```markdown
+Tags are declared in `dart_test.yaml` (`widget`, plus `golden`/`integration`
+reserved for upcoming visual-regression and end-to-end suites).
+```
+
+- [ ] **Step 2: Update the Tags/presets bullet in `docs/testing-architecture.md`**
+
+Replace the existing bullet:
+```markdown
+- **Tags/presets:** there is no `dart_test.yaml` tagging scheme yet (issue #154).
+```
+with:
+```markdown
+- **Tags:** `dart_test.yaml` declares `widget` (applied to all `testWidgets`
+  files via `@Tags(['widget'])`), plus `golden` and `integration` reserved for
+  #135/#152. Slice the suite with `flutter test --tags widget` /
+  `--exclude-tags widget`. The per-test timeout (30s) lives in `dart_test.yaml`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/testing-architecture.md
+git commit -m "docs: document test tags + run commands (#154)"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: No-warning full run**
+
+Run: `fvm flutter test --concurrency=4 --reporter=compact 2>&1 | grep -iE "unknown tag|unrecognized" || echo "no tag warnings"`
+Expected: `no tag warnings`.
+
+- [ ] **Step 2: Full suite + analyze + format**
+
+Run: `fvm flutter test --concurrency=4 --reporter=compact 2>&1 | tail -2` → `All tests passed!` (1565).
+Run: `fvm dart analyze` → `No issues found!`.
+Run: `fvm dart format . --line-length=120 --set-exit-if-changed` → exit 0 (if it reformats, `git add -A`).
+
+- [ ] **Step 3: Tag slices**
+
+Run: `fvm flutter test --tags widget -r compact 2>&1 | tail -1` → `All tests passed!`
+Run: `fvm flutter test --exclude-tags widget -r compact 2>&1 | tail -1` → `All tests passed!`
+
+- [ ] **Step 4: Commit any formatting**
+
+```bash
+git add -A && git commit -m "test: dart_test.yaml tags finalize (#154)" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** dart_test.yaml → Task 1; widget tagging → Task 2; CI timeout → Task 3; docs → Task 4; verification → Task 5. All covered.
+- **YAGNI:** golden/integration declared but unused (no placeholder tests); ~108 unit files untagged.
+- **No placeholders:** full `dart_test.yaml`, exact annotation, full 29-file list, exact CI before/after, exact doc edits.
+- **Consistency:** tag names `widget`/`golden`/`integration` identical across config, annotations, CI, docs.

--- a/docs/superpowers/specs/2026-06-03-dart-test-tags-design.md
+++ b/docs/superpowers/specs/2026-06-03-dart-test-tags-design.md
@@ -1,0 +1,111 @@
+# dart_test.yaml + Test Tags — Design (#154)
+
+**Date:** 2026-06-03
+**Issue:** #154 (test-infrastructure audit follow-up)
+**Status:** Approved (design)
+
+## Problem
+
+There is no `dart_test.yaml` and no test tagging. The suite cannot be sliced
+(fast unit-only vs heavier widget vs platform-sensitive golden vs on-device
+integration), per-category timeouts can't be set, and there is no declared
+vocabulary for the golden/integration categories that issues #135 and #152 will
+add. CI runs one undifferentiated `flutter test --timeout=30s`.
+
+## Research basis (2026 Dart/Flutter standard)
+
+- All tags used with `--tags`/`--exclude-tags` **must be declared** in
+  `dart_test.yaml`, or `flutter test` warns "unrecognized tag". Declaring needs
+  no config (`golden:` alone suffices). — dart-lang/test configuration docs.
+- `dart_test.yaml` supports a default `timeout:` and per-tag
+  `timeout`/`skip`/`add_tags`. `flutter test` honors the file, `--tags`,
+  `--exclude-tags`, and `testWidgets(tags: ...)`.
+- Idiomatic practice tags the **special** categories that must be isolated
+  (golden = platform-sensitive; integration = slow/on-device) and leaves fast
+  default tests untagged. The `alchemist` golden package (the planned tool for
+  #135) **auto-applies the `golden` tag**, so reserving it now is forward-correct.
+- File-level `@Tags(['widget'])` (a library annotation) is the idiomatic way to
+  mark an entire file's tests.
+
+Sources: dart-lang/test `configuration.md`, dart.dev/tools/testing,
+pub.dev/packages/alchemist, flutter_test `testWidgets` API.
+
+## Goals
+
+- Declare a tag vocabulary so `--tags`/`--exclude-tags` work warning-free.
+- Enable a fast unit-only loop and isolate heavy/widget tests.
+- Reserve `golden` and `integration` so #135/#152 land already-isolated.
+- Centralize the per-test timeout; give slow categories more.
+- Document the run commands. No test behavior change; suite stays green.
+
+## Non-goals (YAGNI)
+
+- Do **not** create placeholder golden/integration tests — reserve the tags only.
+- Do **not** tag the ~108 pure-unit/bloc files — untagged = the default fast set
+  (idiomatic; tagging everything is churn for no benefit).
+
+## Design
+
+### 1. `dart_test.yaml` (repo root)
+
+```yaml
+# Tag vocabulary. All tags used with --tags/--exclude-tags must be declared here
+# or `flutter test` warns about unrecognized tags. Declaring needs no body.
+tags:
+  widget:        # widget tests (testWidgets) — need a binding + pump; heavier than pure unit
+  golden:        # golden / visual-regression — platform-sensitive, run in isolation (#135;
+                 # alchemist auto-applies this tag). Reserved: no members yet.
+  integration:   # on-device end-to-end (#152). Reserved: no members yet.
+    timeout: 2x
+
+# Per-test timeout. package:test default is 30s; mirrors the current CI flag so
+# behavior is unchanged. golden/integration get more via their tag config.
+timeout: 30s
+```
+
+### 2. Tag application
+
+- Add the library annotation to the **29 widget-test files** (those using
+  `testWidgets`), at the very top:
+  ```dart
+  @Tags(['widget'])
+  library;
+
+  import 'package:flutter_test/flutter_test.dart';
+  // ...rest unchanged
+  ```
+  All 29 files are confirmed to have no existing `library;`/`@Tags`/`part`
+  directive, so placement is uniform.
+- `golden` / `integration` get no members in this change.
+
+### 3. CI (`.github/workflows/build_and_test.yml`)
+
+- The per-test timeout now lives in `dart_test.yaml`, so drop `--timeout=30s`
+  from the `flutter test` line (behavior unchanged). Keep `--coverage
+  --concurrency=4 --reporter=compact`. CI continues to run **all** tests
+  (including widget); tags are for slicing, not for excluding coverage in CI.
+- (`sonar_scanner.yml` runs `flutter test --coverage` — unchanged.)
+
+### 4. Documentation
+
+- `README.md` Test section: add tag commands —
+  `flutter test --exclude-tags widget` (fast unit loop),
+  `flutter test --tags widget` (widget only),
+  and note `golden`/`integration` are reserved for #135/#152.
+- `docs/testing-architecture.md`: update the "Tags/presets" bullet — the
+  vocabulary now exists; describe the tags and that golden/integration are
+  reserved.
+
+## Verification
+
+- `flutter test` emits **no** "unrecognized tag" warnings (all declared).
+- `flutter test --tags widget` runs exactly the 29 widget files.
+- `flutter test --exclude-tags widget` runs the rest with no widget files.
+- Full `flutter test` green (1565), `dart analyze` clean, `dart format` clean.
+
+## Acceptance
+
+- `dart_test.yaml` exists with declared `widget`/`golden`/`integration` tags +
+  default timeout + per-tag timeout for integration.
+- The 29 widget-test files carry `@Tags(['widget'])`.
+- CI timeout centralized; run commands documented; suite green.

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -276,7 +276,10 @@ All shared doubles live in `test/mocks/`:
   fixture timestamp whose exact value no assertion depends on — never `DateTime.now()`.
 - **Goldens:** there are no golden/visual-regression tests yet (issue #135). The
   bootstrap is where font loading will be wired when they land.
-- **Tags/presets:** there is no `dart_test.yaml` tagging scheme yet (issue #154).
+- **Tags:** `dart_test.yaml` declares `widget` (applied to all `testWidgets`
+  files via `@Tags(['widget'])`), plus `golden` and `integration` reserved for
+  #135/#152. Slice the suite with `flutter test --tags widget` /
+  `--exclude-tags widget`. The per-test timeout (30s) lives in `dart_test.yaml`.
 
 These are documented so newcomers know what is intentional vs. not-yet-done.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.42+1
+version: 0.21.43+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.0 • channel stable • https://github.com/flutter/flutter.git

--- a/test/app/connectivity/connectivity_banner_test.dart
+++ b/test/app/connectivity/connectivity_banner_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';

--- a/test/app/dev_console/tabs/environment_tab_test.dart
+++ b/test/app/dev_console/tabs/environment_tab_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/app/dev_console/tabs/environment_tab.dart';

--- a/test/app/dev_console/tabs/network_tab_test.dart
+++ b/test/app/dev_console/tabs/network_tab_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/app/dev_console/tabs/network_tab.dart';
 import 'package:flutter_bloc_advance/infrastructure/http/dev_console_store.dart';

--- a/test/app/localization/localization_test.dart
+++ b/test/app/localization/localization_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/generated/intl/messages_all.dart';
 import 'package:flutter_bloc_advance/generated/intl/messages_en.dart' as message_en;

--- a/test/app/router/app_router_factory_test.dart
+++ b/test/app/router/app_router_factory_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/app/app.dart';
 import 'package:flutter_bloc_advance/features/auth/presentation/pages/login_page.dart';

--- a/test/app/router/app_router_strategy_test.dart
+++ b/test/app/router/app_router_strategy_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/app/router/router_test.dart
+++ b/test/app/router/router_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/app/router/app_router_strategy.dart';
 import 'package:flutter_bloc_advance/app/router/app_routes_constants.dart';

--- a/test/app/shell/top_bar/breadcrumb_widget_test.dart
+++ b/test/app/shell/top_bar/breadcrumb_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/app/shell/top_bar/breadcrumb_widget.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/features/account/presentation/pages/account_screen_test.dart
+++ b/test/features/account/presentation/pages/account_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/auth/presentation/pages/change_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/change_password_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/auth/presentation/pages/forgot_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/forgot_password_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/core/testing/app_key_constants.dart';

--- a/test/features/auth/presentation/pages/register_screen_go_router_test.dart
+++ b/test/features/auth/presentation/pages/register_screen_go_router_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/auth/presentation/widgets/community_section_widget_test.dart
+++ b/test/features/auth/presentation/widgets/community_section_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/core/testing/app_key_constants.dart';
 import 'package:flutter_bloc_advance/features/auth/presentation/widgets/community_section_widget.dart';

--- a/test/features/auth/presentation/widgets/login_otp_email_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_email_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
+++ b/test/features/auth/presentation/widgets/login_otp_verify_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/dashboard/presentation/pages/dashboard_page_test.dart
+++ b/test/features/dashboard/presentation/pages/dashboard_page_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/features/dashboard/presentation/pages/home_screen_test.dart
+++ b/test/features/dashboard/presentation/pages/home_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/main/app.dart';
 import 'package:flutter_bloc_advance/features/auth/presentation/pages/login_page.dart';

--- a/test/features/settings/presentation/pages/settings_screen_test.dart
+++ b/test/features/settings/presentation/pages/settings_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/core/testing/app_key_constants.dart';
 import 'package:flutter_bloc_advance/generated/l10n.dart';

--- a/test/features/users/presentation/pages/list_user_screen_test.dart
+++ b/test/features/users/presentation/pages/list_user_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/users/presentation/pages/user_editor_screen_test.dart
+++ b/test/features/users/presentation/pages/user_editor_screen_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/test/features/users/presentation/pages/user_extended_info_page_test.dart
+++ b/test/features/users/presentation/pages/user_extended_info_page_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/application/dynamic_form_bloc.dart';

--- a/test/main/app_test.dart
+++ b/test/main/app_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_advance/main/app.dart';

--- a/test/shared/design_system/theme/semantic_colors_test.dart
+++ b/test/shared/design_system/theme/semantic_colors_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/shared/design_system/theme/semantic_colors.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/shared/design_system/tokens/padding_spacing_test.dart
+++ b/test/shared/design_system/tokens/padding_spacing_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/shared/design_system/tokens/app_spacing.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/shared/dynamic_forms/presentation/pages/dynamic_form_page_test.dart
+++ b/test/shared/dynamic_forms/presentation/pages/dynamic_form_page_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/shared/dynamic_forms/presentation/widgets/dynamic_form_renderer_test.dart
+++ b/test/shared/dynamic_forms/presentation/widgets/dynamic_form_renderer_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/domain/entities/form_schema_entity.dart';
 import 'package:flutter_bloc_advance/shared/dynamic_forms/presentation/widgets/dynamic_form_renderer.dart';

--- a/test/shared/widgets/responsive_form_widget_test.dart
+++ b/test/shared/widgets/responsive_form_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/shared/widgets/submit_button_widget_test.dart
+++ b/test/shared/widgets/submit_button_widget_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc_advance/shared/widgets/submit_button_widget.dart';

--- a/test/shared/widgets/web_back_button_disabler_test.dart
+++ b/test/shared/widgets/web_back_button_disabler_test.dart
@@ -1,3 +1,6 @@
+@Tags(['widget'])
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc_advance/shared/widgets/web_back_button_disabler.dart';


### PR DESCRIPTION
## Summary

Closes #154. Adds a test tag vocabulary so the suite can be sliced and so the upcoming golden/e2e suites land already-isolated. Grounded in current (2026) Dart/Flutter test conventions ([dart-lang/test config](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md), [dart.dev/tools/testing](https://dart.dev/tools/testing), [alchemist](https://pub.dev/packages/alchemist)).

### Changes
- **`dart_test.yaml`** (new) — declares tags `widget`, `golden`, `integration` (all tags used with `--tags`/`--exclude-tags` must be declared or `flutter test` warns), per-tag timeout for `integration` (`2x`), and a default per-test `timeout: 30s` (mirrors the old CI flag).
- **29 widget-test files** — file-level `@Tags(['widget'])` (`testWidgets` files; heavier than pure unit).
- **`golden` / `integration`** — declared but **reserved** (no members yet); `alchemist` will auto-apply `golden` in #135.
- **CI** — dropped `--timeout=30s` from `build_and_test.yml` (now centralized in `dart_test.yaml`). CI still runs all tests.
- **Docs** — README run commands + `docs/testing-architecture.md` Tags section.

### Slices
- `flutter test --tags widget` → **273** tests (29 files)
- `flutter test --exclude-tags widget` → **1292** tests (fast unit loop)
- 273 + 1292 = 1565 (full suite)

### Verification
- Full suite **1565 green**, **no "unrecognized tag" warnings**
- `dart analyze` clean, `dart format` clean
- ~108 unit/bloc files intentionally left untagged (idiomatic default-fast set; YAGNI)

### Process
Researched 2026 standards → spec → plan → inline execution → verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)