### PR TITLE
chore(release): bump version to 0.22.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_bloc_advance
 description: "Flutter Bloc Advance Template"
 publish_to: 'none'
-version: 0.21.50+1
+version: 0.22.0+1
 
 # ➜  flutter_bloc_advance git:(main) ✗ flutter --version
 # Flutter 3.44.2 • channel stable • https://github.com/flutter/flutter.git


### PR DESCRIPTION
Version bump `0.21.50+1` → `0.22.0+1` to cut the **v0.22.0** release tag.

This release covers 105 commits / 47 PRs since `v0.21.0`:
- 🛡️ Production security suite (#129–#143) — secure token storage, screen-capture protection, idempotency keys, idle auto-logout, cert pinning, Sentry, route guards
- 🧪 Test infrastructure overhaul (#135, #147–#155, #168) — global bootstrap, deterministic time, golden + e2e tests; 1,417 → 1,626 tests
- 🏗️ Immutable AppConfig + DI (#144); dynamic_forms → shared/ + user extended-info (#121)
- ⬆️ Flutter 3.44.2 / Dart 3.12.2 upgrade (#173)

The full release note will be attached to the GitHub Release once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)