### PR TITLE
docs: test double convention — mock / fake / Dio stub (closes #155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,4 +161,8 @@ When in doubt, prefer sealed and split the BLoC instead of growing the single st
   - `TestEnv.authenticate()` for auth-dependent tests — call it in `setUp` or the test body, **never** in `setUpAll` (the global reset clears the secure store before each test).
   - `TestEnv.apiClient()` for the mock-backed `ApiClient`.
 - A test file that installs its own `MethodChannel` / `SharedPreferences` mock opts out of the global reset with `setUpAll(() => TestEnv.autoReset = false);` (isolated per file). Example: `test/infrastructure/storage/local_storage_test.dart`.
+- **Test doubles** — reach for a `mocktail` mock first; drop to a hand-fake only for genuine stateful behavior; Dio handlers are always hand-written:
+  - **mocktail mock (default):** the `Mock*` classes in `test/mocks/mock_classes.dart`, for interface doubles configured with `when(...)` / `verify(...)` (repository / use-case / BLoC).
+  - **hand-written fake:** a private `_Fake*` / `_Memory*` class next to the test when it needs real stateful behavior (in-memory store, throw-on-Nth-call, selective/sequenced failures, return-driven branching). These are **purpose-built per test** — same-named fakes in different files are not duplication; do not force them into shared "god" fakes.
+  - **Dio handler stub:** a private `_Test*Handler` / `_StubInterceptor` extending Dio's `Interceptor` / `RequestInterceptorHandler` / `ResponseInterceptorHandler` / `ErrorInterceptorHandler`, to test interceptors at the Dio layer (can't be mocked cleanly).
 - Full test structure, per-layer patterns, and guard tests: see `docs/testing-architecture.md`.

--- a/docs/superpowers/plans/2026-06-03-test-double-convention.md
+++ b/docs/superpowers/plans/2026-06-03-test-double-convention.md
@@ -1,0 +1,136 @@
+# Test Double Convention Implementation Plan (#155)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document a clear three-category test-double convention (mocktail mock / hand-written fake / Dio handler stub) in `CLAUDE.md` and `docs/testing-architecture.md`, with explicit "purpose-built, don't consolidate" guidance.
+
+**Architecture:** Documentation-only. No test code changes. Two files edited with consistent wording; verified by a single full-suite confirmation run (unchanged).
+
+**Tech Stack:** Markdown docs; Flutter project (`fvm flutter test` for the confirmation run).
+
+---
+
+## File structure
+
+- Modify `CLAUDE.md` (Testing section) — Task 1.
+- Modify `docs/testing-architecture.md` ("Mocks and fakes" section) — Task 2.
+- Verify — Task 3.
+
+---
+
+## Task 1: Add the convention to `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md` (Testing section)
+
+- [ ] **Step 1: Append a "Test doubles" bullet group**
+
+In `CLAUDE.md`, find the `## Testing` section. Its last bullet is:
+```markdown
+- Full test structure, per-layer patterns, and guard tests: see `docs/testing-architecture.md`.
+```
+Insert the following bullet group IMMEDIATELY BEFORE that "Full test structure" line (so the doc-pointer stays last):
+
+```markdown
+- **Test doubles** — reach for a `mocktail` mock first; drop to a hand-fake only for genuine stateful behavior; Dio handlers are always hand-written:
+  - **mocktail mock (default):** the `Mock*` classes in `test/mocks/mock_classes.dart`, for interface doubles configured with `when(...)` / `verify(...)` (repository / use-case / BLoC).
+  - **hand-written fake:** a private `_Fake*` / `_Memory*` class next to the test when it needs real stateful behavior (in-memory store, throw-on-Nth-call, selective/sequenced failures, return-driven branching). These are **purpose-built per test** — same-named fakes in different files are not duplication; do not force them into shared "god" fakes.
+  - **Dio handler stub:** a private `_Test*Handler` / `_StubInterceptor` extending Dio's `Interceptor` / `RequestInterceptorHandler` / `ResponseInterceptorHandler` / `ErrorInterceptorHandler`, to test interceptors at the Dio layer (can't be mocked cleanly).
+```
+
+- [ ] **Step 2: Verify placement**
+
+Run: `sed -n '/## Testing/,/^## /p' CLAUDE.md`
+Expected: the new "Test doubles" bullet group appears, and the `Full test structure ... see docs/testing-architecture.md` line is the LAST bullet in the section.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document mock/fake/Dio-stub test-double convention in CLAUDE.md (#155)"
+```
+
+---
+
+## Task 2: Expand the convention in `docs/testing-architecture.md`
+
+**Files:**
+- Modify: `docs/testing-architecture.md` ("Mocks and fakes" section)
+
+- [ ] **Step 1: Replace the mock-vs-fake blockquote**
+
+In `docs/testing-architecture.md`, find this exact blockquote at the end of the `## Mocks and fakes` section:
+
+```markdown
+> **mocktail mock vs. hand-written fake:** most tests use `mocktail` mocks from
+> `mock_classes.dart`. A few use a small hand-written `_FakeXRepository` when
+> stateful, return-value-driven behavior makes a mock awkward (e.g.
+> `user_list_bloc_test.dart`). Both are valid; reach for a mock first.
+```
+
+Replace it entirely with:
+
+```markdown
+### Choosing a test double
+
+Three categories — **reach for a mocktail mock first**; drop to a hand-fake only
+for genuine stateful behavior; Dio handlers are always hand-written:
+
+1. **mocktail mock (default)** — the `Mock*` classes in `mock_classes.dart`. Use
+   for interface doubles where the test only configures return values
+   (`when(...).thenReturn` / `thenAnswer`) and verifies calls (`verify`). This is
+   the default for repository / use-case / BLoC doubles.
+2. **hand-written fake** — a private `_Fake*` / `_Memory*` class next to the test,
+   when the double needs real stateful or behavioral logic that mocktail makes
+   awkward: in-memory stores, throw-on-Nth-call, selective/sequenced failures,
+   return-driven branching (e.g. `_FakeUserRepository` in `user_list_bloc_test.dart`,
+   `_MemorySecureStorage`). These are **purpose-built per test** — two same-named
+   fakes in different files implement different surfaces and are *not* duplication;
+   do not consolidate them into a shared "god" fake.
+3. **Dio handler / interceptor stub** — a private `_Test*Handler` / `_StubInterceptor`
+   extending Dio's `Interceptor` / `RequestInterceptorHandler` /
+   `ResponseInterceptorHandler` / `ErrorInterceptorHandler`. Used to test
+   interceptors at the Dio layer; they can't be mocked cleanly, and each records
+   the signals its test asserts on.
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `sed -n '/## Mocks and fakes/,/## Architecture/p' docs/testing-architecture.md`
+Expected: the old blockquote is gone; the new `### Choosing a test double` subsection with the three numbered categories is present; the rest of the section (the `mock_classes.dart` / `fake_data.dart` bullets) is unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/testing-architecture.md
+git commit -m "docs: expand test-double convention into three categories (#155)"
+```
+
+---
+
+## Task 3: Verify
+
+- [ ] **Step 1: Docs reference real classes/paths**
+
+Run: `grep -nE "mock_classes.dart|test_env.dart|_FakeUserRepository|_MemorySecureStorage|RequestInterceptorHandler" CLAUDE.md docs/testing-architecture.md`
+Expected: the referenced paths/classes appear; spot-check that `test/mocks/mock_classes.dart`, `test/features/users/application/user_list_bloc_test.dart` (contains `_FakeUserRepository`), and the Dio handler classes exist (they do).
+
+- [ ] **Step 2: No code touched — confirm suite still green**
+
+Run: `fvm flutter test --concurrency=4 --reporter=compact 2>&1 | tail -2`
+Expected: `All tests passed!` (1565, unchanged — this change is docs-only).
+
+- [ ] **Step 3: Analyze + format unaffected**
+
+Run: `fvm dart analyze` → `No issues found!`
+Run: `fvm dart format . --line-length=120 --set-exit-if-changed` → exit 0.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** three-category convention → Tasks 1 & 2; "don't consolidate"
+  note → both; docs-only / no code change → Task 3 confirms. All covered.
+- **No placeholders:** exact before/after markdown for both edits.
+- **Consistency:** the three categories and rule of thumb are worded consistently
+  across CLAUDE.md and testing-architecture.md.

--- a/docs/superpowers/specs/2026-06-03-test-double-convention-design.md
+++ b/docs/superpowers/specs/2026-06-03-test-double-convention-design.md
@@ -1,0 +1,96 @@
+# Test Double Convention — Design (#155)
+
+**Date:** 2026-06-03
+**Issue:** #155 (test-infrastructure audit follow-up)
+**Status:** Approved (design)
+
+## Problem
+
+The suite mixes `mocktail` mocks and hand-written fakes for test doubles with no
+documented rule, so contributors to this community template can't tell which to
+reach for. The audit issue suggested consolidating "duplicated" doubles.
+
+## Investigation (changed the scope)
+
+Audited all 57 hand-rolled doubles. They fall into three categories and are
+**purpose-built, not duplicated**:
+
+1. **Stateful/behavioral fakes** — `_MemorySecureStorage`, `_FlakyDeleteSecureStorage`,
+   `_ReadThrowsSecureStorage`, `_SelectiveFailSecureStorage`, etc. Encode in-memory
+   state or fail-on-Nth-call behavior.
+2. **Dio handler/interceptor stubs** — `_TestRequestHandler`/`_TestResponseHandler`/
+   `_TestErrorHandler`, `_StubInterceptor`. Extend Dio's handler classes; can't be
+   mocked cleanly.
+3. **Repository/use-case interface fakes** — `_FakeUserRepository`, `_FakeAccountRepository`,
+   etc. Have centralized `mocktail` equivalents (`MockIUserRepository`, ...).
+
+Verified that the apparent duplicates are **same-named but genuinely different**:
+the two `_FakeUserRepository` classes implement different method surfaces
+(list/delete vs retrieve/create); the two `_FakeAccountRepository` classes track
+different fields (`registerResult` vs `account`+`failure`); even the Dio
+`_Test*Handler` classes capture different signals per file (logging uses
+`nextOptions`/`nextResponse`; cache uses `resolvedResponse`/`rejectedError`;
+resilience uses an `_InterceptorResult` value object). Consolidating any of them
+would create kitchen-sink/god doubles that **reduce** per-test clarity.
+
+**Conclusion:** the real gap is the missing convention, not duplication. This is
+a documentation-only change. No test code is touched.
+
+## Goals
+
+- Document a clear, three-category rule for choosing a test double.
+- State explicitly that purpose-built per-test fakes are correct and must not be
+  force-consolidated.
+- No code/test changes; no behavior change.
+
+## Non-goals (YAGNI)
+
+- No consolidation of any existing double (verified to trade clarity for churn).
+- No conversion of hand-fakes to mocktail or vice versa.
+
+## Design
+
+Documentation in two places, consistent wording.
+
+### Convention — three categories
+
+1. **mocktail mock (default).** Use the `Mock*` classes in
+   `test/mocks/mock_classes.dart` for interface doubles where the test only
+   configures return values (`when(...).thenReturn/thenAnswer`) and verifies
+   calls (`verify`). This is the default for repository / use-case / BLoC doubles.
+2. **Hand-written fake.** Use a private `_Fake*` / `_Memory*` class next to the
+   test when the double needs genuine stateful or behavioral logic that mocktail
+   makes awkward: in-memory stores, throw-on-Nth-call, selective/sequenced
+   failures, return-driven branching. These are **expected to be purpose-built
+   per test** — do not force them into shared "god" fakes.
+3. **Dio handler/interceptor stub.** Use a private `_Test*Handler` /
+   `_StubInterceptor` (extending Dio's `Interceptor` / `RequestInterceptorHandler`
+   / `ResponseInterceptorHandler` / `ErrorInterceptorHandler`) to test
+   interceptors at the Dio layer. These can't be mocked cleanly; each records the
+   signals its test asserts on.
+
+**Rule of thumb:** reach for a mocktail mock first; drop to a hand-fake only when
+stateful behavior is needed; Dio handlers are always hand-written.
+
+**Note:** same-named fakes in different files (e.g. `_FakeUserRepository` in two
+bloc tests) are intentionally purpose-built, not duplication — do not consolidate.
+
+### Placement
+
+- `CLAUDE.md` → Testing section: a concise "Test doubles" bullet group with the
+  rule of thumb + three categories.
+- `docs/testing-architecture.md` → expand the existing "Mocks and fakes"
+  section's mock-vs-fake note into the three categories + the no-consolidate note.
+
+## Verification
+
+- `dart analyze` / `dart format` unaffected (markdown only).
+- Full suite unchanged (no test edits) — a single confirmation run.
+- The two docs read consistently and reference real classes/paths.
+
+## Acceptance
+
+- The three-category convention + rule of thumb is documented in CLAUDE.md and
+  testing-architecture.md.
+- The "purpose-built, don't consolidate" guidance is explicit.
+- No test code changed.

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -242,10 +242,27 @@ All shared doubles live in `test/mocks/`:
 - **`fake_data.dart`** — shared fixtures (`mockUserFullPayload`,
   `mockAuthorityPayload`, ...). Prefer these over building entities inline.
 
-> **mocktail mock vs. hand-written fake:** most tests use `mocktail` mocks from
-> `mock_classes.dart`. A few use a small hand-written `_FakeXRepository` when
-> stateful, return-value-driven behavior makes a mock awkward (e.g.
-> `user_list_bloc_test.dart`). Both are valid; reach for a mock first.
+### Choosing a test double
+
+Three categories — **reach for a mocktail mock first**; drop to a hand-fake only
+for genuine stateful behavior; Dio handlers are always hand-written:
+
+1. **mocktail mock (default)** — the `Mock*` classes in `mock_classes.dart`. Use
+   for interface doubles where the test only configures return values
+   (`when(...).thenReturn` / `thenAnswer`) and verifies calls (`verify`). This is
+   the default for repository / use-case / BLoC doubles.
+2. **hand-written fake** — a private `_Fake*` / `_Memory*` class next to the test,
+   when the double needs real stateful or behavioral logic that mocktail makes
+   awkward: in-memory stores, throw-on-Nth-call, selective/sequenced failures,
+   return-driven branching (e.g. `_FakeUserRepository` in `user_list_bloc_test.dart`,
+   `_MemorySecureStorage`). These are **purpose-built per test** — two same-named
+   fakes in different files implement different surfaces and are *not* duplication;
+   do not consolidate them into a shared "god" fake.
+3. **Dio handler / interceptor stub** — a private `_Test*Handler` / `_StubInterceptor`
+   extending Dio's `Interceptor` / `RequestInterceptorHandler` /
+   `ResponseInterceptorHandler` / `ErrorInterceptorHandler`. Used to test
+   interceptors at the Dio layer; they can't be mocked cleanly, and each records
+   the signals its test asserts on.
 
 ---
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.43+1
+version: 0.21.44+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.0 • channel stable • https://github.com/flutter/flutter.git


### PR DESCRIPTION
## Summary

Closes #155. Documents a clear three-category convention for test doubles so contributors know which to reach for. **Docs-only — no test code changed.**

### Investigation (reframed the issue)
The audit issue suggested consolidating "duplicated" doubles. Auditing all 57 hand-rolled doubles showed they are **purpose-built, not duplicated**:
- The two `_FakeUserRepository` classes implement different method surfaces (list/delete vs retrieve/create); the two `_FakeAccountRepository` track different fields; even the Dio `_Test*Handler` classes capture different signals per file (logging vs cache vs resilience's value-object pattern).
- Consolidating any of them would create kitchen-sink/god doubles that **reduce** per-test clarity.

So the real gap was the missing convention, not duplication.

### The convention (CLAUDE.md + docs/testing-architecture.md)
1. **mocktail mock (default)** — `Mock*` from `test/mocks/mock_classes.dart`, for interface doubles configured with `when(...)`/`verify(...)`.
2. **hand-written fake** — private `_Fake*`/`_Memory*` next to the test for genuine stateful behavior (in-memory store, throw-on-Nth-call, selective failures). Purpose-built per test; **not** consolidated.
3. **Dio handler stub** — private `_Test*Handler`/`_StubInterceptor` extending Dio handler classes; can't be mocked cleanly.

Rule of thumb: mocktail first → hand-fake for stateful → Dio handlers always hand-written.

### Verification
- `dart analyze` clean, `dart format` clean, full suite **1565 green** (docs-only, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)