### PR TITLE
test: screen-test verify-by-event-type + dead-mock/brittle-text cleanup (addresses #168)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-screen-test-quality.md
+++ b/docs/superpowers/plans/2026-06-03-screen-test-quality.md
@@ -1,0 +1,161 @@
+# Screen Test Quality Fixes Implementation Plan (#168 slice)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make screen-test action verifications assert the correct event type (so a broken submit/search fails the test), remove a dead repository mock, de-brittle `find.text('User')`, and document the convention. Correctness slice of epic #168.
+
+**Architecture:** Edit 4 screen test files (`user_editor`, `account`, `forgot_password`, `user_list`) + `docs/testing-architecture.md`. Each loose `verify(() => bloc.add(any())).called(N)` becomes a type-matched `verify(() => bloc.add(any(that: isA<XEvent>()))).called(1)` (existing mocktail fallbacks cover the base type, so no new registration). Line numbers may drift — locate by content.
+
+**Tech Stack:** Flutter 3.44.0, `flutter_test`, `bloc_test`, `mocktail`, FVM.
+
+---
+
+## Key facts
+
+- Each screen adds an init event on mount, so `verify(add(any()))` is satisfied even if the action never fired → must match the event TYPE.
+- Event classes: `AccountSubmitEvent` / `AccountFetchEvent`; `ForgotPasswordEmailChanged` (the only forgot-password event; submit dispatches it); `UserListSearch`; `UserEditorFetch` / `UserEditorSubmit` / `UserEditorReset`.
+- `any(that: isA<XEvent>())` reuses the registered base-type fallback (e.g. `UserEditorReset` for `UserEditorEvent`) — `verify(add(any()))` already works in these files, so `any(that:)` works too. If a verify ever errors on a missing fallback, register it in `test/mocks/mock_classes.dart`'s `registerAllFallbackValues()`.
+
+---
+
+## Task 1: `user_editor_screen_test.dart`
+
+**Files:**
+- Modify: `test/features/users/presentation/pages/user_editor_screen_test.dart`
+
+- [ ] **Step 1: Remove the dead `MockUserRepository`**
+
+Delete the field declaration (`late MockUserRepository mockUserRepository;`), its
+`setUp` initialization (`mockUserRepository = MockUserRepository();`), and the
+unused stub in the Edit-mode test
+(`when(() => mockUserRepository.retrieve(userId)).thenAnswer((_) async => const Success(mockUser));`).
+The screen is driven by `mockUserBloc`; the repository mock is never injected.
+(If `Success`/`MockUserRepository` imports become unused, remove them.)
+
+- [ ] **Step 2: Fix the 4 verify sites**
+
+- "Create Mode - Should render empty form" (~line 118): **remove**
+  `verify(() => mockUserBloc.add(any())).called(1);` — it asserts the incidental
+  init event, not the render. The `find.byKey(...)` field assertions remain the test.
+- "Edit Mode - Should load and display user data" (~line 161): replace
+  `verify(() => mockUserBloc.add(any())).called(1);` with
+  `verify(() => mockUserBloc.add(any(that: isA<UserEditorFetch>()))).called(1);`
+- "Create Mode - Should validate form before submit" (~line 253): replace
+  `verify(() => mockUserBloc.add(any())).called(1);` with
+  `verifyNever(() => mockUserBloc.add(any(that: isA<UserEditorSubmit>())));`
+  (an invalid form must NOT dispatch a submit).
+- "Create Mode - Should submit valid form" (~line 296): replace
+  `verify(() => mockUserBloc.add(any())).called(greaterThan(0));` with
+  `verify(() => mockUserBloc.add(any(that: isA<UserEditorSubmit>()))).called(1);`
+
+- [ ] **Step 3: De-brittle `find.text('User')`**
+
+In both fixtures (Edit-mode `mockUser` ~line 130 and View-mode `mockUser` ~line 173),
+change `lastName: 'User'` → `lastName: 'Tester'`. Update the corresponding
+assertions `expect(find.text('User'), findsOneWidget);` (~lines 158, 209) →
+`expect(find.text('Tester'), findsOneWidget);`.
+
+- [ ] **Step 4: Run + analyze/format**
+
+Run: `fvm flutter test test/features/users/presentation/pages/user_editor_screen_test.dart -r compact 2>&1 | tail -3` → `All tests passed!`.
+Run: `fvm dart analyze test/features/users/presentation/pages/user_editor_screen_test.dart` → No issues found.
+Run: `fvm dart format test/features/users/presentation/pages/user_editor_screen_test.dart --line-length=120`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/features/users/presentation/pages/user_editor_screen_test.dart
+git commit -m "test: type-matched verify + drop dead repo mock + unique fixture in user_editor (#168)"
+```
+
+---
+
+## Task 2: account / forgot_password / user_list
+
+**Files:**
+- Modify: `test/features/account/presentation/pages/account_screen_test.dart`
+- Modify: `test/features/auth/presentation/pages/forgot_password_screen_test.dart`
+- Modify: `test/features/users/presentation/pages/user_list_screen_test.dart`
+
+- [ ] **Step 1: account (~line 201)** — the "submit valid form" / Save test. Replace
+  `verify(() => mockAccountBloc.add(any())).called(2);` with
+  `verify(() => mockAccountBloc.add(any(that: isA<AccountSubmitEvent>()))).called(1);`
+  (Add the `account_event.dart` import if `AccountSubmitEvent` isn't in scope.)
+
+- [ ] **Step 2: forgot_password (~line 201)** — "send email Successful". Replace
+  `verify(() => forgotPasswordBloc.add(any())).called(1);` with
+  `verify(() => forgotPasswordBloc.add(any(that: isA<ForgotPasswordEmailChanged>()))).called(1);`
+  (Import `forgot_password_event.dart` if needed.)
+
+- [ ] **Step 3: user_list (~line 185)** — "handles search button tap". Replace
+  `verify(() => mockUserBloc.add(any())).called(greaterThan(0));` with
+  `verify(() => mockUserBloc.add(any(that: isA<UserListSearch>()))).called(1);`
+  Also de-brittle `find.text('User')`: the `mockUsers` fixture `lastName: 'User'`
+  (~line 134) → `lastName: 'Tester'`, and the assertion `find.text('User')` (~line
+  155) → `find.text('Tester')`.
+
+- [ ] **Step 4: Run + analyze/format**
+
+Run: `fvm flutter test test/features/account/presentation/pages/account_screen_test.dart test/features/auth/presentation/pages/forgot_password_screen_test.dart test/features/users/presentation/pages/user_list_screen_test.dart -r compact 2>&1 | tail -3` → `All tests passed!`.
+Run: `fvm dart analyze` → No issues found; `fvm dart format <the 3 files> --line-length=120`.
+
+If a `verify(any(that:))` errors with a missing fallback, add the matching
+`registerFallbackValue(...)` in `test/mocks/mock_classes.dart` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/features/account/presentation/pages/account_screen_test.dart test/features/auth/presentation/pages/forgot_password_screen_test.dart test/features/users/presentation/pages/user_list_screen_test.dart
+git commit -m "test: type-matched verify (account/forgot/user_list) + unique fixture (#168)"
+```
+
+---
+
+## Task 3: document the convention
+
+**Files:**
+- Modify: `docs/testing-architecture.md` (Widget tests subsection)
+
+- [ ] **Step 1:** After the Widget-tests example/bullets, add:
+
+```markdown
+**Verifying actions:** assert the dispatched event **by type** —
+`verify(() => bloc.add(any(that: isA<XEvent>()))).called(1)` — not `any()` /
+`called(greaterThan(0))`. Screens add an init event on mount, so a loose
+`verify(add(any()))` is satisfied even if the action under test never fired
+(false-confidence). For "must NOT happen" cases use
+`verifyNever(() => bloc.add(any(that: isA<XEvent>())))`.
+
+**Other screen-test rules:** don't keep a repository mock that isn't injected
+(screen tests drive the screen through its mock BLoC); prefer `whenListen` + a
+seeded state over re-implementing the bloc's state machine inside an `add` stub;
+use unique fixture values so `findsOneWidget` is unambiguous.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/testing-architecture.md
+git commit -m "docs: screen-test verify-by-event-type convention (#168)"
+```
+
+---
+
+## Task 4: Full verification
+
+- [ ] **Step 1:** `grep -rn "add(any())).called\|called(greaterThan(0))" test/features --include='*_test.dart' | grep -v golden` → no loose `add(any())` verifications remain (only `any(that: isA<…>())`).
+- [ ] **Step 2:** `fvm flutter test --concurrency=4 --reporter=compact 2>&1 | tail -2` → `All tests passed!`.
+- [ ] **Step 3:** `fvm dart analyze` → clean; `fvm dart format . --line-length=120 --set-exit-if-changed` → exit 0.
+- [ ] **Step 4 (if formatting):** `git add -A && git commit -m "test: screen-test quality finalize (#168)" || echo "nothing to commit"`
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** 7 verify sites (Tasks 1–2), dead repo (Task 1), brittle text
+  (Tasks 1–2), convention doc (Task 3), verification (Task 4). #6/#7/#8–11 stay in
+  the epic.
+- **No placeholders:** exact per-site before/after + event types; fixture/text
+  changes specified; fallback fallback noted.
+- **Consistency:** `any(that: isA<XEvent>())` + `.called(1)` / `verifyNever`
+  pattern uniform across all sites.

--- a/docs/superpowers/specs/2026-06-03-screen-test-quality-design.md
+++ b/docs/superpowers/specs/2026-06-03-screen-test-quality-design.md
@@ -1,0 +1,97 @@
+# Screen Test Quality — Design (#168, scoped slice)
+
+**Date:** 2026-06-03
+**Issue:** #168 (screen behavior-test quality epic)
+**Status:** Approved (design) — this spec covers the **correctness slice** (#1–3) +
+brittle-text (#5) + convention doc. The epic's #6/#7 (mock rewrite, surface API)
+and #8–11 (cosmetic) remain open in #168.
+
+## Problem
+
+Several screen behavior tests are green but don't actually verify the behavior
+they claim. The systemic issue: `verify(() => bloc.add(any())).called(N)` with no
+event-type matcher — and since each screen adds an init event on mount, a loose
+`any()`/`greaterThan(0)` is satisfied even if the action under test (submit/search)
+never fired. Plus a dead `MockUserRepository` and brittle `find.text('User')`.
+
+## Goals
+
+- Make submit/search/load verifications assert the **correct event type**, so a
+  broken action fails the test.
+- Remove the dead repository mock.
+- De-brittle `find.text('User')` assertions.
+- Document the screen-test convention so this class of false-confidence test
+  doesn't recur.
+- No behavior change to assertions' intent; suite stays green.
+
+## Non-goals (kept in epic #168)
+
+- #6 rewrite `user_editor`'s mock (re-implements the bloc state machine) to
+  `whenListen`.
+- #7 unify the surface-size API.
+- #8–11 cosmetic (naming, `addTearDown` placement, redundant `pump`).
+
+## Fixes
+
+### 1. Event-type-matched verifications (7 sites, 4 files)
+
+Existing mocktail fallbacks already cover `any(that: isA<…>())` (the base-type
+fallback is registered), so no new fallback registration is needed.
+
+| File:site | Test intent | Current | New |
+| --- | --- | --- | --- |
+| `account_screen_test.dart:201` | Save submits | `add(any()).called(2)` | `add(any(that: isA<AccountSubmitEvent>())).called(1)` |
+| `forgot_password_screen_test.dart:201` | Send email | `add(any()).called(1)` | `add(any(that: isA<ForgotPasswordEmailChanged>())).called(1)` |
+| `user_list_screen_test.dart:185` | Search dispatched | `add(any()).called(greaterThan(0))` | `add(any(that: isA<UserListSearch>())).called(1)` |
+| `user_editor_screen_test.dart:161` | Edit-mode fetch | `add(any()).called(1)` | `add(any(that: isA<UserEditorFetch>())).called(1)` |
+| `user_editor_screen_test.dart:253` | Invalid form blocks submit | `add(any()).called(1)` | `verifyNever(() => …add(any(that: isA<UserEditorSubmit>())))` |
+| `user_editor_screen_test.dart:296` | Valid form submits | `add(any()).called(greaterThan(0))` | `add(any(that: isA<UserEditorSubmit>())).called(1)` |
+| `user_editor_screen_test.dart:118` | Create-mode renders empty form | `add(any()).called(1)` | **remove** — it asserts the incidental init event, not the render; the field-key assertions are the real test |
+
+Event classes: `AccountSubmitEvent`/`AccountFetchEvent`,
+`ForgotPasswordEmailChanged` (the only forgot-password event; submit dispatches
+it), `UserListSearch`, `UserEditorFetch`/`UserEditorSubmit`/`UserEditorReset`.
+
+After each change, run the file: a correctly-failing test (e.g. if the action
+didn't fire) must now fail; the suite stays green because the actions DO fire.
+
+### 2. Remove dead `MockUserRepository`
+
+`user_editor_screen_test.dart` creates `mockUserRepository` and stubs
+`retrieve()`, but never injects it (the screen is driven by `mockUserBloc`).
+Delete the field, its `setUp` init, and the `retrieve` stub (lines ~25, 30, 136).
+
+### 3. De-brittle `find.text('User')`
+
+The fixture `lastName: 'User'` collides with common tokens, making
+`find.text('User'), findsOneWidget` fragile in `user_editor_screen_test.dart`
+(edit/view) and `user_list_screen_test.dart`. Change the fixture `lastName` to a
+unique value (e.g. `'Tester'`) and update the corresponding `find.text(...)`
+assertions. (Login/firstName/email are already unique.)
+
+### 4. Document the convention
+
+Add to `docs/testing-architecture.md` (Widget tests subsection):
+
+- Verify an action by **event type**: `verify(() => bloc.add(any(that: isA<XEvent>()))).called(1)`
+  — not `any()` / `greaterThan(0)` (screens add an init event on mount, so a loose
+  verify is satisfied even if the action never fired).
+- Don't keep a repository mock that isn't injected — screen tests drive the
+  screen through its mock BLoC.
+- Mock the BLoC's state stream with `whenListen` + a seeded state; don't
+  re-implement the bloc's state machine inside the `add` stub.
+- Use unique fixture values so `findsOneWidget` is unambiguous.
+
+## Verification
+
+- The 6 rewritten verifications use `isA<…>()` matchers; the render-only verify is
+  removed; `verifyNever` guards the invalid-submit case.
+- No `MockUserRepository` / no `find.text('User')` brittleness in the two files.
+- `grep verify(() => .*add(any())).called` in the four files → only type-matched
+  forms remain.
+- Full `flutter test` green; `dart analyze` / `dart format` clean.
+
+## Acceptance
+
+- 7 verify sites corrected (6 type-matched, 1 removed); dead repo removed; brittle
+  text fixed; convention documented. Suite green. #168's #6/#7/#8–11 stay open.

--- a/docs/testing-architecture.md
+++ b/docs/testing-architecture.md
@@ -203,6 +203,26 @@ testWidgets('renders dashboard when authenticated', (tester) async {
 Provide BLoC state with a `MockBloc` so the UI renders deterministically without
 real business logic.
 
+**Verifying actions — by event type, not `any()`.** Assert the dispatched event
+with a type matcher and an explicit count:
+
+```dart
+verify(() => bloc.add(any(that: isA<UserEditorSubmit>()))).called(1);   // action fired
+verifyNever(() => bloc.add(any(that: isA<UserEditorSubmit>())));        // must NOT fire (e.g. invalid form)
+```
+
+Do **not** use `verify(() => bloc.add(any())).called(...)` or `.called(greaterThan(0))`:
+screens add an init event on mount (a load/`Reset`), so a loose verify is satisfied
+even if the action under test never fired — a false-confidence test. (A real case:
+a "submit valid form" test passed under `add(any())` while the form was actually
+invalid — a required field unfilled — so no submit ever dispatched. Tightening to
+`isA<…Submit>()` exposed it; the fix was to make the test fill a genuinely valid form.)
+
+**Other screen-test rules:** don't keep a repository mock that isn't injected (the
+screen is driven through its mock BLoC); prefer `whenListen` + a seeded state over
+re-implementing the bloc's state machine inside an `add` stub; use unique fixture
+values so `findsOneWidget` is unambiguous (avoid common tokens like `'User'`).
+
 ### ApiClient tests — stub Dio at the wire
 
 Inject a custom interceptor through the `dio` parameter to simulate transport

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.48+1
+version: 0.21.49+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.0 • channel stable • https://github.com/flutter/flutter.git

--- a/test/features/account/presentation/pages/account_screen_test.dart
+++ b/test/features/account/presentation/pages/account_screen_test.dart
@@ -198,7 +198,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Verify AccountSubmitEvent was called with correct data
-      verify(() => mockAccountBloc.add(any())).called(2);
+      verify(() => mockAccountBloc.add(any(that: isA<AccountSubmitEvent>()))).called(1);
     });
 
     testWidgets('Given form submission When server returns error Then should display failure message', (tester) async {

--- a/test/features/auth/presentation/pages/forgot_password_screen_test.dart
+++ b/test/features/auth/presentation/pages/forgot_password_screen_test.dart
@@ -198,7 +198,7 @@ void main() {
       await tester.pumpAndSettle();
 
       //Then:
-      verify(() => forgotPasswordBloc.add(any())).called(1);
+      verify(() => forgotPasswordBloc.add(any(that: isA<ForgotPasswordEmailChanged>()))).called(1);
     });
 
     // Send Email  Button Test Success

--- a/test/features/users/presentation/pages/user_editor_screen_test.dart
+++ b/test/features/users/presentation/pages/user_editor_screen_test.dart
@@ -276,20 +276,31 @@ void main() {
       await tester.pumpWidget(buildTestableWidget(mode: EditorFormMode.create));
       await tester.pumpAndSettle();
 
+      // Fill all required text fields.
       await tester.enterText(find.byKey(const Key('userEditorLoginFieldKey')), 'newuser');
       await tester.enterText(find.byKey(const Key('userEditorFirstNameFieldKey')), 'New');
       await tester.enterText(find.byKey(const Key('userEditorLastNameFieldKey')), 'User');
       await tester.enterText(find.byKey(const Key('userEditorEmailFieldKey')), 'new@example.com');
+      // Allow onChanged callbacks to propagate before selecting the authority.
+      await tester.pumpAndSettle();
+
+      // The AuthoritiesDropdown (isRequired: true) must have a non-empty value or
+      // saveAndValidate() returns false and UserEditorSubmit is never dispatched.
+      // Tap the dropdown to open the popup menu, then select 'ROLE_USER'.
+      await tester.ensureVisible(find.byKey(const Key('userEditorAuthoritiesFieldKey')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('userEditorAuthoritiesFieldKey')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('ROLE_USER').last);
+      await tester.pumpAndSettle();
 
       await tester.ensureVisible(find.byKey(const Key('userEditorSubmitButtonKey')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('userEditorSubmitButtonKey')));
       await tester.pumpAndSettle();
 
-      // ASSERT
-      // TODO(#168): UserEditorSubmit is never dispatched — the loose verify was masking a real bug.
-      // Tracked in issue #168. Re-tighten once the screen wires up the submit event correctly.
-      verify(() => mockUserBloc.add(any())).called(greaterThan(0));
+      // ASSERT — UserEditorSubmit must be dispatched exactly once for a fully valid form.
+      verify(() => mockUserBloc.add(any(that: isA<UserEditorSubmit>()))).called(1);
 
       await userStateController.close();
       await tester.binding.setSurfaceSize(null);

--- a/test/features/users/presentation/pages/user_editor_screen_test.dart
+++ b/test/features/users/presentation/pages/user_editor_screen_test.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_bloc_advance/core/result/result.dart';
 import 'package:flutter_bloc_advance/features/users/data/models/user.dart';
 import 'package:flutter_bloc_advance/generated/l10n.dart';
 import 'package:flutter_bloc_advance/features/users/application/authority_bloc.dart';
@@ -22,12 +21,10 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../mocks/mock_classes.dart';
 
 void main() {
-  late MockUserRepository mockUserRepository;
   late MockAuthorityBloc mockAuthorityBloc;
   late MockUserEditorBloc mockUserBloc;
 
   setUp(() async {
-    mockUserRepository = MockUserRepository();
     mockUserBloc = MockUserEditorBloc();
     mockAuthorityBloc = MockAuthorityBloc();
 
@@ -115,8 +112,6 @@ void main() {
       expect(find.byKey(const Key('userEditorActivatedFieldKey')), findsOneWidget);
       expect(find.byType(AuthoritiesDropdown), findsOneWidget);
 
-      verify(() => mockUserBloc.add(any())).called(1);
-
       await userStateController.close();
     });
 
@@ -127,13 +122,12 @@ void main() {
         id: userId,
         login: 'testuser',
         firstName: 'Test',
-        lastName: 'User',
+        lastName: 'Tester',
         email: 'test@example.com',
         activated: true,
         authorities: ['ROLE_USER'],
       );
 
-      when(() => mockUserRepository.retrieve(userId)).thenAnswer((_) async => const Success(mockUser));
       when(() => mockUserBloc.state).thenReturn(const UserEditorInitial());
 
       final userStateController = StreamController<UserEditorState>.broadcast();
@@ -155,10 +149,10 @@ void main() {
       // ASSERT
       expect(find.text('testuser'), findsOneWidget);
       expect(find.text('Test'), findsOneWidget);
-      expect(find.text('User'), findsOneWidget);
+      expect(find.text('Tester'), findsOneWidget);
       expect(find.text('test@example.com'), findsOneWidget);
 
-      verify(() => mockUserBloc.add(any())).called(1);
+      verify(() => mockUserBloc.add(any(that: isA<UserEditorFetch>()))).called(1);
 
       await userStateController.close();
     });
@@ -170,7 +164,7 @@ void main() {
         id: userId,
         login: 'testuser',
         firstName: 'Test',
-        lastName: 'User',
+        lastName: 'Tester',
         email: 'test@example.com',
         activated: true,
         authorities: ['ROLE_USER'],
@@ -206,7 +200,7 @@ void main() {
 
       expect(find.text('testuser'), findsOneWidget);
       expect(find.text('Test'), findsOneWidget);
-      expect(find.text('User'), findsOneWidget);
+      expect(find.text('Tester'), findsOneWidget);
       expect(find.text('test@example.com'), findsOneWidget);
 
       await userStateController.close();
@@ -250,7 +244,7 @@ void main() {
       final loginField = tester.widget<FormBuilderTextField>(find.byKey(const Key('userEditorLoginFieldKey')));
       expect(loginField.validator, isNotNull);
 
-      verify(() => mockUserBloc.add(any())).called(1);
+      verifyNever(() => mockUserBloc.add(any(that: isA<UserEditorSubmit>())));
 
       await userStateController.close();
     });
@@ -293,6 +287,8 @@ void main() {
       await tester.pumpAndSettle();
 
       // ASSERT
+      // TODO(#168): UserEditorSubmit is never dispatched — the loose verify was masking a real bug.
+      // Tracked in issue #168. Re-tighten once the screen wires up the submit event correctly.
       verify(() => mockUserBloc.add(any())).called(greaterThan(0));
 
       await userStateController.close();

--- a/test/features/users/presentation/pages/user_list_screen_test.dart
+++ b/test/features/users/presentation/pages/user_list_screen_test.dart
@@ -131,7 +131,7 @@ void main() {
           login: 'user-1',
           email: 'admin@example.com',
           firstName: 'Admin',
-          lastName: 'User',
+          lastName: 'Tester',
           activated: true,
           langKey: 'en',
           createdBy: 'system',
@@ -152,7 +152,7 @@ void main() {
 
       // ASSERT
       expect(find.text('admin@example.com'), findsOneWidget);
-      expect(find.text('User'), findsOneWidget);
+      expect(find.text('Tester'), findsOneWidget);
       expect(find.text('Active'), findsNWidgets(2)); // header + data badge
 
       // Clean up
@@ -182,7 +182,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // ASSERT
-      verify(() => mockUserBloc.add(any())).called(greaterThan(0));
+      verify(() => mockUserBloc.add(any(that: isA<UserListSearch>()))).called(1);
 
       // Clean up
       await userStateController.close();


### PR DESCRIPTION
## Summary

Addresses the **correctness slice** of #168 (does NOT close the epic — #6/#7/#8–11 remain). Makes screen-test action verifications assert the **event type** so a broken submit/search actually fails the test, removes a dead repository mock, and de-brittles `find.text('User')`.

### Fixed (7 verify sites → type-matched)
- `account_screen_test` Save → `isA<AccountSubmitEvent>()` (was `.called(2)` counting fetch+submit)
- `forgot_password_screen_test` send → `isA<ForgotPasswordEmailChanged>()`
- `user_list_screen_test` search → `isA<UserListSearch>()` (was `greaterThan(0)`)
- `user_editor_screen_test`: edit-load → `isA<UserEditorFetch>()`; invalid-form → `verifyNever(isA<UserEditorSubmit>())`; valid-form → `isA<UserEditorSubmit>()`; render-only → removed the incidental init-event verify.

### 🐛 Real test bug uncovered & fixed
Tightening `user_editor`'s "submit valid form" verify from `greaterThan(0)` to `isA<UserEditorSubmit>()` **failed** — the test never produced a *valid* form: the `AuthoritiesDropdown` is `isRequired: true`, but the test only filled login/name/email and never selected a role, so `saveAndValidate()` returned false and **no submit was ever dispatched**. The loose verify was passing on the on-mount `UserEditorReset` event. Fixed the test to select `ROLE_USER` (+ `pumpAndSettle` after entry) so it genuinely submits — exactly the false-confidence class #168 flagged.

### Also
- Removed the dead `MockUserRepository` (+ unused `Success` import) from `user_editor_screen_test` — never injected; the screen is driven by the mock BLoC.
- De-brittled `find.text('User')` → unique fixture `lastName: 'Tester'` (user_editor + user_list).
- Documented the convention in `docs/testing-architecture.md` (verify by event type, no dangling repo mocks, `whenListen` over mock-reimplemented state, unique fixtures).

### Verification
- No loose `add(any())` / `greaterThan(0)` verifications remain in presentation tests; full suite **1626 passed**; `dart analyze` clean; `dart format` clean.

Remaining in #168: #6 (rewrite user_editor mock to `whenListen`), #7 (unify surface API), #8–11 (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)